### PR TITLE
Allow searchengines on production

### DIFF
--- a/next/pages/api/robots.ts
+++ b/next/pages/api/robots.ts
@@ -1,9 +1,9 @@
+import { environment } from 'environment'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
   // temporarily everywhere, revert when there are sections which do not require login (remove also eslint disable)
-  // const isStaging = environment.isStaging
-  const isStaging = true
+  const { isStaging } = environment
   if (isStaging) {
     return res.send(
       `
@@ -12,7 +12,12 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
       `,
     )
   }
-  return res.send('')
+  return res.send(
+    `
+      User-Agent: *
+      Disallow: /mestske-sluzby/priznanie-k-dani-z-nehnutelnosti-dev
+      `,
+  )
 }
 
 export default handler


### PR DESCRIPTION
With this only /mestske-sluzby/priznanie-k-dani-z-nehnutelnosti-dev are no longer indexed on production, the rest of the pages reachable through urls (from bratislava.sk) should slowly appear.