### PR TITLE
Add Turnstile captcha, fix EmailVerificationSuccess status

### DIFF
--- a/next/.env.bratiska-cli-build.dev
+++ b/next/.env.bratiska-cli-build.dev
@@ -9,3 +9,5 @@ NEXT_PUBLIC_COGNITO_IDENTITY_POOL_ID=eu-central-1:e31a6d0a-5e01-4600-a20a-e4fb97
 NEXT_PUBLIC_AWS_REGION=eu-central-1
 NEXT_PUBLIC_CITY_ACCOUNT_URL=https://nest-city-account.dev.bratislava.sk
 FOP_URL=https://fop.dev.bratislava.sk
+
+NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=0x4AAAAAAADcxthQfH_Hhf_4

--- a/next/.env.bratiska-cli-build.prod
+++ b/next/.env.bratiska-cli-build.prod
@@ -11,3 +11,5 @@ NEXT_PUBLIC_COGNITO_IDENTITY_POOL_ID=eu-central-1:baeb3be5-19f1-49ef-8939-2635e6
 NEXT_PUBLIC_AWS_REGION=eu-central-1
 NEXT_PUBLIC_CITY_ACCOUNT_URL=https://nest-city-account.bratislava.sk
 FOP_URL=https://fop.dev.bratislava.sk
+
+NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=0x4AAAAAAADcxthQfH_Hhf_4

--- a/next/.env.bratiska-cli-build.staging
+++ b/next/.env.bratiska-cli-build.staging
@@ -9,3 +9,5 @@ NEXT_PUBLIC_COGNITO_IDENTITY_POOL_ID=eu-central-1:e31a6d0a-5e01-4600-a20a-e4fb97
 NEXT_PUBLIC_AWS_REGION=eu-central-1
 NEXT_PUBLIC_CITY_ACCOUNT_URL=https://nest-city-account.staging.bratislava.sk
 FOP_URL=https://fop.dev.bratislava.sk
+
+NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=0x4AAAAAAADcxthQfH_Hhf_4

--- a/next/.env.development
+++ b/next/.env.development
@@ -11,3 +11,5 @@ NEXT_PUBLIC_COGNITO_IDENTITY_POOL_ID=eu-central-1:e31a6d0a-5e01-4600-a20a-e4fb97
 NEXT_PUBLIC_AWS_REGION=eu-central-1
 NEXT_PUBLIC_CITY_ACCOUNT_URL=https://nest-city-account.staging.bratislava.sk
 FOP_URL=https://fop.dev.bratislava.sk
+
+NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=0x4AAAAAAADcxthQfH_Hhf_4

--- a/next/components/forms/segments/IdentityVerificationForm/IdentityVerificationForm.tsx
+++ b/next/components/forms/segments/IdentityVerificationForm/IdentityVerificationForm.tsx
@@ -9,14 +9,17 @@ import InputField from 'components/forms/widget-components/InputField/InputField
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { Controller } from 'react-hook-form'
+import Turnstile from 'react-turnstile'
+import { useCounter } from 'usehooks-ts'
 
 interface Data {
   rc: string
   idCard: string
+  turnstileToken: string
 }
 
 interface Props {
-  onSubmit: (rc: string, idCard: string) => void
+  onSubmit: (rc: string, idCard: string, turnstileToken: string) => void
   error?: AccountError | null | undefined
 }
 
@@ -35,12 +38,17 @@ const schema = {
       minLength: 1,
       errorMessage: { minLength: 'account:id_card_required' },
     },
+    turnstileToken: {
+      type: 'string',
+      minLength: 1,
+    },
   },
-  required: ['rc', 'idCard'],
+  required: ['rc', 'idCard', 'turnstileToken'],
 }
 
 const IdentityVerificationForm = ({ onSubmit, error }: Props) => {
   const { t } = useTranslation('account')
+  const turnstileKeyCounter = useCounter()
   const router = useRouter()
   const {
     handleSubmit,
@@ -55,7 +63,11 @@ const IdentityVerificationForm = ({ onSubmit, error }: Props) => {
   return (
     <form
       className="flex flex-col space-y-4"
-      onSubmit={handleSubmit((data: Data) => onSubmit(data.rc, data.idCard))}
+      onSubmit={handleSubmit((data: Data) => {
+        // force turnstile rerender as it's always available just for a single request
+        turnstileKeyCounter.increment()
+        return onSubmit(data.rc, data.idCard, data.turnstileToken)
+      })}
     >
       <h1 className="text-h3">{t('identity_verification_title')}</h1>
       {error && (
@@ -87,6 +99,21 @@ const IdentityVerificationForm = ({ onSubmit, error }: Props) => {
             tooltip={t('id_card_tooltip')}
             {...field}
             errorMessage={errors.idCard}
+          />
+        )}
+      />
+      <Controller
+        name="turnstileToken"
+        control={control}
+        render={({ field: { onChange } }) => (
+          <Turnstile
+            key={turnstileKeyCounter.count}
+            sitekey={process.env.NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY}
+            onVerify={(token) => onChange(token)}
+            onError={() => onChange(null)}
+            onTimeout={() => onChange(null)}
+            onExpire={() => onChange(null)}
+            className="mb-2"
           />
         )}
       />

--- a/next/package.json
+++ b/next/package.json
@@ -67,6 +67,7 @@
     "react-simple-snackbar": "^1.1.11",
     "react-stately": "3.21.0",
     "react-sweet-progress": "1.1.2",
+    "react-turnstile": "^1.1.0",
     "rehype-raw": "6.1.1",
     "remark-directive": "^2.0.1",
     "remark-directive-rehype": "^0.4.2",

--- a/next/pages/register.tsx
+++ b/next/pages/register.tsx
@@ -57,12 +57,16 @@ const RegisterPage = ({ page }: AsyncServerProps<typeof getServerSideProps>) => 
   } = useAccount()
   const router = useRouter()
 
-  const verifyIdentityAndRefreshUserData = async (rc: string, idCard: string) => {
+  const verifyIdentityAndRefreshUserData = async (
+    rc: string,
+    idCard: string,
+    turnstileToken: string,
+  ) => {
     setLastRc(rc)
     setLastIdCard(idCard)
-    await verifyIdentity(rc, idCard)
+    await verifyIdentity(rc, idCard, turnstileToken)
     // give the queue a few seconds to process the verification
-    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await new Promise((resolve) => setTimeout(resolve, 8000))
     // status will be set according to current cognito tier - pending if still processing
     await refreshUserData()
   }

--- a/next/utils/api.ts
+++ b/next/utils/api.ts
@@ -121,6 +121,7 @@ export const xmlToFormData = (eform: string, data: string) => {
 interface Identity {
   birthNumber: string
   identityCard: string
+  turnstileToken: string
 }
 
 export const verifyIdentityApi = (data: Identity, token: string) => {

--- a/next/yarn.lock
+++ b/next/yarn.lock
@@ -14258,6 +14258,11 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-turnstile@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-turnstile/-/react-turnstile-1.1.0.tgz#4b69950f6cff287ecbaf58f1beae35808d54ad16"
+  integrity sha512-zHuMcBL8QAeU7JUjRigL+FF/Zat0dbE53Rr1MOtOGhNDYOFXIRNBCktfL5cJszcQJALk+qjOctTJY/I+6lVYvQ==
+
 react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
- turnstile validates in lambda on cognito pre-signup hook (this is already true) and on backend identity verification (this will be true soon)
- contains an unrelated ugly fix for when emailverificationsuccess statew was immediately overwritten in response from user login - this workaround should be replaced very soon (🤞 ) together with moving the accountstatus out of the hook into a more localized state