### PR TITLE
Prefill form

### DIFF
--- a/next/components/forms/FormStateProvider.tsx
+++ b/next/components/forms/FormStateProvider.tsx
@@ -1,5 +1,7 @@
 import { GenericObjectType, RJSFSchema, UiSchema } from '@rjsf/utils'
+import { isProductionDeployment } from 'frontend/utils/general'
 import { JSONSchema7 } from 'json-schema'
+import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import React, { createContext, PropsWithChildren, useContext, useMemo, useState } from 'react'
 
@@ -67,8 +69,11 @@ export const FormStateProvider = ({
   children,
 }: PropsWithChildren<FormStateProviderProps>) => {
   const { t } = useTranslation('forms')
+  const router = useRouter()
 
-  const [stepIndex, setStepIndex] = useState<FormStepIndex>(0)
+  const shouldPrefill = !isProductionDeployment() && router.query?.prefill === 'true'
+
+  const [stepIndex, setStepIndex] = useState<FormStepIndex>(shouldPrefill ? 'summary' : 0)
   const [formData, setFormData] = useState<GenericObjectType>(initialFormData.formDataJson)
 
   const [skipModal, setSkipModal] = useState<SkipModal>({ open: false, skipAllowed: false })

--- a/next/components/forms/segments/FormModals/FormModals.tsx
+++ b/next/components/forms/segments/FormModals/FormModals.tsx
@@ -1,4 +1,6 @@
 import { useServerSideAuth } from 'frontend/hooks/useServerSideAuth'
+import { isProductionDeployment } from 'frontend/utils/general'
+import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import React, { useState } from 'react'
 
@@ -11,6 +13,10 @@ const FormModals = () => {
   const { skipModal } = useFormState()
   const { t } = useTranslation('account')
 
+  // don't show modals when we prefill data automatically
+  const router = useRouter()
+  const shouldPrefill = router.query.prefill === 'true' && isProductionDeployment()
+
   const { isAuthenticated, tierStatus, isLegalEntity } = useServerSideAuth()
 
   const [registrationModal, setRegistrationModal] = useState<boolean>(true)
@@ -22,7 +28,7 @@ const FormModals = () => {
         <SkipStepModal show onClose={skipModal.onClose} onSkip={skipModal.onSkip} />
       )}
 
-      {!isAuthenticated && (
+      {!shouldPrefill && !isAuthenticated && (
         <RegistrationModal
           title={t('register_modal.header_sent_title')}
           subtitle={t('register_modal.header_sent_subtitle')}
@@ -30,7 +36,7 @@ const FormModals = () => {
           onClose={() => setRegistrationModal(false)}
         />
       )}
-      {isAuthenticated && !tierStatus.isIdentityVerified && (
+      {!shouldPrefill && isAuthenticated && !tierStatus.isIdentityVerified && (
         <IdentityVerificationModal
           show={identityVerificationModal}
           onClose={() => setIdentityVerificationModal(false)}


### PR DESCRIPTION
A little helper for (manual) tests of the form-sending flow. Will need updating once file scans are completely done.

To get nicer prefill data, we can update the json-xsd-schema-lib - I think they are generated through faker ? But they are really basic right now (passing through validations though).