### PR TITLE
Custom cognito tax form beta attribute

### DIFF
--- a/next/frontend/dtos/accountDto.ts
+++ b/next/frontend/dtos/accountDto.ts
@@ -38,4 +38,5 @@ export interface UserData {
   'custom:tier'?: Tier
   'custom:account_type'?: AccountType
   'custom:turnstile_token'?: string
+  'custom:2024_tax_form_beta'?: string
 }


### PR DESCRIPTION
The rest of the setup is on cognito site.

The type is string (can be only string or number in cognito), the expected usage is to treat it as bool/flag.