### PR TITLE
FORM-498: Fix non-scrolling registration modal

### DIFF
--- a/next/components/forms/segments/RegistrationModal/RegistrationModal.tsx
+++ b/next/components/forms/segments/RegistrationModal/RegistrationModal.tsx
@@ -87,7 +87,7 @@ const RegistrationModal = ({
     <div
       role="button"
       tabIndex={0}
-      className="h-full fixed w-full z-50 inset-0 flex items-center justify-center"
+      className="h-full fixed w-full z-50 inset-0 flex items-center justify-center hBase:items-start overflow-auto py-0 hBase:py-8"
       style={{ background: 'rgba(var(--color-gray-800), .4)', marginTop: '0' }}
       onClick={onClose}
       onKeyPress={(event: React.KeyboardEvent) => handleOnKeyPress(event, onClose)}

--- a/next/tailwind.config.js
+++ b/next/tailwind.config.js
@@ -36,6 +36,7 @@ module.exports = {
       md: '768px',
       lg: '1216px',
       xl: '1280px',
+      hBase: { raw: '(max-height: 830px)' },
     },
     boxShadow: {
       lg: '0px 16px 24px rgba(0, 0, 0, 0.12)',


### PR DESCRIPTION
Add breakpoint to tailwind config, because it seems like there are none for Max Height media queries to make it custom solution