### PR TITLE
Track form steps as custom events

### DIFF
--- a/next/components/forms/FormPageWrapper.tsx
+++ b/next/components/forms/FormPageWrapper.tsx
@@ -28,22 +28,17 @@ export type FormPageWrapperProps = {
   ssrCurrentAuthProps?: GetSSRCurrentAuth
 }
 
-// keeps hash, removes trailing id along with last slash: /mestske-sluzby/slug/id#hash -> /mestske-sluzby/slug#hash
-const matchUrlWithoutId = /(\/mestske-sluzby\/[^/]+)\/[^#/]+/
-
 // custom plausible tracking - we exclude '/mestske-sluzby/*/*' in top level plausible provider
-// instead, we track the url without the UUID
-// this is done on '/mestske-sluzby/slug#hash' url, note that '/mestske-sluzby/slug/whatever#hash' would still be ignored even with manual tracking
-// reference https://plausible.io/docs/custom-locations
-const useCustomPlausibleFormPagesTracking = () => {
+// instead, we track these as custom events: formSlug#hash
+const useCustomPlausibleFormPagesTracking = (formSlug: string) => {
   const router = useRouter()
   const plausible = usePlausible()
   const firstRender = useRef(true)
 
   useEffect(() => {
     const onHashChangeStart = (url: string) => {
-      const urlWithoutId = url?.replace(matchUrlWithoutId, '$1')
-      plausible('pageview', { u: urlWithoutId })
+      const hash = url.split('#')[1]
+      plausible(`${formSlug}#${hash}`)
     }
 
     router.events.on('hashChangeStart', onHashChangeStart)
@@ -51,24 +46,23 @@ const useCustomPlausibleFormPagesTracking = () => {
     return () => {
       router.events.off('hashChangeStart', onHashChangeStart)
     }
-  }, [plausible, router.events])
+  }, [formSlug, plausible, router.events])
 
   // track initial pageview
   useEffect(() => {
     if (firstRender.current) {
       firstRender.current = false
-      const initialUrlWithoutId = router.asPath?.replace(matchUrlWithoutId, '$1')
-      // initialUrlWithoutId being undefined should not happen, but better to catch it if it does
-      plausible('pageview', { u: initialUrlWithoutId || '/error-in-custom-tracking' })
+      const hash = router.asPath.split('#')[1]
+      plausible(`${formSlug}#${hash}`)
     }
-  }, [router.asPath, plausible])
+  }, [router.asPath, plausible, formSlug])
 }
 
 const FormPageWrapper = ({ schema, uiSchema, initialFormData }: FormPageWrapperProps) => {
-  useCustomPlausibleFormPagesTracking()
-
   const router = useRouter()
   const formSlug = router.query.slug as string
+
+  useCustomPlausibleFormPagesTracking(formSlug)
 
   return (
     <FormSentRenderer

--- a/next/frontend/hooks/useFormExportImport.tsx
+++ b/next/frontend/hooks/useFormExportImport.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from 'frontend/api/constants'
 import logger from 'frontend/utils/logger'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
+import { usePlausible } from 'next-plausible'
 import React, { createContext, PropsWithChildren, useContext, useRef } from 'react'
 
 import { RegistrationModalType } from '../../components/forms/segments/RegistrationModal/RegistrationModal'
@@ -30,6 +31,8 @@ export const useGetContext = ({ initialFormData }: FormExportImportProviderProps
   const { setConceptSaveErrorModal } = useFormModals()
   const { turnOffLeaveProtection } = useFormLeaveProtection()
   const router = useRouter()
+  // track each imported/exported xml/pdf in analytics - event format should match the one in FormPagesWrapper
+  const plausible = usePlausible()
 
   const [openSnackbarError] = useSnackbar({ variant: 'error' })
   const [openSnackbarSuccess] = useSnackbar({ variant: 'success' })
@@ -106,6 +109,7 @@ export const useGetContext = ({ initialFormData }: FormExportImportProviderProps
       downloadBlob(new Blob([response.data.xmlForm]), fileName)
       closeSnackbarInfo()
       openSnackbarSuccess(t('success_messages.xml_export'))
+      plausible(`${formSlug}#export-xml`)
     } catch (error) {
       openSnackbarError(t('errors.xml_export'))
     }
@@ -134,6 +138,7 @@ export const useGetContext = ({ initialFormData }: FormExportImportProviderProps
       setImportedFormData(response.data.jsonForm)
       closeSnackbarInfo()
       openSnackbarSuccess(t('success_messages.xml_import'))
+      plausible(`${formSlug}#import-xml`)
     } catch (error) {
       openSnackbarError(t('errors.xml_import'))
     }
@@ -185,6 +190,7 @@ export const useGetContext = ({ initialFormData }: FormExportImportProviderProps
 
   const exportPdf = async () => {
     await (initialFormData.isTaxForm ? exportTaxPdf() : exportOrdinaryPdf())
+    plausible(`${formSlug}#export-pdf`)
   }
 
   const saveConcept = async (fromModal?: boolean) => {

--- a/next/pages/_app.tsx
+++ b/next/pages/_app.tsx
@@ -64,9 +64,8 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
                   }
                   // exclude instances of forms (i.e./mestske-sluzby/priznanie-k-dani-z-nehnutelnosti is still tracked)
                   // we track those manually along with step hashes so that we can track "funnels" across steps
-                  // exclude="/mestske-sluzby/*/*"
+                  exclude="/mestske-sluzby/*/*"
                   taggedEvents
-                  hash
                   // uncomment for local testing, needs to be run with `yarn build && yarn start`
                   // trackLocalhost
                 >


### PR DESCRIPTION
Custom url approach did not work well for this, evne with some more experiments yesterday (did these direclty to master 😬 ), so instead this:
- tracks steps of forms as custom events in plausible
- tracks pdf downloads as custom events - while at it, started tracking also xml download/uploads, it's reasonably interesting whether this feature is being used