### PR TITLE
SSO: register/login/logout redirects

### DIFF
--- a/next/frontend/hooks/useAccount.tsx
+++ b/next/frontend/hooks/useAccount.tsx
@@ -19,6 +19,7 @@ import * as AWS from 'aws-sdk/global'
 import { AWSError } from 'aws-sdk/global'
 import { useStatusBarContext } from 'components/forms/info-components/StatusBar'
 import AccountMarkdown from 'components/forms/segments/AccountMarkdown/AccountMarkdown'
+import { APPROVED_SSO_ORIGINS } from 'frontend/utils/sso'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import React, { ReactNode, useCallback, useContext, useEffect, useState } from 'react'
@@ -27,20 +28,9 @@ import { useInterval } from 'usehooks-ts'
 import { subscribeApi, UNAUTHORIZED_ERROR_TEXT, verifyIdentityApi } from '../api/api'
 import { ROUTES } from '../api/constants'
 import { GeneralError } from '../dtos/generalApiDto'
-import { isBrowser, isProductionDeployment } from '../utils/general'
+import { isBrowser } from '../utils/general'
 import logger, { faro } from '../utils/logger'
 import useSnackbar from './useSnackbar'
-
-const approvedSSODomains = isProductionDeployment()
-  ? ['https://kupaliska.bratislava.sk', 'https://bratislava.sk']
-  : [
-      // multiple ports to make testing login across multiple apps running locally easier
-      'http://localhost:3000',
-      'http://localhost:3001',
-      'http://localhost:3002',
-      'http://localhost:3003',
-      'https://kupaliska.staging.bratislava.sk',
-    ]
 
 export enum PostMessageTypes {
   ACCESS_TOKEN = 'ACCESS_TOKEN',
@@ -254,12 +244,12 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
   }
 
   // postMessage to all approved domains at the window top
