### PR TITLE
Redirect target persisted between page reloads

### DIFF
--- a/next/frontend/hooks/useSSORedirect.tsx
+++ b/next/frontend/hooks/useSSORedirect.tsx
@@ -1,0 +1,57 @@
+import { ROUTES } from 'frontend/api/constants'
+import logger from 'frontend/utils/logger'
+import { getValidRedirectFromQuery } from 'frontend/utils/sso'
+import { useRouter } from 'next/router'
+import React, { useCallback, useState } from 'react'
+import { useEffectOnce } from 'usehooks-ts'
+
+interface SSORedirectState {
+  redirectTarget: string
+  redirectTargetIsAnotherPage: boolean
+  setRedirect: (newTarget: string) => void
+  redirect: () => void
+}
+
+const SSORedirectContext = React.createContext<SSORedirectState>({} as SSORedirectState)
+
+export const SSORedirectProvider = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter()
+  const [redirectTarget, setRedirectTarget] = useState<string>(ROUTES.HOME)
+  const redirectTargetIsAnotherPage = redirectTarget.startsWith('/')
+
+  const redirect = useCallback(() => {
+    if (redirectTarget.startsWith('/')) {
+      router.push(redirectTarget).catch((error_) => logger.error('Failed redirect', error_))
+    } else {
+      window.location.href = redirectTarget
+    }
+  }, [redirectTarget, router])
+
+  // if trying to set incorrect redirect target, throws and keeps the previous value
+  const setRedirect = useCallback((newTarget: string) => {
+    const redirectTo = getValidRedirectFromQuery(newTarget)
+    if (!redirectTo) throw new Error('Redirect path not valid, keeping previous value!')
+    setRedirectTarget(redirectTo)
+  }, [])
+
+  useEffectOnce(() => {
+    // if we're redirected from another site for login, we'll have the redirection target ready in 'from' query param on first load
+    setRedirectTarget(getValidRedirectFromQuery(router.query.from) || ROUTES.HOME)
+  })
+
+  return (
+    <SSORedirectContext.Provider
+      value={{ setRedirect, redirect, redirectTarget, redirectTargetIsAnotherPage }}
+    >
+      {children}
+    </SSORedirectContext.Provider>
+  )
+}
+
+export default function useSSORedirect() {
+  const context = React.useContext(SSORedirectContext)
+  if (context === undefined) {
+    throw new Error('useSSORedirect must be used within a SSORedirectProvider')
+  }
+  return context
+}

--- a/next/pages/_app.tsx
+++ b/next/pages/_app.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StatusBarProvider } from 'components/forms/info-components/StatusBar'
 import CookieConsent from 'components/forms/segments/CookieConsent/CookieConsent'
 import { GlobalStateProvider } from 'components/forms/states/GlobalState'
+import { SSORedirectProvider } from 'frontend/hooks/useSSORedirect'
 import { AppProps } from 'next/app'
 import { Inter } from 'next/font/google'
 import Head from 'next/head'
@@ -46,8 +47,10 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
                 <SnackbarProvider>
                   <AccountProvider>
                     <GlobalStateProvider>
-                      <Component {...pageProps} />
-                      <CookieConsent />
+                      <SSORedirectProvider>
+                        <Component {...pageProps} />
+                        <CookieConsent />
+                      </SSORedirectProvider>
                     </GlobalStateProvider>
                   </AccountProvider>
                 </SnackbarProvider>

--- a/next/pages/logout.tsx
+++ b/next/pages/logout.tsx
@@ -1,18 +1,15 @@
 import AccountContainer from 'components/forms/segments/AccountContainer/AccountContainer'
 import AccountSuccessAlert from 'components/forms/segments/AccountSuccessAlert/AccountSuccessAlert'
 import LoginRegisterLayout from 'components/layouts/LoginRegisterLayout'
-import { getValidRedirectFromQuery } from 'frontend/utils/sso'
+import useSSORedirect from 'frontend/hooks/useSSORedirect'
 import { GetServerSidePropsContext } from 'next'
-import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useCallback, useEffect } from 'react'
+import { useEffect } from 'react'
 
 import PageWrapper from '../components/layouts/PageWrapper'
-import { ROUTES } from '../frontend/api/constants'
 import useAccount from '../frontend/hooks/useAccount'
 import { isProductionDeployment } from '../frontend/utils/general'
