### PR TITLE
[#600] Trim text at the end of line

### DIFF
--- a/next/components/forms/segments/AccountSectionHeader/MunicipalServicesSectionHeader.tsx
+++ b/next/components/forms/segments/AccountSectionHeader/MunicipalServicesSectionHeader.tsx
@@ -1,7 +1,6 @@
 import SelectField from 'components/forms/widget-components/SelectField/SelectField'
 import { SelectOption } from 'components/forms/widget-components/SelectField/SelectOption.interface'
 import { Dispatch, SetStateAction } from 'react'
-import { useWindowSize } from 'usehooks-ts'
 
 type MunicipalServicesSectionHeaderBase = {
   title: string
@@ -18,7 +17,6 @@ const MunicipalServicesSectionHeader = ({
   setCurrentPage,
   setSelectorValue,
 }: MunicipalServicesSectionHeaderBase) => {
-  const { width } = useWindowSize()
   return (
     <div className="bg-gray-50">
       <span className="m-auto flex h-full w-full max-w-screen-lg flex-col justify-end pb-4 pl-4 pt-6 lg:px-0 lg:pb-8 lg:pt-16">
@@ -36,7 +34,6 @@ const MunicipalServicesSectionHeader = ({
           hideScrollbar
           alwaysOneSelected
           enumOptions={enumOptions}
-          maxWordSize={width > 480 ? 45 : 25}
         />
       </span>
     </div>

--- a/next/components/forms/widget-components/SelectField/Dropdown.tsx
+++ b/next/components/forms/widget-components/SelectField/Dropdown.tsx
@@ -15,7 +15,6 @@ interface DropdownProps {
   type: 'one' | 'multiple' | 'arrow' | 'radio'
   divider?: boolean
   hideScrollbar?: boolean
-  maxWordSize?: number
   className?: string
   onChooseOne?: (option: SelectOption, close?: boolean) => void
   onUnChooseOne?: (option: SelectOption, close?: boolean) => void
@@ -36,7 +35,6 @@ const Dropdown: FC<DropdownProps> = (props: DropdownProps) => {
     type,
     divider,
     hideScrollbar,
-    maxWordSize = 22,
     className,
     onChooseOne,
     onUnChooseOne,
@@ -98,7 +96,6 @@ const Dropdown: FC<DropdownProps> = (props: DropdownProps) => {
             selected={isSelected(option)}
             type={type}
             isBold={isRowBold}
-            maxWordSize={maxWordSize}
             onChooseOne={(opt: SelectOption, close?: boolean) =>
               onChooseOne ? onChooseOne(opt, close) : null
             }

--- a/next/components/forms/widget-components/SelectField/DropdownRow.tsx
+++ b/next/components/forms/widget-components/SelectField/DropdownRow.tsx
@@ -13,7 +13,6 @@ interface DropdownRowProps {
   selected?: boolean
   type: 'one' | 'multiple' | 'arrow' | 'radio'
   divider?: boolean
-  maxWordSize?: number
   onChooseOne: (option: SelectOption, close?: boolean) => void
   onUnChooseOne: (option: SelectOption, close?: boolean) => void
   onChooseMulti: (option: SelectOption) => void
@@ -26,7 +25,6 @@ const DropdownRow = ({
   selected,
   type,
   divider,
-  maxWordSize,
   onChooseOne,
   onUnChooseOne,
   onChooseMulti,
@@ -41,9 +39,12 @@ const DropdownRow = ({
     },
   )
 
-  const optionClassName = cx('dropdown text-16 w-full', {
-    'text-16-semibold': isBold,
-  })
+  const optionClassName = cx(
+    'dropdown text-16 w-full overflow-x-hidden overflow-ellipsis whitespace-nowrap scrollbar-hide',
+    {
+      'text-16-semibold': isBold,
+    },
+  )
 
   // EVENT HANDLERS
   const handleOnClick = () => {
@@ -66,9 +67,6 @@ const DropdownRow = ({
     ) : null
 
   const optionText = option.title ?? String(option.const)
-  const transformedOptionText = `${optionText.slice(0, maxWordSize)}${
-    maxWordSize && optionText.length > maxWordSize ? '...' : ''
-  }`
 
   // RENDER
   return (
@@ -81,7 +79,7 @@ const DropdownRow = ({
     >
       <div className="dropdown flex h-full flex-col justify-center">
         <div className="dropdown flex flex-row justify-center">
-          <p className={optionClassName}>{transformedOptionText}</p>
+          <p className={optionClassName}>{optionText}</p>
           <div className="dropdown relative flex flex-col justify-center">
             {rowIcon}
             <div className="dropdown absolute inset-0 z-10" />

--- a/next/components/forms/widget-components/SelectField/SelectField.tsx
+++ b/next/components/forms/widget-components/SelectField/SelectField.tsx
@@ -58,7 +58,6 @@ type SelectFieldProps = FieldWrapperProps & {
   selectAllOption?: boolean
   hideScrollbar?: boolean
   alwaysOneSelected?: boolean
-  maxWordSize?: number
   onChange: (values: SelectOption[]) => void
   placeholder?: string
   className?: string
@@ -85,7 +84,6 @@ const SelectFieldComponent: ForwardRefRenderFunction<HTMLDivElement, SelectField
     disabled,
     hideScrollbar,
     alwaysOneSelected,
-    maxWordSize = 17,
     className,
     onChange,
     size,
@@ -263,7 +261,6 @@ const SelectFieldComponent: ForwardRefRenderFunction<HTMLDivElement, SelectField
             multiple={type === 'multiple'}
             filter={filter}
             filterRef={filterRef}
-            maxWordSize={maxWordSize}
             placeholder={placeholder}
             disabled={disabled}
             onRemove={handleOnRemove}
@@ -303,7 +300,6 @@ const SelectFieldComponent: ForwardRefRenderFunction<HTMLDivElement, SelectField
               divider={dropdownDivider}
               hideScrollbar={hideScrollbar}
               selectAllOption={selectAllOption}
-              maxWordSize={maxWordSize + 5}
               absolute
               onChooseOne={handleOnChooseOne}
               onUnChooseOne={handleOnUnChooseOne}

--- a/next/components/forms/widget-components/SelectField/SelectFieldBox.tsx
+++ b/next/components/forms/widget-components/SelectField/SelectFieldBox.tsx
@@ -12,7 +12,6 @@ interface SelectFieldBoxProps {
   placeholder?: string
   filter: string
   filterRef?: React.RefObject<HTMLInputElement>
-  maxWordSize?: number
   disabled?: boolean
   onRemove: (optionId: number) => void
   onRemoveAll: () => void
@@ -36,7 +35,6 @@ const SelectFieldBoxComponent: ForwardRefRenderFunction<HTMLDivElement, SelectFi
     placeholder,
     filter,
     filterRef,
-    maxWordSize = 17,
     disabled,
     onRemove,
     onRemoveAll,
@@ -98,11 +96,7 @@ const SelectFieldBoxComponent: ForwardRefRenderFunction<HTMLDivElement, SelectFi
                 />
               ))
             ) : (
-              <p>
-                {`${getOptionTitle(value[0]).slice(0, maxWordSize)}${
-                  getOptionTitle(value[0]).length > maxWordSize ? '...' : ''
-                }`}
-              </p>
+              <p>{getOptionTitle(value[0])}</p>
             )
           ) : (
             <Tag text={multipleOptionsTagText} size="small" onRemove={onRemoveAll} removable />

--- a/next/components/forms/widget-wrappers/SelectWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/SelectWidgetRJSF.tsx
@@ -34,7 +34,6 @@ const SelectWidgetRJSF = ({
     dropdownDivider,
     className,
     hideScrollbar = false,
-    maxWordSize,
     size,
     labelSize,
   } = options
@@ -127,7 +126,6 @@ const SelectWidgetRJSF = ({
         onChange={handleOnChange}
         hideScrollbar={hideScrollbar}
         alwaysOneSelected={false}
-        maxWordSize={maxWordSize}
         size={size}
         labelSize={labelSize}
       />

--- a/next/schema-generator/generator/uiOptionsTypes.ts
+++ b/next/schema-generator/generator/uiOptionsTypes.ts
@@ -110,7 +110,6 @@ export type SelectUiOptions = {
   dropdownDivider?: boolean
   selectAllOption?: boolean
   hideScrollbar?: boolean
-  maxWordSize?: number
   // selectType?: 'one' | 'multiple' | 'arrow' | 'radio'
 } & WidgetUiOptions
 


### PR DESCRIPTION
- Trim text in the select dropdown rows at the end of the line instead of after an arbitrary number of characters
- The selected line is displayed whole