### PR TITLE
Read only fields

### DIFF
--- a/next/components/forms/steps/Summary/FormSummary.tsx
+++ b/next/components/forms/steps/Summary/FormSummary.tsx
@@ -7,7 +7,7 @@ import SummaryFormLegalText from './SummaryFormLegalText'
 import { FormSummaryProvider } from './useFormSummary'
 
 const FormSummary = () => {
-  const { formData, schema, uiSchema } = useFormState()
+  const { formData, schema, uiSchema, isReadonly } = useFormState()
 
   return (
     <FormSummaryProvider>
@@ -20,7 +20,7 @@ const FormSummary = () => {
           // The validator is not used, but it's required by the form. We use our own validation in `useFormSummary`.
           validator={rjfsValidator}
           experimental_defaultFormStateBehavior={defaultFormStateBehavior}
-          readonly
+          readonly={isReadonly}
           onSubmit={(e) => {
             console.log('form submit', e.formData)
           }}

--- a/next/components/forms/steps/Summary/FormSummary.tsx
+++ b/next/components/forms/steps/Summary/FormSummary.tsx
@@ -7,7 +7,7 @@ import SummaryFormLegalText from './SummaryFormLegalText'
 import { FormSummaryProvider } from './useFormSummary'
 
 const FormSummary = () => {
-  const { formData, schema, uiSchema, isReadonly } = useFormState()
+  const { formData, schema, uiSchema} = useFormState()
 
   return (
     <FormSummaryProvider>
@@ -20,7 +20,7 @@ const FormSummary = () => {
           // The validator is not used, but it's required by the form. We use our own validation in `useFormSummary`.
           validator={rjfsValidator}
           experimental_defaultFormStateBehavior={defaultFormStateBehavior}
-          readonly={isReadonly}
+          readonly
           onSubmit={(e) => {
             console.log('form submit', e.formData)
           }}

--- a/next/components/forms/steps/Summary/SummaryFieldRJSF.tsx
+++ b/next/components/forms/steps/Summary/SummaryFieldRJSF.tsx
@@ -18,7 +18,7 @@ export type SummaryFieldRJSFProps = Pick<
 
 const SummaryFieldRJSF = ({ formData, schema, idSchema, fieldType }: SummaryFieldRJSFProps) => {
   const { fieldHasError } = useFormSummary()
-  const { goToStepByFieldId } = useFormState()
+  const { goToStepByFieldId, isReadonly } = useFormState()
   const formatter = useDateFormatter()
 
   const formatDate = (value: string) => {
@@ -80,6 +80,7 @@ const SummaryFieldRJSF = ({ formData, schema, idSchema, fieldType }: SummaryFiel
           onGoToStep={() => {
             goToStepByFieldId(idSchema.$id)
           }}
+          isEditable={!isReadonly}
         />
       ))}
     </div>

--- a/next/components/forms/steps/Summary/SummaryWidgetRJSF.tsx
+++ b/next/components/forms/steps/Summary/SummaryWidgetRJSF.tsx
@@ -39,7 +39,10 @@ type TypeAndOptions =
       options: WidgetProps['options']
     }
 
-export type SummaryWidgetRJSFProps = Pick<WidgetProps, 'id' | 'label' | 'value' | 'uiSchema'> &
+export type SummaryWidgetRJSFProps = Pick<
+  WidgetProps,
+  'id' | 'label' | 'value' | 'uiSchema' | 'readonly'
+> &
   TypeAndOptions
 
 const ValueComponent = ({
@@ -50,7 +53,7 @@ const ValueComponent = ({
 }: Pick<SummaryWidgetRJSFProps, 'widgetType' | 'value' | 'options' | 'uiSchema'>) => {
   const formatter = useDateFormatter()
 
-  if (!value || Array.isArray(value) && value.length === 0) {
+  if (!value || (Array.isArray(value) && value.length === 0)) {
     return <>-</>
   }
 
@@ -58,14 +61,13 @@ const ValueComponent = ({
     case 'select':
       const selectOptions = options as SelectRJSFOptions
       const selectArray = Array.isArray(value) ? value : [value]
-      const selectLabels = selectArray.map(innerValue => selectOptions.enumOptions?.find((option) => option.value === innerValue)?.label ??
-        (innerValue as string))
-      
-      return (
-        <>
-          {selectLabels.join(', ')}
-        </>
+      const selectLabels = selectArray.map(
+        (innerValue) =>
+          selectOptions.enumOptions?.find((option) => option.value === innerValue)?.label ??
+          (innerValue as string),
       )
+
+      return <>{selectLabels.join(', ')}</>
     case 'radio':
       const radioOptions = options as RadioButtonRJSFOptions
       return (
@@ -118,6 +120,7 @@ const SummaryWidgetRJSF = ({
   value,
   options,
   uiSchema,
+  readonly,
 }: SummaryWidgetRJSFProps) => {
   const { fieldHasError } = useFormSummary()
   const { goToStepByFieldId } = useFormState()
@@ -140,6 +143,7 @@ const SummaryWidgetRJSF = ({
         onGoToStep={() => {
           goToStepByFieldId(id)
         }}
+        isEditable={!readonly}
       />
     </div>
   )

--- a/next/components/forms/steps/Summary/SummaryWidgetRJSF.tsx
+++ b/next/components/forms/steps/Summary/SummaryWidgetRJSF.tsx
@@ -120,10 +120,9 @@ const SummaryWidgetRJSF = ({
   value,
   options,
   uiSchema,
-  readonly,
 }: SummaryWidgetRJSFProps) => {
   const { fieldHasError } = useFormSummary()
-  const { goToStepByFieldId } = useFormState()
+  const { goToStepByFieldId, isReadonly } = useFormState()
 
   return (
     <div>
@@ -143,7 +142,7 @@ const SummaryWidgetRJSF = ({
         onGoToStep={() => {
           goToStepByFieldId(id)
         }}
-        isEditable={!readonly}
+        isEditable={!isReadonly}
       />
     </div>
   )

--- a/next/components/forms/widget-components/FieldBase.ts
+++ b/next/components/forms/widget-components/FieldBase.ts
@@ -6,6 +6,7 @@ export type FieldBaseProps = {
   required?: boolean
   disabled?: boolean
   explicitOptional?: boolean
+  readonly?: boolean
 }
 
 export type FieldAdditionalProps = {

--- a/next/components/forms/widget-wrappers/CheckboxWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/CheckboxWidgetRJSF.tsx
@@ -33,6 +33,7 @@ const CheckboxWidgetRJSF = (props: CheckboxesWidgetRJSFProps) => {
     schema: { maxItems },
     rawErrors,
     required,
+    readonly,
   } = props
   const {
     enumOptions,
@@ -59,6 +60,7 @@ const CheckboxWidgetRJSF = (props: CheckboxesWidgetRJSFProps) => {
         className={className}
         label={label}
         required={required}
+        disabled={readonly}
       >
         {enumOptions.map((option: EnumOptionsType) => {
           return (
@@ -66,7 +68,7 @@ const CheckboxWidgetRJSF = (props: CheckboxesWidgetRJSFProps) => {
               key={option.value}
               value={option.value}
               variant={variant}
-              isDisabled={isDisabled(option.value as string)}
+              isDisabled={isDisabled(option.value as string) || readonly}
               tooltip={getTooltip(option.value as string)}
             >
               {option.label}

--- a/next/components/forms/widget-wrappers/DatePickerWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/DatePickerWidgetRJSF.tsx
@@ -23,6 +23,7 @@ const DatePickerWidgetRJSF = ({
   disabled,
   value,
   onChange,
+  readonly,
 }: DatePickerWidgetRJSFProps) => {
   const {
     helptext,
@@ -39,7 +40,7 @@ const DatePickerWidgetRJSF = ({
         label={label}
         errorMessage={rawErrors}
         required={required}
-        disabled={disabled}
+        disabled={disabled || readonly}
         helptext={helptext}
         tooltip={tooltip}
         explicitOptional={explicitOptional}

--- a/next/components/forms/widget-wrappers/InputFieldWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/InputFieldWidgetRJSF.tsx
@@ -27,6 +27,7 @@ const InputFieldWidgetRJSF = ({
   disabled,
   onChange,
   rawErrors,
+  readonly,
 }: InputFieldWidgetRJSFProps) => {
   const {
     helptext,
@@ -59,7 +60,7 @@ const InputFieldWidgetRJSF = ({
         value={value ?? undefined}
         errorMessage={rawErrors}
         required={required}
-        disabled={disabled}
+        disabled={disabled || readonly}
         helptext={helptext}
         tooltip={tooltip}
         className={className}

--- a/next/components/forms/widget-wrappers/RadioButtonWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/RadioButtonWidgetRJSF.tsx
@@ -28,7 +28,7 @@ interface RadioButtonFieldWidgetRJSFProps extends WidgetProps {
 }
 
 const RadioButtonsWidgetRJSF = (props: RadioButtonFieldWidgetRJSFProps) => {
-  const { options, value, onChange, label, rawErrors, required } = props
+  const { options, value, onChange, label, rawErrors, required, readonly } = props
   const {
     enumOptions,
     className,
@@ -55,6 +55,7 @@ const RadioButtonsWidgetRJSF = (props: RadioButtonFieldWidgetRJSFProps) => {
         label={label}
         orientation={orientations === 'row' ? 'horizontal' : 'vertical'}
         required={required}
+        disabled={readonly}
       >
         {enumOptions.map((radioElement: EnumOptionsType) => {
           return (

--- a/next/components/forms/widget-wrappers/SelectFieldWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/SelectFieldWidgetRJSF.tsx
@@ -30,8 +30,18 @@ interface SelectFieldWidgetRJSFProps<T = unknown> extends WidgetProps {
 }
 
 const SelectFieldWidgetRJSF = (props: SelectFieldWidgetRJSFProps) => {
-  const { label, options, value, required, disabled, placeholder, schema, onChange, rawErrors } =
-    props
+  const {
+    label,
+    options,
+    value,
+    required,
+    disabled,
+    placeholder,
+    schema,
+    onChange,
+    rawErrors,
+    readonly,
+  } = props
   const {
     enumOptions,
     selectAllOption,
@@ -129,7 +139,7 @@ const SelectFieldWidgetRJSF = (props: SelectFieldWidgetRJSFProps) => {
         dropdownDivider={dropdownDivider}
         errorMessage={rawErrors}
         required={required}
-        disabled={disabled}
+        disabled={disabled || readonly}
         className={className}
         onChange={handleOnChange}
         explicitOptional={explicitOptional}

--- a/next/components/forms/widget-wrappers/TextAreaFieldWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/TextAreaFieldWidgetRJSF.tsx
@@ -24,6 +24,7 @@ const TextAreaFieldWidgetRJSF = (props: TextAreaFieldWidgetRJSFProps) => {
     disabled,
     options,
     onChange,
+    readonly,
   }: TextAreaFieldWidgetRJSFProps = props
 
   const {
@@ -56,7 +57,7 @@ const TextAreaFieldWidgetRJSF = (props: TextAreaFieldWidgetRJSFProps) => {
         label={label}
         placeholder={placeholder}
         required={required}
-        disabled={disabled}
+        disabled={disabled || readonly}
         helptext={helptext}
         tooltip={tooltip}
         className={cx('h-[196px]', className)}

--- a/next/components/forms/widget-wrappers/TimePickerWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/TimePickerWidgetRJSF.tsx
@@ -22,6 +22,7 @@ const TimePickerWidgetRJSF = ({
   disabled,
   value,
   onChange,
+  readonly,
 }: TimePickerWidgetRJSFProps) => {
   const {
     helptext,
@@ -38,7 +39,7 @@ const TimePickerWidgetRJSF = ({
         label={label}
         errorMessage={rawErrors}
         required={required}
-        disabled={disabled}
+        disabled={disabled || readonly}
         helptext={helptext}
         tooltip={tooltip}
         explicitOptional={explicitOptional}

--- a/next/components/forms/widget-wrappers/UploadWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/UploadWidgetRJSF.tsx
@@ -15,7 +15,7 @@ interface UploadWidgetRJSFProps extends WidgetProps {
 }
 
 const UploadWidgetRJSF = (props: UploadWidgetRJSFProps) => {
-  const { options, schema, label, required, value, disabled, onChange, rawErrors } = props
+  const { options, schema, label, required, value, disabled, onChange, rawErrors, readonly } = props
 
   const {
     size,
@@ -92,7 +92,7 @@ const UploadWidgetRJSF = (props: UploadWidgetRJSFProps) => {
         helptext={helptext}
         sizeLimit={size}
         supportedFormats={supportedFormats}
-        disabled={disabled}
+        disabled={disabled || readonly}
         onUpload={handleUpload}
         onFileRemove={handleFileRemove}
         onFileRetry={handleFileRetry}

--- a/next/components/forms/widget-wrappers/fieldGroupsRJSF/DateFromToWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/fieldGroupsRJSF/DateFromToWidgetRJSF.tsx
@@ -16,6 +16,7 @@ const DateFromToWidgetRJSF = ({
   schema,
   uiSchema,
   errorSchema,
+  readonly,
 }: DateFromToWidgetRJSFProps) => {
   const schemaProperties = {
     ...(schema.properties as Record<string, { type: string; title: string }>),
@@ -66,8 +67,8 @@ const DateFromToWidgetRJSF = ({
           DateToValue={formData?.endDate ?? null}
           DateFromLabel={schemaProperties?.startDate?.title}
           DateToLabel={schemaProperties?.endDate?.title}
-          DateFromDisabled={localUiSchema?.DateFromDisabled as unknown as boolean}
-          DateToDisabled={localUiSchema?.DateToDisabled as unknown as boolean}
+          DateFromDisabled={(localUiSchema?.DateFromDisabled as unknown as boolean) || readonly}
+          DateToDisabled={(localUiSchema?.DateToDisabled as unknown as boolean) || readonly}
         />
       </div>
     </WidgetWrapper>

--- a/next/components/forms/widget-wrappers/fieldGroupsRJSF/DateTimeWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/fieldGroupsRJSF/DateTimeWidgetRJSF.tsx
@@ -15,6 +15,7 @@ const DateTimeWidgetRJSF = ({
   schema,
   uiSchema,
   errorSchema,
+  readonly,
 }: DateTimeWidgetRJSFProps) => {
   const schemaProperties = {
     ...(schema.properties as Record<string, { type: string; title: string }>),
@@ -65,8 +66,8 @@ const DateTimeWidgetRJSF = ({
           TimeValue={formData.timeValue}
           DateLabel={schemaProperties?.dateValue?.title}
           TimeLabel={schemaProperties?.timeValue?.title}
-          DateDisabled={localUiSchema?.DateDisabled as unknown as boolean}
-          TimeDisabled={localUiSchema?.TimeDisabled as unknown as boolean}
+          DateDisabled={(localUiSchema?.DateDisabled as unknown as boolean) || readonly}
+          TimeDisabled={(localUiSchema?.TimeDisabled as unknown as boolean) || readonly}
         />
       </div>
     </WidgetWrapper>

--- a/next/components/forms/widget-wrappers/fieldGroupsRJSF/TimeFromToWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/fieldGroupsRJSF/TimeFromToWidgetRJSF.tsx
@@ -16,6 +16,7 @@ const TimeFromToWidgetRJSF = ({
   schema,
   uiSchema,
   errorSchema,
+  readonly,
 }: TimeFromToWidgetRJSFProps) => {
   const schemaProperties = {
     ...(schema.properties as Record<string, { type: string; title: string }>),
@@ -66,8 +67,8 @@ const TimeFromToWidgetRJSF = ({
           TimeToValue={formData?.endTime}
           TimeFromLabel={schemaProperties?.startTime?.title}
           TimeToLabel={schemaProperties?.endTime?.title}
-          TimeFromDisabled={localUiSchema?.TimeFromDisabled as unknown as boolean}
-          TimeToDisabled={localUiSchema?.TimeToDisabled as unknown as boolean}
+          TimeFromDisabled={(localUiSchema?.TimeFromDisabled as unknown as boolean) || readonly}
+          TimeToDisabled={(localUiSchema?.TimeToDisabled as unknown as boolean) || readonly}
         />
       </div>
     </WidgetWrapper>


### PR DESCRIPTION
The styling is inconsistent - created a followup (draft) task for that here  - https://github.com/orgs/bratislava/projects/6/views/5?pane=issue&itemId=39605991

Otherwise should be functioning. Disabled === readonly afaik, let me know if there should be a difference in behaviour. I did not see the `readonly` prop being used in SummaryForm (despite it always being set), so I've used it for conditionally (not) displaying the edit button in readonly forms - would also like to check about this, whether I did not break something unexpected.