-import logger from '../frontend/utils/logger'
 import { AsyncServerProps } from '../frontend/utils/types'
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
@@ -38,20 +35,12 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 const LogoutPage = ({ page }: AsyncServerProps<typeof getServerSideProps>) => {
   const { t } = useTranslation('account')
   const { logout, isAuth } = useAccount()
-  const router = useRouter()
-  const redirect = useCallback(() => {
-    const redirectUrl = getValidRedirectFromQuery(router.query.from) || ROUTES.HOME
-    if (redirectUrl.startsWith('/')) {
-      router.push(redirectUrl).catch((error_) => logger.error('Failed redirect', error_))
-    } else {
-      window.location.href = redirectUrl
-    }
-  }, [router])
+  const { redirect } = useSSORedirect()
   useEffect(() => {
     if (!isAuth) {
       redirect()
     }
-  }, [isAuth, router, redirect])
+  }, [isAuth, redirect])
 
   // TODO replace AccountSuccessAlert with something more fitting
   return (

--- a/next/pages/prihlasenie.tsx
+++ b/next/pages/prihlasenie.tsx
@@ -3,17 +3,14 @@ import AccountContainer from 'components/forms/segments/AccountContainer/Account
 import EmailVerificationForm from 'components/forms/segments/EmailVerificationForm/EmailVerificationForm'
 import LoginForm from 'components/forms/segments/LoginForm/LoginForm'
 import LoginRegisterLayout from 'components/layouts/LoginRegisterLayout'
-import { getValidRedirectFromQuery } from 'frontend/utils/sso'
+import useSSORedirect from 'frontend/hooks/useSSORedirect'
 import { GetServerSidePropsContext } from 'next'
-import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useCallback, useEffect } from 'react'
+import { useEffect } from 'react'
 
 import PageWrapper from '../components/layouts/PageWrapper'
-import { ROUTES } from '../frontend/api/constants'
 import useAccount, { AccountStatus } from '../frontend/hooks/useAccount'
 import { isProductionDeployment } from '../frontend/utils/general'
-import logger from '../frontend/utils/logger'
 import { AsyncServerProps } from '../frontend/utils/types'
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
@@ -39,33 +36,23 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 const LoginPage = ({ page }: AsyncServerProps<typeof getServerSideProps>) => {
   const { login, error, status, resendVerificationCode, verifyEmail, lastEmail, user } =
     useAccount()
-  const router = useRouter()
-
-  // TODO move to general util
-  const redirect = useCallback(async () => {
-    const from = getValidRedirectFromQuery(router.query.from) || ROUTES.HOME
-    if (from.startsWith('/')) {
-      await router.push(from).catch((error_) => logger.error('Failed redirect', error_))
-    } else {
-      window.location.href = from
-    }
-  }, [router])
+  const { redirect } = useSSORedirect()
 
   useEffect(() => {
     if (user !== null && user !== undefined) {
-      redirect().catch((error_) => logger.error('Failed redirect', error_))
+      redirect()
     }
   }, [user, redirect])
 
   const onLogin = async (email: string, password: string) => {
     if (await login(email, password)) {
-      await redirect()
+      redirect()
     }
   }
 
   const onVerifyEmail = async (verificationCode: string) => {
     if (await verifyEmail(verificationCode)) {
-      await redirect()
+      redirect()
     }
   }
 

--- a/next/pages/registracia.tsx
+++ b/next/pages/registracia.tsx
@@ -5,7 +5,7 @@ import AccountSuccessAlert from 'components/forms/segments/AccountSuccessAlert/A
 import EmailVerificationForm from 'components/forms/segments/EmailVerificationForm/EmailVerificationForm'
 import RegisterForm from 'components/forms/segments/RegisterForm/RegisterForm'
 import LoginRegisterLayout from 'components/layouts/LoginRegisterLayout'
-import { getValidRedirectFromQuery } from 'frontend/utils/sso'
+import useSSORedirect from 'frontend/hooks/useSSORedirect'
 import { GetServerSidePropsContext } from 'next'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
@@ -44,10 +44,9 @@ const RegisterPage = ({ page }: AsyncServerProps<typeof getServerSideProps>) => 
   const { signUp, resendVerificationCode, verifyEmail, error, status, lastEmail, setStatus } =
     useAccount()
   const router = useRouter()
-  const possibleRedirect = getValidRedirectFromQuery(router.query.from)
+  const { redirect, redirectTargetIsAnotherPage } = useSSORedirect()
   // only divert user from verification if he's coming from another site
-  const preVerificationRedirect =
-    possibleRedirect && !possibleRedirect.startsWith('/') ? possibleRedirect : null
+  const preVerificationRedirect = redirectTargetIsAnotherPage
 
   return (
     <PageWrapper locale={page.locale} localizations={page.localizations}>
@@ -70,9 +69,7 @@ const RegisterPage = ({ page }: AsyncServerProps<typeof getServerSideProps>) => 
                 email: lastEmail,
               })}
               confirmLabel={t('identity_verification_link')}
-              onConfirm={() => {
-                window.location.href = preVerificationRedirect
-              }}
+              onConfirm={() => redirect()}
             />
           ) : (
             <AccountSuccessAlert


### PR DESCRIPTION
What this solves: when the user comes to login/register with a `from` query to which they should be redirected afterwards, but they don't complete the initial flow (i.e., they land on login, but instead go to registration), we still want to redirect them back the moment they succesfully login or create the account.