-  // in reality only one message will be sent, this exists to limit the possible domains only to hardcoded list in approvedSSODomains
+  // in reality only one message will be sent, this exists to limit the possible domains only to hardcoded list in APPROVED_SSO_ORIGINS
   // TODO refactor to different file
   // eslint-disable-next-line unicorn/consistent-function-scoping
   const postMessageToApprovedDomains = (message: CityAccountPostMessage) => {
     // TODO - log to faro if none of the origins match
-    approvedSSODomains.forEach((domain) => {
+    APPROVED_SSO_ORIGINS.forEach((domain) => {
       window?.top?.postMessage(message, domain)
     })
   }

--- a/next/frontend/utils/sso.ts
+++ b/next/frontend/utils/sso.ts
@@ -1,0 +1,36 @@
+import { isProductionDeployment } from './general'
+import logger from './logger'
+
+export const APPROVED_SSO_ORIGINS = isProductionDeployment()
+  ? ['https://kupaliska.bratislava.sk', 'https://bratislava.sk']
+  : [
+      // multiple ports to make testing login across multiple apps running locally easier
+      'http://localhost:3000',
+      'http://localhost:3001',
+      'http://localhost:3002',
+      'http://localhost:3003',
+      'https://kupaliska.staging.bratislava.sk',
+      'https://kupaliska.bratislava.sk',
+      'https://bratislava.sk',
+    ]
+
+// returns null if path is invalid or not an allowed origin
+export const getValidRedirectFromQuery = (path: unknown) => {
+  if (path && typeof path === 'string') {
+    // check if it's a local route
+    if (path.startsWith('/')) {
+      // TODO decodeURIComponent used originally, check if it's needed for some edge-case
+      return decodeURIComponent(path)
+    }
+    // check if it's an approved SSO domain
+    try {
+      const url = new URL(path)
+      if (APPROVED_SSO_ORIGINS.includes(url.origin)) {
+        return path
+      }
+    } catch (error) {
+      logger.error('Failed to parse redirect URL', error, path)
+    }
+  }
+  return null
+}

--- a/next/frontend/utils/sso.ts
+++ b/next/frontend/utils/sso.ts
@@ -19,8 +19,7 @@ export const getValidRedirectFromQuery = (path: unknown) => {
   if (path && typeof path === 'string') {
     // check if it's a local route
     if (path.startsWith('/')) {
-      // TODO decodeURIComponent used originally, check if it's needed for some edge-case
-      return decodeURIComponent(path)
+      return path
     }
     // check if it's an approved SSO domain
     try {

--- a/next/pages/logout.tsx
+++ b/next/pages/logout.tsx
@@ -1,0 +1,75 @@
+import AccountContainer from 'components/forms/segments/AccountContainer/AccountContainer'
+import AccountSuccessAlert from 'components/forms/segments/AccountSuccessAlert/AccountSuccessAlert'
+import LoginRegisterLayout from 'components/layouts/LoginRegisterLayout'
+import { getValidRedirectFromQuery } from 'frontend/utils/sso'
+import { GetServerSidePropsContext } from 'next'
+import { useRouter } from 'next/router'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useCallback, useEffect } from 'react'
+
+import PageWrapper from '../components/layouts/PageWrapper'
+import { ROUTES } from '../frontend/api/constants'
+import useAccount from '../frontend/hooks/useAccount'
+import { isProductionDeployment } from '../frontend/utils/general'
+import logger from '../frontend/utils/logger'
+import { AsyncServerProps } from '../frontend/utils/types'
+
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const locale = ctx.locale ?? 'sk'
+
+  return {
+    props: {
+      page: {
+        locale: ctx.locale,
+        localizations: ['sk', 'en']
+          .filter((l) => l !== ctx.locale)
+          .map((l) => ({
+            slug: '',
+            locale: l,
+          })),
+      },
+      isProductionDeployment: isProductionDeployment(),
+      ...(await serverSideTranslations(locale)),
+    },
+  }
+}
+
+const LogoutPage = ({ page }: AsyncServerProps<typeof getServerSideProps>) => {
+  const { t } = useTranslation('account')
+  const { logout, isAuth } = useAccount()
+  const router = useRouter()
+  const redirect = useCallback(() => {
+    const redirectUrl = getValidRedirectFromQuery(router.query.from) || ROUTES.HOME
+    if (redirectUrl.startsWith('/')) {
+      router.push(redirectUrl).catch((error_) => logger.error('Failed redirect', error_))
+    } else {
+      window.location.href = redirectUrl
+    }
+  }, [router])
+  useEffect(() => {
+    if (!isAuth) {
+      redirect()
+    }
+  }, [isAuth, router, redirect])
+
+  // TODO replace AccountSuccessAlert with something more fitting
+  return (
+    <PageWrapper locale={page.locale} localizations={page.localizations}>
+      <LoginRegisterLayout backButtonHidden>
+        <AccountContainer className="md:pt-6 pt-0 mb-0 md:mb-8">
+          <AccountSuccessAlert
+            title={t('logout_page.title')}
+            description={t('logout_page.description')}
+            confirmLabel={t('logout_page.confirm_label')}
+            onConfirm={() => logout()}
+            cancelLabel={t('logout_page.cancel_label')}
+            onCancel={() => redirect()}
+          />
+        </AccountContainer>
+      </LoginRegisterLayout>
+    </PageWrapper>
+  )
+}
+
+export default LogoutPage

--- a/next/pages/prihlasenie.tsx
+++ b/next/pages/prihlasenie.tsx
@@ -3,6 +3,7 @@ import AccountContainer from 'components/forms/segments/AccountContainer/Account
 import EmailVerificationForm from 'components/forms/segments/EmailVerificationForm/EmailVerificationForm'
 import LoginForm from 'components/forms/segments/LoginForm/LoginForm'
 import LoginRegisterLayout from 'components/layouts/LoginRegisterLayout'
+import { getValidRedirectFromQuery } from 'frontend/utils/sso'
 import { GetServerSidePropsContext } from 'next'
 import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -40,14 +41,14 @@ const LoginPage = ({ page }: AsyncServerProps<typeof getServerSideProps>) => {
     useAccount()
   const router = useRouter()
 
+  // TODO move to general util
   const redirect = useCallback(async () => {
-    const from =
-      router.query.from &&
-      typeof router.query.from === 'string' &&
-      router.query.from.startsWith('/')
-        ? decodeURIComponent(router.query.from)
-        : ROUTES.HOME
-    await router.push(from).catch((error_) => logger.error('Failed redirect', error_))
+    const from = getValidRedirectFromQuery(router.query.from) || ROUTES.HOME
+    if (from.startsWith('/')) {
+      await router.push(from).catch((error_) => logger.error('Failed redirect', error_))
+    } else {
+      window.location.href = from
+    }
   }, [router])
 
   useEffect(() => {

--- a/next/pages/registracia.tsx
+++ b/next/pages/registracia.tsx
@@ -5,6 +5,7 @@ import AccountSuccessAlert from 'components/forms/segments/AccountSuccessAlert/A
 import EmailVerificationForm from 'components/forms/segments/EmailVerificationForm/EmailVerificationForm'
 import RegisterForm from 'components/forms/segments/RegisterForm/RegisterForm'
 import LoginRegisterLayout from 'components/layouts/LoginRegisterLayout'
+import { getValidRedirectFromQuery } from 'frontend/utils/sso'
 import { GetServerSidePropsContext } from 'next'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
@@ -43,6 +44,10 @@ const RegisterPage = ({ page }: AsyncServerProps<typeof getServerSideProps>) => 
   const { signUp, resendVerificationCode, verifyEmail, error, status, lastEmail, setStatus } =
     useAccount()
   const router = useRouter()
+  const possibleRedirect = getValidRedirectFromQuery(router.query.from)
+  // only divert user from verification if he's coming from another site
+  const preVerificationRedirect =
+    possibleRedirect && !possibleRedirect.startsWith('/') ? possibleRedirect : null
 
   return (
     <PageWrapper locale={page.locale} localizations={page.localizations}>
@@ -57,6 +62,17 @@ const RegisterPage = ({ page }: AsyncServerProps<typeof getServerSideProps>) => 
               onResend={resendVerificationCode}
               onSubmit={verifyEmail}
               error={error}
+            />
+          ) : preVerificationRedirect ? (
+            <AccountSuccessAlert
+              title={t('register_success_title')}
+              description={formatUnicorn(t('register_success_description'), {
+                email: lastEmail,
+              })}
+              confirmLabel={t('identity_verification_link')}
+              onConfirm={() => {
+                window.location.href = preVerificationRedirect
+              }}
             />
           ) : (
             <AccountSuccessAlert

--- a/next/public/locales/sk/account.json
+++ b/next/public/locales/sk/account.json
@@ -766,5 +766,11 @@
         }
       }
     }
+  },
+  "logout_page": {
+    "title": "Odhlásenie",
+    "description": "Budete odhlásený zo všetkých aplikácii využívajúcich Mestské konto.",
+    "confirm_label": "Odhlásiť sa",
+    "cancel_label": "Späť"
   }
 }


### PR DESCRIPTION
This is needed so that a user may come from another site which uses city-account just as a single sign-on "host", do what he needs and be redirected back where they came from.

Added a logout page so that user confirms he's logging out from everywhere (also a CSRF measure compared to just logging out on visiting the url).