### PR TITLE
SSO: share JWT accessToken to approved domains via postMessage

### DIFF
--- a/next/frontend/hooks/useAccount.tsx
+++ b/next/frontend/hooks/useAccount.tsx
@@ -255,6 +255,8 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
 
   // postMessage to all approved domains at the window top
   // in reality only one message will be sent, this exists to limit the possible domains only to hardcoded list in approvedSSODomains
+  // TODO refactor to different file
+  // eslint-disable-next-line unicorn/consistent-function-scoping
   const postMessageToApprovedDomains = (message: CityAccountPostMessage) => {
     // TODO - log to faro if none of the origins match
     approvedSSODomains.forEach((domain) => {
@@ -262,6 +264,7 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
     })
   }
 
+  // TODO refactor to different file
   // used in /sso, to send the jwt access token to approved domains where city-account is used for single sign on
   const postAccessToken = () => {
     const cognitoUser = userPool.getCurrentUser()

--- a/next/frontend/hooks/useAccount.tsx
+++ b/next/frontend/hooks/useAccount.tsx
@@ -260,7 +260,7 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
   const postMessageToApprovedDomains = (message: CityAccountPostMessage) => {
     // TODO - log to faro if none of the origins match
     approvedSSODomains.forEach((domain) => {
-      window.top.postMessage(message, domain)
+      window?.top?.postMessage(message, domain)
     })
   }
 

--- a/next/pages/sso.tsx
+++ b/next/pages/sso.tsx
@@ -1,0 +1,32 @@
+import AccountMarkdown from 'components/forms/segments/AccountMarkdown/AccountMarkdown'
+import { GetServerSidePropsContext } from 'next'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useEffectOnce } from 'usehooks-ts'
+
+import useAccount from '../frontend/hooks/useAccount'
+
+const SSOPage = () => {
+  const { postAccessToken } = useAccount()
+  const { t } = useTranslation('account')
+  useEffectOnce(() => {
+    postAccessToken()
+  })
+
+  return <AccountMarkdown content={t('sso_placeholder')} />
+}
+
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const locale = ctx.locale ?? 'sk'
+
+  return {
+    props: {
+      page: {
+        locale: ctx.locale,
+      },
+      ...(await serverSideTranslations(locale)),
+    },
+  }
+}
+
+export default SSOPage

--- a/next/pages/sso.tsx
+++ b/next/pages/sso.tsx
@@ -1,4 +1,5 @@
 import AccountMarkdown from 'components/forms/segments/AccountMarkdown/AccountMarkdown'
+import { isProductionDeployment } from 'frontend/utils/general'
 import { GetServerSidePropsContext } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -17,6 +18,8 @@ const SSOPage = () => {
 }
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  if (isProductionDeployment()) return { notFound: true }
+
   const locale = ctx.locale ?? 'sk'
 
   return {

--- a/next/public/locales/sk/account.json
+++ b/next/public/locales/sk/account.json
@@ -18,6 +18,7 @@
     "BIRTH_NUMBER_AND_IDENTITY_CARD_INCONSISTENCY": "Overenie bolo neúspešné. Skontrolujte správnosť údajov.",
     "BIRTHNUMBER_IFO_DUPLICITY": "Tieto osobné údaje už boli použité pri inej e-mailovej adrese. Ak ste účet nevytvorili vy, kontaktujte nás na info@bratislava.sk."
   },
+  "sso_placeholder": "Táto stránka slúži pre komunikáciu s ostatnými mestskými službami. <a href='/'>Späť domov</a>.",
   "login_title": "Prihláste sa do svojho konta",
   "email_label": "E-mail",
   "email_description": "Zadajte e-mail, na ktorý si prajete dostávať od mesta informácie.",


### PR DESCRIPTION
Ended up dropping the useAccount rewrite for now (I know I've been talking about it for a while), in the end what we really need in the other projects authenticating through city account is not shared account hook but rather something like this - the ability for approved domains to:
a) redirect to city-account page when user is not logged in and let the user login/register within existing flow (not covered here) and 
b) let the approved domains open city-account in an invisible webview (will be covered in other projects) and receive an access token which they can store and use to access backend resources until it expires (after which point, they can ask for another one in the same manner)

🙏 will be glad to receive any feedback on this - though I may merge it beforehand to allow testing against staging. I've disabled this on production until we have it tested.

The 'other-side' of this interaction in the 'kupaliska-start-fe' repo https://github.com/bratislava/kupaliska-starz-fe/pull/43