### PR TITLE
Forms improvements v4

### DIFF
--- a/next/components/forms/widget-wrappers/BAArrayFieldItemTemplate.tsx
+++ b/next/components/forms/widget-wrappers/BAArrayFieldItemTemplate.tsx
@@ -44,7 +44,7 @@ const BAArrayFieldItemTemplate = <
   })
 
   const contentStyle = cx({
-    'p-4 md:p-6': variant === 'nested',
+    'px-4 md:px-6': variant === 'nested',
   })
 
   const title = getArrayFieldItemTemplateTitle(itemTitle, index)
@@ -55,7 +55,7 @@ const BAArrayFieldItemTemplate = <
     onDropIndexClick(innerIndex)({ preventDefault: () => {} })
   }
 
-  const dataCyProps: ChildrenProps = children.props;
+  const dataCyProps: ChildrenProps = children.props
 
   return (
     <div className={boxStyle} data-cy={`section-${dataCyProps.name}`}>

--- a/next/components/forms/widget-wrappers/BAObjectFieldTemplate.tsx
+++ b/next/components/forms/widget-wrappers/BAObjectFieldTemplate.tsx
@@ -1,10 +1,29 @@
 import { getUiOptions, ObjectFieldTemplateProps } from '@rjsf/utils'
 import cx from 'classnames'
+import { PropsWithChildren, useMemo } from 'react'
 import { ObjectFieldUiOptions } from 'schema-generator/generator/uiOptionsTypes'
 
 import FormMarkdown from '../info-components/FormMarkdown'
 import { WidgetSpacingContextProvider } from './useWidgetSpacingContext'
 import WidgetWrapper from './WidgetWrapper'
+
+/* TODO: Remove when all schemas on server are replaced */
+type LegacyObjectFieldUiOptions = {
+  objectDisplay?: 'columns'
+  objectColumnRatio?: string
+}
+
+/* TODO: Remove when all schemas on server are replaced */
+const convertLegacyUiOptions = (uiOptions: ObjectFieldUiOptions | LegacyObjectFieldUiOptions) => {
+  if (uiOptions.objectDisplay === 'columns' && typeof uiOptions.objectColumnRatio === 'string') {
+    return {
+      columns: true,
+      columnsRatio: uiOptions.objectColumnRatio,
+    } satisfies ObjectFieldUiOptions
+  }
+
+  return uiOptions as ObjectFieldUiOptions
+}
 
 const getPropertySpacing = (isInColumnObject: boolean, isFirst: boolean, isLast: boolean) => {
   // The column object itself has spacing, therefore its children should not have one
@@ -20,58 +39,71 @@ const getPropertySpacing = (isInColumnObject: boolean, isFirst: boolean, isLast:
   }
 }
 
+const ColumnDisplay = ({
+  uiOptions,
+  children,
+}: PropsWithChildren<{ uiOptions: ObjectFieldUiOptions }>) => {
+  if (uiOptions.columns && uiOptions.columnsRatio) {
+    const gridTemplateColumns = uiOptions.columnsRatio
+      .split('/')
+      .map((value) => `minmax(0, ${value}fr)`)
+      .join(' ')
+
+    return (
+      // For screens below sm, we want to display them as rows
+      <div className="flex flex-col gap-6 sm:grid" style={{ gridTemplateColumns }}>
+        {children}
+      </div>
+    )
+  }
+
+  return <>{children}</>
+}
+
 /**
  * Our custom implementation of https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/core/src/components/templates/ObjectFieldTemplate.tsx
  * This allows us to provide specific UI options for styling the template (e.g. columns).
  * This implementation removes titles and descriptions from objects. It might be needed to add it back.
  */
 const BAObjectFieldTemplate = ({ idSchema, properties, uiSchema }: ObjectFieldTemplateProps) => {
-  const options = getUiOptions(uiSchema) as ObjectFieldUiOptions
+  const options = useMemo(() => {
+    const uiOptions = getUiOptions(uiSchema) as ObjectFieldUiOptions
+    return convertLegacyUiOptions(uiOptions)
+  }, [uiSchema])
 
   const defaultSpacing = {
+    wrapper: {},
     boxed: { spaceBottom: 'medium' as const, spaceTop: 'medium' as const },
-    columns: {},
-    noObjectDisplay: { spaceTop: 'none' as const, spaceBottom: 'none' as const },
-  }[options.objectDisplay ?? 'noObjectDisplay']
+  }[options.objectDisplay ?? 'wrapper']
 
   const fieldsetClassname = cx({
-    'flex flex-col gap-6 sm:grid': options.objectDisplay === 'columns',
     'border-grey-200 rounded-xl border p-4': options.objectDisplay === 'boxed',
   })
 
-  const gridTemplateColumns =
-    options.objectDisplay === 'columns' && typeof options.objectColumnRatio === 'string'
-      ? options.objectColumnRatio
-          .split('/')
-          .map((value) => `minmax(0, ${value}fr)`)
-          .join(' ')
-      : undefined
-
   return (
     <WidgetWrapper id={idSchema.$id} options={options} defaultSpacing={defaultSpacing}>
-      <fieldset className={fieldsetClassname} style={{ gridTemplateColumns }} data-cy={`fieldset-${idSchema.$id}`}>
-        {options.objectDisplay === 'boxed' && options.title && (
-          <h3 className="text-h3 mb-3">{options.title}</h3>
-        )}
-        {options.objectDisplay === 'boxed' && options.description && (
-          <div className="text-p2 whitespace-pre-wrap">
+      <fieldset className={fieldsetClassname} data-cy={`fieldset-${idSchema.$id}`}>
+        {options.title && <h3 className="text-h3 mb-3">{options.title}</h3>}
+        {options.description && (
+          <div className="text-p2 mb-3 whitespace-pre-wrap">
             <FormMarkdown>{options.description}</FormMarkdown>
           </div>
         )}
-        {properties.map(({ content }, index) => {
-          const isInColumnObject = options.objectDisplay === 'columns'
-          const isFirst = index === 0
-          const isLast = index === properties.length - 1
+        <ColumnDisplay uiOptions={options}>
+          {properties.map(({ content }, index) => {
+            const isFirst = index === 0
+            const isLast = index === properties.length - 1
 
-          return (
-            <WidgetSpacingContextProvider
-              spacing={getPropertySpacing(isInColumnObject, isFirst, isLast)}
-              key={index}
-            >
-              {content}
-            </WidgetSpacingContextProvider>
-          )
-        })}
+            return (
+              <WidgetSpacingContextProvider
+                spacing={getPropertySpacing(Boolean(options.columns), isFirst, isLast)}
+                key={index}
+              >
+                {content}
+              </WidgetSpacingContextProvider>
+            )
+          })}
+        </ColumnDisplay>
       </fieldset>
     </WidgetWrapper>
   )

--- a/next/components/forms/widget-wrappers/BAObjectFieldTemplate.tsx
+++ b/next/components/forms/widget-wrappers/BAObjectFieldTemplate.tsx
@@ -63,7 +63,8 @@ const ColumnDisplay = ({
 /**
  * Our custom implementation of https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/core/src/components/templates/ObjectFieldTemplate.tsx
  * This allows us to provide specific UI options for styling the template (e.g. columns).
- * This implementation removes titles and descriptions from objects. It might be needed to add it back.
+ * This implementation removes `TitleFieldTemplate` and `DescriptionFieldTemplate` from the
+ * implementation and displays them directly.
  */
 const BAObjectFieldTemplate = ({ idSchema, properties, uiSchema }: ObjectFieldTemplateProps) => {
   const options = useMemo(() => {

--- a/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/osoby.ts
+++ b/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/osoby.ts
@@ -25,8 +25,8 @@ const menoTitulField = object(
   'menoTitul',
   { required: true },
   {
-    objectDisplay: 'columns',
-    objectColumnRatio: '3/1',
+    columns: true,
+    columnsRatio: '3/1',
   },
   [input('meno', { title: 'Meno', required: true }, {}), input('titul', { title: 'Titul' }, {})],
 )
@@ -36,8 +36,8 @@ const ulicaCisloFields = (type: UlicaCisloTyp) =>
     `ulicaCislo${type}`,
     { required: true },
     {
-      objectDisplay: 'columns',
-      objectColumnRatio: '3/1',
+      columns: true,
+      columnsRatio: '3/1',
     },
     [
       input(
@@ -63,8 +63,8 @@ const obecPscField = object(
   'obecPsc',
   { required: true },
   {
-    objectDisplay: 'columns',
-    objectColumnRatio: '3/1',
+    columns: true,
+    columnsRatio: '3/1',
   },
   [
     input('obec', { title: 'Obec', required: true }, {}),

--- a/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/stavbyBase.ts
+++ b/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/stavbyBase.ts
@@ -13,8 +13,8 @@ export const stavbyBase = (step: StepEnum) => [
     'riadok1',
     { required: true },
     {
-      objectDisplay: 'columns',
-      objectColumnRatio: '3/1',
+      columns: true,
+      columnsRatio: '3/1',
     },
     [
       input('ulicaACisloDomu', { title: 'Ulica a číslo domu', required: true }, {}),
@@ -29,8 +29,8 @@ export const stavbyBase = (step: StepEnum) => [
     'riadok2',
     { required: true },
     {
-      objectDisplay: 'columns',
-      objectColumnRatio: '1/1',
+      columns: true,
+      columnsRatio: '1/1',
     },
     [
       select(

--- a/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/step3.ts
+++ b/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/step3.ts
@@ -158,8 +158,8 @@ const innerArray = (kalkulacka: boolean) =>
             'parcelneCisloSposobVyuzitiaPozemku',
             { required: true },
             {
-              objectDisplay: 'columns',
-              objectColumnRatio: '1/1',
+              columns: true,
+              columnsRatio: '1/1',
             },
             [
               input(
@@ -279,8 +279,8 @@ const innerArray = (kalkulacka: boolean) =>
             'datumy',
             {},
             {
-              objectDisplay: 'columns',
-              objectColumnRatio: '1/1',
+              columns: true,
+              columnsRatio: '1/1',
             },
             [
               datePicker(

--- a/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/step4.ts
+++ b/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/step4.ts
@@ -179,8 +179,8 @@ const innerArray = (kalkulacka: boolean) =>
           'castStavbyOslobodenaOdDaneDetaily',
           {},
           {
-            objectDisplay: 'columns',
-            objectColumnRatio: '1/1',
+            columns: true,
+            columnsRatio: '1/1',
           },
           [
             number(
@@ -214,8 +214,8 @@ const innerArray = (kalkulacka: boolean) =>
         'datumy',
         {},
         {
-          objectDisplay: 'columns',
-          objectColumnRatio: '1/1',
+          columns: true,
+          columnsRatio: '1/1',
         },
         [
           datePicker(

--- a/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/step5.ts
+++ b/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/step5.ts
@@ -169,8 +169,8 @@ const innerArray = (kalkulacka: boolean) =>
         'datumy',
         {},
         {
-          objectDisplay: 'columns',
-          objectColumnRatio: '1/1',
+          columns: true,
+          columnsRatio: '1/1',
         },
         [
           datePicker(

--- a/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/step6.ts
+++ b/next/schema-generator/definitions/priznanie-k-dani-z-nehnutelnosti/step6.ts
@@ -214,8 +214,8 @@ const innerArray = (kalkulacka: boolean) =>
               'datumy',
               {},
               {
-                objectDisplay: 'columns',
-                objectColumnRatio: '1/1',
+                columns: true,
+                columnsRatio: '1/1',
               },
               [
                 datePicker(
@@ -281,8 +281,8 @@ const innerArray = (kalkulacka: boolean) =>
                   'riadok',
                   {},
                   {
-                    objectDisplay: 'columns',
-                    objectColumnRatio: '1/1',
+                    columns: true,
+                    columnsRatio: '1/1',
                   },
                   [
                     input(
@@ -327,8 +327,8 @@ const innerArray = (kalkulacka: boolean) =>
                   'datumy',
                   {},
                   {
-                    objectDisplay: 'columns',
-                    objectColumnRatio: '1/1',
+                    columns: true,
+                    columnsRatio: '1/1',
                   },
                   [
                     datePicker(

--- a/next/schema-generator/definitions/shared/investicne.ts
+++ b/next/schema-generator/definitions/shared/investicne.ts
@@ -45,8 +45,8 @@ const ziadatelInvestorFields = [
     'mestoPsc',
     { required: true },
     {
-      objectDisplay: 'columns',
-      objectColumnRatio: '3/1',
+      columns: true,
+      columnsRatio: '3/1',
     },
     [
       input('mesto', { title: 'Mesto', required: true }, {}),

--- a/next/schema-generator/generator/uiOptionsTypes.ts
+++ b/next/schema-generator/generator/uiOptionsTypes.ts
@@ -137,20 +137,23 @@ export type ArrayFieldUiOptions = Pick<WidgetUiOptions, 'spaceTop' | 'spaceBotto
   )
 
 export type ObjectFieldUiOptions = Pick<WidgetUiOptions, 'spaceTop' | 'spaceBottom'> &
-  (
+  ({
+    /* @defaultValue `wrapper` */
+    objectDisplay?: 'wrapper' | 'boxed'
+    title?: string
+    description?: string
+  } & (
     | {
-        objectDisplay?: 'columns'
+        columns?: false
+      }
+    | {
+        columns: true
         /**
          * Slash separated numeric values, e.g. '1/2' or '1/2/3'
          */
-        objectColumnRatio?: string
+        columnsRatio: string
       }
-    | {
-        objectDisplay?: 'boxed'
-        title?: string
-        description?: string
-      }
-  )
+  ))
 
 export type SchemaUiOptions = {
   moreInformationUrl?: string


### PR DESCRIPTION
Although I don't like to change the UI options this is a must.

Decouple whether object displays columns and display type in objects to: 
 - "wrapper" (new default) can have title and description
 - "boxed" can have columns

The schemas currently present on the server are handled by `convertLegacyUiOptions`, we need to think about how to handle these cases in the future. We might not remove `convertLegacyUiOptions` in the future, but just keep it for old sent forms (if we want to display them).