### PR TITLE
FORM-436: Change phone helpText in phone modal, edit FieldErrorMessage

### DIFF
--- a/next/components/forms/info-components/FieldErrorMessage.tsx
+++ b/next/components/forms/info-components/FieldErrorMessage.tsx
@@ -12,7 +12,7 @@ const FieldErrorMessage: FC<FieldErrorMessageProps> = ({
   return errorMessage.length > 0 ? (
     <div className="text-p3 sm:text-16 mt-1 text-error" {...errorMessageProps}>
       {errorMessage?.map((error, i) => (
-        <div key={i}>{`${error.slice(0, 1).toUpperCase()}${error.slice(1).toLowerCase()}${
+        <div key={i}>{`${error.slice(0, 1).toUpperCase()}${error.slice(1)}${
           error.trim().slice(-1) === '.' ? '' : '.'
         }`}</div>
       ))}

--- a/next/public/locales/en/account.json
+++ b/next/public/locales/en/account.json
@@ -435,7 +435,7 @@
     "email_button": "Edit",
     "email_tooltip": "If you would like to change the e-mail that you use to log in to your account and to which we send you all information related to your account, contact us at <a href='mailto:info@bratislava.sk'>info@bratislava.sk</a>.",
     "phone_number": "Phone number",
-    "phone_number_pattern": "With pattern +421...",
+    "phone_number_pattern": "With pattern +421XXXXXXXXX",
     "address": "Correspondence address",
     "street": "Street and number",
     "city": "City",

--- a/next/public/locales/en/forms.json
+++ b/next/public/locales/en/forms.json
@@ -27,7 +27,7 @@
   "postal_code_description": "",
   "postal_code_required": "Postal code is required",
   "postal_code_format": "Postal code is not valid",
-  "phone_format": "Type in the correct form (+421...)",
+  "phone_format": "Type in the correct form (+421XXXXXXXXX)",
   "changes_submit": "Submit",
   "buttons": {
     "previous": "Previous",

--- a/next/public/locales/sk/account.json
+++ b/next/public/locales/sk/account.json
@@ -443,7 +443,7 @@
     "email_button": "Upraviť",
     "email_tooltip": "Ak by ste si priali zmeniť e-mail, ktorým sa do konta prihlasujete a na ktorý vám zasielame všetky informácie týkajúce sa vášho konta, kontaktuje nás na <a href='mailto:info@bratislava.sk'>info@bratislava.sk</a>.",
     "phone_number": "Telefónne číslo",
-    "phone_number_pattern": "V tvare +421...",
+    "phone_number_pattern": "V tvare +421XXXXXXXXX",
     "address": "Korešpondenčná adresa",
     "street": "Ulica a číslo",
     "city": "Mesto",

--- a/next/public/locales/sk/forms.json
+++ b/next/public/locales/sk/forms.json
@@ -27,7 +27,7 @@
   "postal_code_description": "Zadávajte bez medzier, napr. 11111",
   "postal_code_required": "PSČ je povinné",
   "postal_code_format": "PSČ nie je valídne",
-  "phone_format": "Zadajte v správnom tvare (+421...)",
+  "phone_format": "Zadajte v správnom tvare (+421XXXXXXXXX)",
   "buttons": {
     "previous": "Späť",
     "skip": "Preskočiť",


### PR DESCRIPTION
I changed the FieldErrorMessage because everything but the first letter will be in lower case. I don't think we want that. In my case, the error in the InputField looked like +421xxxxxxxxx, but it should be +421XXXXXXXXX.