### PR TITLE
FROM-331: StatusBar component on top of the page

### DIFF
--- a/next/components/forms/info-components/StatusBar.tsx
+++ b/next/components/forms/info-components/StatusBar.tsx
@@ -1,16 +1,17 @@
 /** A react component with state provided through context
  * which shows a red status bar with white text on top of the page
  */
-import React, { createContext, useContext, useState } from 'react'
 import cx from 'classnames'
-import SectionContainer from '../segments/SectionContainer/SectionContainer'
+import React, { createContext, useContext, useState } from 'react'
+
 import ErrorIcon from '../icon-components/ErrorIcon'
+import { SectionContainer } from '../segments/SectionContainer/SectionContainer'
 
 const StatusBarContext = createContext<{
-  StatusBarContent: React.ReactNode
+  statusBarContent: React.ReactNode
   setStatusBarContent: React.Dispatch<React.SetStateAction<React.ReactNode>>
 }>({
-  StatusBarContent: false,
+  statusBarContent: null,
   setStatusBarContent: () => undefined,
 })
 
@@ -19,9 +20,9 @@ interface StatusBarProviderProps {
 }
 
 export const StatusBarProvider: React.FC<StatusBarProviderProps> = ({ children }) => {
-  const [StatusBarContent, setStatusBarContent] = useState<React.ReactNode>(null)
+  const [statusBarContent, setStatusBarContent] = useState<React.ReactNode>(null)
   return (
-    <StatusBarContext.Provider value={{ StatusBarContent, setStatusBarContent }}>
+    <StatusBarContext.Provider value={{ statusBarContent, setStatusBarContent }}>
       {children}
     </StatusBarContext.Provider>
   )
@@ -34,10 +35,9 @@ interface StatusBarProps {
 }
 
 export const StatusBar: React.FC<StatusBarProps> = ({ className }) => {
-  const { StatusBarContent } = useStatusBarContext()
-
+  const { statusBarContent } = useStatusBarContext()
   return (
-    StatusBarContent && (
+    statusBarContent && (
       <div className={cx('w-full bg-negative-700 text-white', className)}>
         <div className="container mx-auto h-full flex items-center justify-center">
           <SectionContainer>
@@ -45,7 +45,7 @@ export const StatusBar: React.FC<StatusBarProps> = ({ className }) => {
               <span className="hidden md:flex mr-3">
                 <ErrorIcon solid className="w-5 h-5" />
               </span>
-              <p className="text-p2">{StatusBarContent}</p>
+              <p className="text-p2">{statusBarContent}</p>
             </div>
           </SectionContainer>
         </div>

--- a/next/components/forms/info-components/StatusBar.tsx
+++ b/next/components/forms/info-components/StatusBar.tsx
@@ -1,0 +1,55 @@
+/** A react component with state provided through context
+ * which shows a red status bar with white text on top of the page
+ */
+import React, { createContext, useContext, useState } from 'react'
+import cx from 'classnames'
+import SectionContainer from '../segments/SectionContainer/SectionContainer'
+import ErrorIcon from '../icon-components/ErrorIcon'
+
+const StatusBarContext = createContext<{
+  StatusBarContent: React.ReactNode
+  setStatusBarContent: React.Dispatch<React.SetStateAction<React.ReactNode>>
+}>({
+  StatusBarContent: false,
+  setStatusBarContent: () => undefined,
+})
+
+interface StatusBarProviderProps {
+  children?: React.ReactNode
+}
+
+export const StatusBarProvider: React.FC<StatusBarProviderProps> = ({ children }) => {
+  const [StatusBarContent, setStatusBarContent] = useState<React.ReactNode>(null)
+  return (
+    <StatusBarContext.Provider value={{ StatusBarContent, setStatusBarContent }}>
+      {children}
+    </StatusBarContext.Provider>
+  )
+}
+
+export const useStatusBarContext = () => useContext(StatusBarContext)
+
+interface StatusBarProps {
+  className?: string
+}
+
+export const StatusBar: React.FC<StatusBarProps> = ({ className }) => {
+  const { StatusBarContent } = useStatusBarContext()
+
+  return (
+    StatusBarContent && (
+      <div className={cx('w-full bg-negative-700 text-white', className)}>
+        <div className="container mx-auto h-full flex items-center justify-center">
+          <SectionContainer>
+            <div className="row flex items-center py-4">
+              <span className="hidden md:flex mr-3">
+                <ErrorIcon solid className="w-5 h-5" />
+              </span>
+              <p className="text-p2">{StatusBarContent}</p>
+            </div>
+          </SectionContainer>
+        </div>
+      </div>
+    )
+  )
+}

--- a/next/components/forms/segments/AccountNavBar/AccountNavBar.tsx
+++ b/next/components/forms/segments/AccountNavBar/AccountNavBar.tsx
@@ -18,6 +18,7 @@ import { Item } from 'react-stately'
 
 import Brand from '../../simple-components/Brand'
 import Link from './NavBarLink'
+import { StatusBar, useStatusBarContext } from 'components/forms/info-components/StatusBar'
 
 interface IProps extends LanguageSelectProps {
   className?: string
@@ -99,6 +100,7 @@ export const AccountNavBar = ({
           'fixed top-0 left-0 w-full bg-white z-40 shadow',
         )}
       >
+        <StatusBar className="hidden lg:flex" />
         <div className="max-w-screen-lg m-auto hidden h-[57px] w-full items-center lg:flex gap-x-6">
           <Brand
             className="group grow"
@@ -191,7 +193,7 @@ export const AccountNavBar = ({
           </nav>
         </div>
         {isAuth && sectionsList && !hiddenHeaderNav && (
-          <div className="border-t border-gray-200 max-w-screen-lg m-auto h-[57px] w-full items-center justify-between lg:flex">
+          <div className="hidden border-t border-gray-200 max-w-screen-lg m-auto h-[57px] w-full items-center justify-between lg:flex">
             <ul className="w-full h-full flex items-center">
               {sectionsList.map((sectionItem) => (
                 <li className="w-full h-full" key={sectionItem.id}>
@@ -218,46 +220,45 @@ export const AccountNavBar = ({
       {/* Mobile */}
       <div
         id="mobile-navbar"
-        className={cx(
-          className,
-          'h-16 flex items-center py-5 px-8 -mx-8 border-b-2',
-          'lg:hidden fixed top-0 w-full bg-white z-40 gap-x-6',
-        )}
+        className={cx(className, 'lg:hidden fixed top-0 left-0 w-full bg-white z-40 gap-x-6')}
       >
-        <Brand url="/" className="grow" />
-        {!navHidden && (
-          <div className={cx('flex items-center gap-x-5')}>
-            <div className="text-h4 text-font/50 relative flex cursor-pointer items-center bg-transparent">
-              <Link href={t('searchLink')} variant="plain" className="p-4">
-                <SearchIcon />
-              </Link>
+        {!burgerOpen && <StatusBar className="flex lg:hidden" />}
+        <div className="h-16 flex items-center py-5 px-8 border-b-2">
+          <Brand url="/" className="grow" />
+          {!navHidden && (
+            <div className={cx('flex items-center gap-x-5')}>
+              <div className="text-h4 text-font/50 relative flex cursor-pointer items-center bg-transparent">
+                <Link href={t('searchLink')} variant="plain" className="p-4">
+                  <SearchIcon />
+                </Link>
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        <button
-          onClick={() => (isAuth ? setBurgerOpen(!burgerOpen) : router.push(ROUTES.LOGIN))}
-          className="-mr-4 px-4 py-5"
-        >
-          <div className="flex w-6 items-center justify-center">
-            {burgerOpen ? (
-              <HamburgerClose />
-            ) : isAuth && sectionsList ? (
-              <Hamburger />
-            ) : (
-              <Avatar userData={userData} />
-            )}
-          </div>
-        </button>
+          <button
+            onClick={() => (isAuth ? setBurgerOpen(!burgerOpen) : router.push(ROUTES.LOGIN))}
+            className="-mr-4 px-4 py-5"
+          >
+            <div className="flex w-6 items-center justify-center">
+              {burgerOpen ? (
+                <HamburgerClose />
+              ) : isAuth && sectionsList ? (
+                <Hamburger />
+              ) : (
+                <Avatar userData={userData} />
+              )}
+            </div>
+          </button>
 
-        {burgerOpen && (
-          <HamburgerMenu
-            sectionsList={sectionsList}
-            menuItems={menuItems}
-            closeMenu={() => setBurgerOpen(false)}
-            onRouteChange={onRouteChange}
-          />
-        )}
+          {burgerOpen && (
+            <HamburgerMenu
+              sectionsList={sectionsList}
+              menuItems={menuItems}
+              closeMenu={() => setBurgerOpen(false)}
+              onRouteChange={onRouteChange}
+            />
+          )}
+        </div>
       </div>
     </>
   )

--- a/next/components/forms/segments/AccountNavBar/AccountNavBar.tsx
+++ b/next/components/forms/segments/AccountNavBar/AccountNavBar.tsx
@@ -18,7 +18,8 @@ import { Item } from 'react-stately'
 
 import Brand from '../../simple-components/Brand'
 import Link from './NavBarLink'
-import { StatusBar, useStatusBarContext } from 'components/forms/info-components/StatusBar'
+import { StatusBar } from 'components/forms/info-components/StatusBar'
+import { useElementSize } from 'usehooks-ts'
 
 interface IProps extends LanguageSelectProps {
   className?: string
@@ -61,6 +62,8 @@ export const AccountNavBar = ({
 }: IProps) => {
   const [burgerOpen, setBurgerOpen] = useState(false)
   const { isAuth, logout, userData } = useAccount()
+  const [desktopRef, { height: desktopHeight }] = useElementSize()
+  const [mobileRef, { height: mobileHeight }] = useElementSize()
 
   const languageKey = getLanguageKey(languageSelectProps.currentLanguage)
   const anotherLanguage = languageSelectProps.languages?.find((l) => l.key !== languageKey)
@@ -90,7 +93,7 @@ export const AccountNavBar = ({
       : router.pathname.startsWith(sectionItem.link)
 
   return (
-    <>
+    <div style={{ marginBottom: Math.max(desktopHeight, mobileHeight) }}>
       {/* Desktop */}
       <div
         id="desktop-navbar"
@@ -99,6 +102,7 @@ export const AccountNavBar = ({
           'text-p2 items-center',
           'fixed top-0 left-0 w-full bg-white z-40 shadow',
         )}
+        ref={desktopRef}
       >
         <StatusBar className="hidden lg:flex" />
         <div className="max-w-screen-lg m-auto hidden h-[57px] w-full items-center lg:flex gap-x-6">
@@ -221,6 +225,7 @@ export const AccountNavBar = ({
       <div
         id="mobile-navbar"
         className={cx(className, 'lg:hidden fixed top-0 left-0 w-full bg-white z-40 gap-x-6')}
+        ref={mobileRef}
       >
         {!burgerOpen && <StatusBar className="flex lg:hidden" />}
         <div className="h-16 flex items-center py-5 px-8 border-b-2">
@@ -260,7 +265,7 @@ export const AccountNavBar = ({
           )}
         </div>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/next/components/forms/segments/AccountSectionHeader/AccountSectionHeader.tsx
+++ b/next/components/forms/segments/AccountSectionHeader/AccountSectionHeader.tsx
@@ -6,7 +6,7 @@ type AccountSectionHeaderBase = {
 const AccountSectionHeader = (props: AccountSectionHeaderBase) => {
   const { title, text } = props
   return (
-    <div className="bg-gray-50 mt-16 lg:mt-28">
+    <div className="bg-gray-50">
       <span className="flex flex-col justify-end w-full h-full max-w-screen-lg m-auto pl-4 lg:px-0 py-6 lg:py-16">
         <h1 className="text-h1">{title}</h1>
         {text && <p className="text-p1 mt-3">{text}</p>}

--- a/next/components/forms/segments/AccountSectionHeader/MunicipalServicesSectionHeader.tsx
+++ b/next/components/forms/segments/AccountSectionHeader/MunicipalServicesSectionHeader.tsx
@@ -19,7 +19,7 @@ const MunicipalServicesSectionHeader = ({
   setSelectorValue,
 }: MunicipalServicesSectionHeaderBase) => {
   return (
-    <div className="bg-gray-50 mt-16 lg:mt-28">
+    <div className="bg-gray-50">
       <span className="flex flex-col justify-end w-full h-full max-w-screen-lg m-auto pl-4 lg:px-0 pt-6 lg:pt-16 pb-4 lg:pb-8">
         <h1 className="text-h1 mb-6">{title}</h1>
         <SelectField

--- a/next/components/forms/segments/AccountSectionHeader/TaxFeeSectionHeader.tsx
+++ b/next/components/forms/segments/AccountSectionHeader/TaxFeeSectionHeader.tsx
@@ -50,7 +50,7 @@ const TaxFeeSectionHeader = (props: AccountSectionHeaderBase) => {
   const { t } = useTranslation('account')
   const router = useRouter()
   return (
-    <div className="lg:px-0 bg-gray-50 h-full mt-16 lg:mt-28 px-4">
+    <div className="lg:px-0 bg-gray-50 h-full px-4">
       <div className="flex flex-col py-6 gap-4 max-w-screen-lg m-auto">
         <div className="flex items-center gap-0.5 cursor-pointer">
           <div className="w-5 h-5 flex justify-center items-center">

--- a/next/components/forms/segments/LoginRegisterNavBar/LoginRegisterNavBar.tsx
+++ b/next/components/forms/segments/LoginRegisterNavBar/LoginRegisterNavBar.tsx
@@ -4,6 +4,8 @@ import cx from 'classnames'
 import Brand from 'components/forms/simple-components/Brand'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
+import { StatusBar } from 'components/forms/info-components/StatusBar'
+import { useElementSize } from 'usehooks-ts'
 
 interface IProps {
   className?: string
@@ -24,10 +26,12 @@ const BackButton = () => {
 
 export const LoginRegisterNavBar = ({ className, currentLanguage, backButtonHidden }: IProps) => {
   const languageKey = getLanguageKey(currentLanguage)
+  const [desktopRef, { height: desktopHeight }] = useElementSize()
+  const [mobileRef, { height: mobileHeight }] = useElementSize()
 
   const { t } = useTranslation('account')
   return (
-    <>
+    <div style={{ marginBottom: Math.max(desktopHeight, mobileHeight) }}>
       {/* Desktop */}
       <div
         id="desktop-navbar"
@@ -36,7 +40,9 @@ export const LoginRegisterNavBar = ({ className, currentLanguage, backButtonHidd
           'text-p2 items-center',
           'fixed top-0 left-0 w-full bg-white z-40 shadow',
         )}
+        ref={desktopRef}
       >
+        <StatusBar className="hidden lg:flex" />
         <div className="max-w-screen-lg m-auto hidden h-[57px] w-full items-center lg:flex">
           {!backButtonHidden && <BackButton />}
           <Brand
@@ -55,24 +61,24 @@ export const LoginRegisterNavBar = ({ className, currentLanguage, backButtonHidd
       {/* Mobile */}
       <div
         id="mobile-navbar"
-        className={cx(
-          className,
-          'h-16 flex items-center py-5 px-8 -mx-8 border-b-2',
-          'lg:hidden fixed top-0 w-full bg-white z-40',
-        )}
+        className={cx(className, 'lg:hidden fixed top-0 left-0 w-full bg-white z-40 gap-x-6')}
+        ref={mobileRef}
       >
-        {!backButtonHidden && <BackButton />}
-        <Brand
-          url="/"
-          className="mx-auto"
-          title={
-            <p className="text-p2 text-font group-hover:text-gray-600">
-              <span className="font-semibold">Bratislava</span>
-            </p>
-          }
-        />
+        <StatusBar className="flex lg:hidden" />
+        <div className="h-16 flex items-center py-5 px-8 border-b-2">
+          {!backButtonHidden && <BackButton />}
+          <Brand
+            url="/"
+            className="mx-auto"
+            title={
+              <p className="text-p2 text-font group-hover:text-gray-600">
+                <span className="font-semibold">Bratislava</span>
+              </p>
+            }
+          />
+        </div>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/next/components/layouts/AccountPageLayout.tsx
+++ b/next/components/layouts/AccountPageLayout.tsx
@@ -8,7 +8,6 @@ import { ROUTES } from '@utils/constants'
 import useAccount from '@utils/useAccount'
 import cx from 'classnames'
 import AccountNavBar from 'components/forms/segments/AccountNavBar/AccountNavBar'
-import SectionContainer from 'components/forms/segments/SectionContainer/SectionContainer'
 import { usePageWrapperContext } from 'components/layouts/PageWrapper'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
@@ -93,20 +92,18 @@ const AccountPageLayout = ({ className, children, hiddenHeaderNav }: AccountPage
 
   return (
     <div className={cx('flex flex-col min-h-screen', className)}>
-      <SectionContainer>
-        <AccountNavBar
-          currentLanguage={locale}
-          onLanguageChange={handleLanguageChange}
-          sectionsList={sectionsList}
-          menuItems={menuItems}
-          navHidden
-          hiddenHeaderNav={hiddenHeaderNav}
-          languages={[
-            { key: 'sk', title: t('language_long.sk') },
-            { key: 'en', title: t('language_long.en') },
-          ]}
-        />
-      </SectionContainer>
+      <AccountNavBar
+        currentLanguage={locale}
+        onLanguageChange={handleLanguageChange}
+        sectionsList={sectionsList}
+        menuItems={menuItems}
+        navHidden
+        hiddenHeaderNav={hiddenHeaderNav}
+        languages={[
+          { key: 'sk', title: t('language_long.sk') },
+          { key: 'en', title: t('language_long.en') },
+        ]}
+      />
       <div className="bg-gray-0">{children}</div>
     </div>
   )

--- a/next/components/layouts/LoginRegisterLayout.tsx
+++ b/next/components/layouts/LoginRegisterLayout.tsx
@@ -1,6 +1,5 @@
 import cx from 'classnames'
 import LoginRegisterNavBar from 'components/forms/segments/LoginRegisterNavBar/LoginRegisterNavBar'
-import SectionContainer from 'components/forms/segments/SectionContainer/SectionContainer'
 import { usePageWrapperContext } from 'components/layouts/PageWrapper'
 import { ReactNode } from 'react'
 
@@ -19,12 +18,7 @@ const LoginRegisterLayout = ({
 
   return (
     <div className={cx('flex', 'flex-col', 'min-h-screen', className)}>
-      <div className="h-16 bg-white lg:h-14">
-        <SectionContainer>
-          <LoginRegisterNavBar currentLanguage={locale} backButtonHidden={backButtonHidden} />
-        </SectionContainer>
-      </div>
-
+      <LoginRegisterNavBar currentLanguage={locale} backButtonHidden={backButtonHidden} />
       <div className="md:bg-main-100 flex flex-col gap-0 md:gap-6 grow pt-0 md:pt-8">
         {children}
       </div>

--- a/next/components/styleguide/showcases/StatusBarShowCase.tsx
+++ b/next/components/styleguide/showcases/StatusBarShowCase.tsx
@@ -1,0 +1,28 @@
+import { useStatusBarContext } from 'components/forms/info-components/StatusBar'
+import Button from '../../forms/simple-components/Button'
+import { Stack } from '../Stack'
+import { Wrapper } from '../Wrapper'
+
+interface StatusBarShowCaseProps {}
+
+const StatusBarShowCase = ({}: StatusBarShowCaseProps) => {
+  const { setStatusBarContent } = useStatusBarContext()
+  return (
+    <Wrapper direction="column" title="StatusBar">
+      <Stack>
+        <Button
+          variant="category"
+          text="Show status bar at the top of the page"
+          onPress={() =>
+            setStatusBarContent(
+              'Laborum velit dolore enim voluptate sint anim occaecat est sit. Mollit nisi incididunt eu officia Lorem occaecat culpa consectetur voluptate aute veniam. Est eu irure ut eiusmod ut nisi ex fugiat laboris qui ad eiusmod. Enim aliqua ut occaecat nisi minim sint veniam ipsum sit in aute.',
+            )
+          }
+        />
+        <Button variant="category" text="Hide status bar" onPress={() => setStatusBarContent('')} />
+      </Stack>
+    </Wrapper>
+  )
+}
+
+export default StatusBarShowCase

--- a/next/pages/_app.tsx
+++ b/next/pages/_app.tsx
@@ -32,15 +32,15 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
       </Head>
       <QueryParamProvider adapter={NextAdapter}>
         <SSRProvider>
-          <AccountProvider>
-            <div className={`${inter.variable} font-sans`}>
-              <SnackbarProvider>
-                <StatusBarProvider>
+          <StatusBarProvider>
+            <AccountProvider>
+              <div className={`${inter.variable} font-sans`}>
+                <SnackbarProvider>
                   <Component {...pageProps} />
-                </StatusBarProvider>
-              </SnackbarProvider>
-            </div>
-          </AccountProvider>
+                </SnackbarProvider>
+              </div>
+            </AccountProvider>
+          </StatusBarProvider>
         </SSRProvider>
       </QueryParamProvider>
     </>

--- a/next/pages/_app.tsx
+++ b/next/pages/_app.tsx
@@ -10,6 +10,7 @@ import { NextAdapter } from 'next-query-params'
 import { SSRProvider } from 'react-aria'
 import SnackbarProvider from 'react-simple-snackbar'
 import { QueryParamProvider } from 'use-query-params'
+import { StatusBarProvider } from 'components/forms/info-components/StatusBar'
 
 const inter = Inter({
   variable: '--inter-font',
@@ -34,7 +35,9 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
           <AccountProvider>
             <div className={`${inter.variable} font-sans`}>
               <SnackbarProvider>
-                <Component {...pageProps} />
+                <StatusBarProvider>
+                  <Component {...pageProps} />
+                </StatusBarProvider>
               </SnackbarProvider>
             </div>
           </AccountProvider>

--- a/next/pages/form/[eform].tsx
+++ b/next/pages/form/[eform].tsx
@@ -75,12 +75,7 @@ const FormTestPage = ({ page, eform }: AsyncServerProps<typeof getServerSideProp
       ]}
     >
       <AccountPageLayout hiddenHeaderNav>
-        <GeneratedFormRJSF
-          eform={eform}
-          escapedSlug={escapedSlug}
-          formSlug={formSlug}
-          wrapperClassName="mt-16"
-        />
+        <GeneratedFormRJSF eform={eform} escapedSlug={escapedSlug} formSlug={formSlug} />
       </AccountPageLayout>
     </PageWrapper>
   )

--- a/next/pages/styleguide.tsx
+++ b/next/pages/styleguide.tsx
@@ -30,7 +30,9 @@ import TagShowCase from '../components/styleguide/showcases/TagShowCase'
 import TextAreaFieldShowCase from '../components/styleguide/showcases/TextAreaFieldShowCase'
 import ToggleShowCase from '../components/styleguide/showcases/ToggleShowCase'
 import UploadShowCase from '../components/styleguide/showcases/UploadShowCase'
+import StatusBarShowCase from '../components/styleguide/showcases/StatusBarShowCase'
 import StyleGuideWrapper from '../components/styleguide/StyleGuideWrapper'
+import { StatusBar } from 'components/forms/info-components/StatusBar'
 
 const Styleguide = ({ page }: AsyncServerProps<typeof getServerSideProps>) => {
   /**
@@ -38,37 +40,41 @@ const Styleguide = ({ page }: AsyncServerProps<typeof getServerSideProps>) => {
    * Path to StyleGuide showcase components should be ./next/components/styleguide/showcases
    * */
   return (
-    <PageWrapper locale={page.locale}>
-      <StyleGuideWrapper>
-        {/* HERE ADD SHOWCASES */}
-        <TagShowCase />
-        <TooltipShowCase />
-        <FieldHeaderShowCase />
-        <ButtonShowCase />
-        <DatePickerShowCase />
-        <InputFieldShowCase />
-        <SpinnerShowCase />
-        <TextAreaFieldShowCase />
-        <AlertShowCase />
-        <SearchFieldShowCase />
-        <ToggleShowCase />
-        <TimePickerShowCase />
-        <UploadShowCase />
-        <DropdownShowCase />
-        <SelectFieldShowCase />
-        <ModalShowCase />
-        <AccordionShowCase />
-        <ProgressBarShowCase />
-        <SingleCheckboxShowCase />
-        <CheckboxGroupShowCase />
-        <RadioButtonShowCase />
-        <StepperShowCase />
-        <SummaryRowShowCase />
-        <BannerShowCase />
-        <ServiceCardShowCase />
-        <SnackbarShowCase />
-      </StyleGuideWrapper>
-    </PageWrapper>
+    <>
+      <StatusBar />
+      <PageWrapper locale={page.locale}>
+        <StyleGuideWrapper>
+          {/* HERE ADD SHOWCASES */}
+          <StatusBarShowCase />
+          <TagShowCase />
+          <TooltipShowCase />
+          <FieldHeaderShowCase />
+          <ButtonShowCase />
+          <DatePickerShowCase />
+          <InputFieldShowCase />
+          <SpinnerShowCase />
+          <TextAreaFieldShowCase />
+          <AlertShowCase />
+          <SearchFieldShowCase />
+          <ToggleShowCase />
+          <TimePickerShowCase />
+          <UploadShowCase />
+          <DropdownShowCase />
+          <SelectFieldShowCase />
+          <ModalShowCase />
+          <AccordionShowCase />
+          <ProgressBarShowCase />
+          <SingleCheckboxShowCase />
+          <CheckboxGroupShowCase />
+          <RadioButtonShowCase />
+          <StepperShowCase />
+          <SummaryRowShowCase />
+          <BannerShowCase />
+          <ServiceCardShowCase />
+          <SnackbarShowCase />
+        </StyleGuideWrapper>
+      </PageWrapper>
+    </>
   )
 }
 


### PR DESCRIPTION
First part of the task - a status bar for displaying various errors. WIll be used to warn the user about failed verification. DIsplays on top of the page header.

Slightly simplified the mobile account header styling while at this, as it got in the way. Recommended to check the changes with "hide whitespace changes" toggled in github.

![Screenshot 2023-03-22 at 14 02 47](https://user-images.githubusercontent.com/2327312/226912816-6acc758f-92f3-406a-8c8c-a7e6eb462a53.png)

Edit: also changed the header behaviour - now that the height is dynamic, dealing with the offset of the rest of the content in the header itself + removed the static offsets from the rest of the sectiosn (please let me know if I missed any)
