### PR TITLE
Prevent auto-zoom to input on mobile safari

### DIFF
--- a/next/pages/_app.tsx
+++ b/next/pages/_app.tsx
@@ -44,6 +44,8 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
         <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#e46054" />
         <meta name="msapplication-TileColor" content="#da532c" />
         <meta name="theme-color" content="#ffffff" />
+        {/* Prevents automatic zooming on input fields on safari, which some users consider a bug. Source: https://stackoverflow.com/a/46254706 */}
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
         {/* look for CookieConsent component for 3rd party scripts you'd expect to find here */}
       </Head>
 


### PR DESCRIPTION
Solves https://github.com/orgs/bratislava/projects/6?pane=issue&itemId=30900790 and partly https://inovaciebratislava.slack.com/archives/C045D57G23V/p1687243677096489