### PR TITLE
fix: KEDA scaller when metric is fluctuating

### DIFF
--- a/next/kubernetes/envs/Prod/scaler.yml
+++ b/next/kubernetes/envs/Prod/scaler.yml
@@ -15,10 +15,10 @@ spec:
         serverAddress: http://kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
         metricName: container_cpu_usage_percent
         threshold: '85'
-        query: 100 * (sum(rate(container_cpu_usage_seconds_total{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", container=~".*"}[10m])) by (namespace, pod, container) / on (pod, container) group_left() kube_pod_container_resource_limits{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", container=~".*", resource="cpu"})
+        query: max(100 * (sum(rate(container_cpu_usage_seconds_total{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", container=~".*"}[1m])) by (namespace, pod, container) / on (pod, container) group_left() kube_pod_container_resource_limits{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", container=~".*", resource="cpu"}))
     - type: prometheus
       metadata:
         serverAddress: http://kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
         metricName: container_memory_usage_percent
         threshold: '85'
-        query: sum by (namespace, pod) (100 * (avg_over_time(container_memory_working_set_bytes{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", service="kube-prometheus-kubelet"}[10m]) / on (pod, container) group_left() kube_pod_container_resource_limits{resource="memory", namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*"}))
+        query: max(100 * (avg_over_time(container_memory_working_set_bytes{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", service="kube-prometheus-kubelet"}[1m]) / on (pod, container) group_left() kube_pod_container_resource_limits{resource="memory", namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*"}))


### PR DESCRIPTION
* Lower rolling window on Prometheus queries for KEDA autoscaler, because `10m` smoothed rapidly fluctuating metrics a bit too much and no upscaling was performed
* Change final `sum` to `max` function to scale no matter what pod is hitting the limit (they don't have to hit it on average)