### PR TITLE
Add custom errors for uploaded files in forms

### DIFF
--- a/next/components/forms/useFormFileUpload.tsx
+++ b/next/components/forms/useFormFileUpload.tsx
@@ -163,7 +163,12 @@ export const useGetContext = ({ initialFormData }: FormFileUploadProviderProps) 
         onError: (error) => {
           updateFileStatus({
             type: FormFileUploadStatusEnum.UploadServerError,
-            error: { rawError: error.toString() },
+            error: {
+              // eslint-disable-next-line @typescript-eslint/no-base-to-string
+              rawError: error.toString(),
+              errorCode: error?.response?.data?.statusCode,
+              errorName: error?.response?.data?.errorName,
+            },
             canRetry: true,
           })
         },

--- a/next/components/forms/widget-components/Upload/UploadFileCard.tsx
+++ b/next/components/forms/widget-components/Upload/UploadFileCard.tsx
@@ -26,6 +26,11 @@ type UploadedFileProps = {
   onFileDownload?: () => void
 }
 
+const FILE_ERROR_NAME_ENUM = {
+  FILE_SIZE_ZERO_ERROR: 'fileSizeZero',
+  FORM_NOT_FOUND_ERROR: 'formNotFound',
+}
+
 const UploadFileCard = ({
   fileInfo,
   onFileRetry,
@@ -120,13 +125,19 @@ const UploadFileCard = ({
 
       {isErrorStyle && (
         <div className="flex justify-between gap-6 pb-2">
-          <div className="text-error">
+          <div className="max-w-[80%] text-error">
             {fileInfo.status.type === FormFileUploadStatusEnum.UploadError &&
               t(`errors.${fileInfo.status.error.translationKey}`, {
                 additionalParam: fileInfo.status.error.additionalParam,
               })}
-            {fileInfo.status.type === FormFileUploadStatusEnum.UploadServerError &&
-              fileInfo.status.error.rawError}
+            {fileInfo.status.type === FormFileUploadStatusEnum.UploadServerError && (
+              <>
+                {fileInfo.status.error.errorName &&
+                FILE_ERROR_NAME_ENUM[fileInfo.status.error.errorName]
+                  ? t(`errors.${FILE_ERROR_NAME_ENUM[fileInfo.status.error.errorName]}`)
+                  : fileInfo.status.error.rawError}
+              </>
+            )}
             {fileInfo.status.type !== FormFileUploadStatusEnum.UploadError &&
               fileInfo.status.type !== FormFileUploadStatusEnum.UploadServerError &&
               t(`fileUploadStatus.${fileInfo.status.type}`)}

--- a/next/frontend/types/formFileUploadTypes.ts
+++ b/next/frontend/types/formFileUploadTypes.ts
@@ -39,6 +39,8 @@ export type FormFileUploadResponseFileStatus = {
   type: FormFileUploadStatusEnum.UploadServerError
   error: {
     rawError: string
+    errorCode?: number
+    errorName?: string
   }
   canRetry: boolean
 }

--- a/next/frontend/utils/formFileUpload.ts
+++ b/next/frontend/utils/formFileUpload.ts
@@ -4,7 +4,7 @@ import {
   GetFileResponseDtoStatusEnum,
   PostFileResponseDto,
 } from '@clients/openapi-forms'
-import { AxiosProgressEvent, AxiosResponse } from 'axios'
+import { AxiosError, AxiosProgressEvent, AxiosResponse } from 'axios'
 import flatten from 'lodash/flatten'
 import { extensions } from 'mime-types'
 import prettyBytes from 'pretty-bytes'
@@ -35,7 +35,9 @@ export const uploadFile = async ({
   abortController: AbortController
   onProgress: (progressPercentage: number) => void
   onSuccess: (response: AxiosResponse<PostFileResponseDto>) => void
-  onError: (error: Error) => void
+  onError: (
+    error: AxiosError<{ rawError: string; statusCode?: number; errorName?: string }>,
+  ) => void
 }) => {
   try {
     const response = await formsApi.filesControllerUploadFile(formId, file, file.name, id, {

--- a/next/public/locales/sk/account.json
+++ b/next/public/locales/sk/account.json
@@ -884,7 +884,9 @@
     "uploadingList": "Nahrávané súbory",
     "errors": {
       "largeFile": "Súbor je príliš veľký, maximálna veľkosť {{additionalParam}}.",
-      "invalidFileType": "Nepodporovaný formát súboru, podporované formáty: {{additionalParam}}."
+      "invalidFileType": "Nepodporovaný formát súboru, podporované formáty: {{additionalParam}}.",
+      "formNotFound": "Systém nenašiel formulár, ku ktorému sa snažíte nahrať súbor. Formulár mohol byť vymazaný alebo došlo k chybe. Prosím, skúste obnoviť stránku a ak problém pretrváva, kontaktujte nás na podporu.",
+      "fileSizeZero": "Nemôžete nahrať tento súbor, pretože má nulovú veľkosť. Skontrolujte, či súbor nie je prázdny, a skúste to znova."
     },
     "fileUploadStatus": {
       "UploadQueued": "Nahráva sa",


### PR DESCRIPTION
- https://github.com/bratislava/nest-forms-backend/issues/234
- Added custom error message for not finding form to which user tries to upload file
- Also added custom error message for when file has size zero
- Possibility to add other custom errors, based on BE response message `errorName`