### PR TITLE
Move non verified alert outside of user profile header

### DIFF
--- a/next/components/forms/info-components/Alert.tsx
+++ b/next/components/forms/info-components/Alert.tsx
@@ -111,7 +111,7 @@ const Alert = ({
       </div>
       {message && title && (
         <div
-          className={cx('text-p2 w-full pl-9 font-normal', {
+          className={cx('text-p2 w-full font-normal md:pl-9', {
             'text-gray-0': solid,
             'text-gray-700': !solid,
           })}
@@ -119,7 +119,7 @@ const Alert = ({
           {title && message}
         </div>
       )}
-      <AlertButtons className="pl-9" buttons={buttons} />
+      <AlertButtons className="md:pl-9" buttons={buttons} />
     </div>
   )
 }

--- a/next/components/forms/info-components/Alert.tsx
+++ b/next/components/forms/info-components/Alert.tsx
@@ -111,7 +111,7 @@ const Alert = ({
       </div>
       {message && title && (
         <div
-          className={cx('text-p2 w-full font-normal md:pl-9', {
+          className={cx('text-p2 w-full pl-9 font-normal', {
             'text-gray-0': solid,
             'text-gray-700': !solid,
           })}
@@ -119,7 +119,7 @@ const Alert = ({
           {title && message}
         </div>
       )}
-      <AlertButtons className="md:pl-9" buttons={buttons} />
+      <AlertButtons className="pl-9" buttons={buttons} />
     </div>
   )
 }

--- a/next/components/forms/segments/UserProfile/UserProfileDetail.tsx
+++ b/next/components/forms/segments/UserProfile/UserProfileDetail.tsx
@@ -1,6 +1,7 @@
 import cx from 'classnames'
 import Alert from 'components/forms/info-components/Alert'
 import { UserData } from 'frontend/dtos/accountDto'
+import { useServerSideAuth } from 'frontend/hooks/useServerSideAuth'
 import { useTranslation } from 'next-i18next'
 import { useId } from 'react'
 
@@ -35,6 +36,7 @@ const UserProfileDetail = (props: UserProfileDetailProps) => {
   } = props
   const { t } = useTranslation('account')
   const formId = `form-${useId()}`
+  const { tierStatus } = useServerSideAuth()
 
   const handleOnSubmit = (newUserData: UserData) => {
     onSubmit({
@@ -45,10 +47,28 @@ const UserProfileDetail = (props: UserProfileDetailProps) => {
 
   return (
     <div
-      className={cx(' flex flex-col', 'md:static md:z-0', {
+      className={cx('mt-3 flex flex-col bg-white', 'md:static md:z-0', {
         'fixed inset-0 z-50': isEditing,
       })}
     >
+      {!tierStatus.isIdentityVerified && (
+        <div className="flex w-full items-center justify-center bg-white p-3 md:px-8 md:py-3">
+          <div className="md:max-w-screen-lg">
+            <Alert
+              title={t('verification_status_required')}
+              message={t('verification_status_required_alert')}
+              type="warning"
+              buttons={[
+                {
+                  title: t('verification_url_text'),
+                  link: '/overenie-identity',
+                },
+              ]}
+              fullWidth
+            />
+          </div>
+        </div>
+      )}
       <UserProfileSection>
         <UserProfileSectionHeader
           title={t('profile_detail.title')}

--- a/next/components/forms/segments/UserProfile/UserProfileDetail.tsx
+++ b/next/components/forms/segments/UserProfile/UserProfileDetail.tsx
@@ -47,7 +47,7 @@ const UserProfileDetail = (props: UserProfileDetailProps) => {
 
   return (
     <div
-      className={cx('mt-3 flex flex-col bg-white', 'md:static md:z-0', {
+      className={cx('flex flex-col bg-white pt-3', 'md:static md:z-0', {
         'fixed inset-0 z-50': isEditing,
       })}
     >

--- a/next/components/forms/segments/UserProfile/UserProfileSectionHeader.tsx
+++ b/next/components/forms/segments/UserProfile/UserProfileSectionHeader.tsx
@@ -1,5 +1,4 @@
 import cx from 'classnames'
-import Alert from 'components/forms/info-components/Alert'
 import { useServerSideAuth } from 'frontend/hooks/useServerSideAuth'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -27,6 +26,7 @@ const UserProfileSectionHeader = ({
 }: UserProfileSectionHeaderProps) => {
   const { tierStatus } = useServerSideAuth()
   const { t } = useTranslation('account')
+
   return (
     <div
       className={cx(
@@ -58,20 +58,6 @@ const UserProfileSectionHeader = ({
         </div>
         {children && <div className={cx({ 'w-full md:w-fit': childrenToColumn })}>{children}</div>}
       </div>
-      {mainHeader && !tierStatus.isIdentityVerified && (
-        <Alert
-          title={t('verification_status_required')}
-          message={t('verification_status_required_alert')}
-          type="warning"
-          buttons={[
-            {
-              title: t('verification_url_text'),
-              link: '/overenie-identity',
-            },
-          ]}
-          fullWidth
-        />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
- Moved alert to be outside of profile header and appear according to Figma. 
- Changed padding of alert text on mobile
- https://github.com/bratislava/konto.bratislava.sk/issues/681