### PR TITLE
Force logout on assert

### DIFF
--- a/next/frontend/utils/amplifyClient.ts
+++ b/next/frontend/utils/amplifyClient.ts
@@ -6,6 +6,19 @@ import { ROUTES } from '../api/constants'
 import { useSsrAuth } from '../hooks/useSsrAuth'
 import logger from './logger'
 
+// Attempts to fix https://github.com/aws-amplify/amplify-js/issues/13182
+export const removeAllCookiesAndClearLocalStorage = () => {
+  const cookies = document.cookie.split(';').map((cookie) => cookie.trim())
+  cookies.forEach((cookie) => {
+    const cookieName = cookie.split('=')[0]
+    if (cookieName !== 'gdpr-consents') {
+      // https://stackoverflow.com/questions/179355/clearing-all-cookies-with-javascript
+      document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
+    }
+  })
+  localStorage.clear()
+}
+
 const fetchAccessTokenString = async () => {
   const session = await fetchAuthSession()
   return session.tokens?.accessToken?.toString() ?? null

--- a/next/frontend/utils/amplifyServer.ts
+++ b/next/frontend/utils/amplifyServer.ts
@@ -10,6 +10,7 @@ import { ssrAuthContextPropKey, SsrAuthContextType } from '../../components/logi
 import { ROUTES } from '../api/constants'
 import { assertContextSpecAndIdToken } from './amplifyAssert'
 import { baRunWithAmplifyServerContext } from './amplifyServerRunner'
+import logger from './logger'
 import {
   getRedirectUrl,
   getSafeRedirect,
@@ -76,7 +77,18 @@ export const amplifyGetServerSideProps = <
     baRunWithAmplifyServerContext({
       nextServerContext: { request: context.req, response: context.res },
       operation: async (contextSpec) => {
-        await assertContextSpecAndIdToken(context, contextSpec)
+        try {
+          await assertContextSpecAndIdToken(context, contextSpec)
+        } catch (error) {
+          logger.error('Error in assertContextSpecAndIdToken')
+          logger.error(error)
+          return {
+            redirect: {
+              destination: '/force-logout',
+              permanent: false,
+            },
+          }
+        }
 
         const isSignedIn = await getIsSignedIn(contextSpec)
         const getAccessTokenFn = isSignedIn

--- a/next/pages/force-logout.tsx
+++ b/next/pages/force-logout.tsx
@@ -1,12 +1,10 @@
 import logger from 'frontend/utils/logger'
-import { useRouter } from 'next/router'
 import { useEffectOnce } from 'usehooks-ts'
 
 import { removeAllCookiesAndClearLocalStorage, useSignOut } from '../frontend/utils/amplifyClient'
 
 const ForceLogoutPage = () => {
   const { signOut } = useSignOut()
-  const { replace } = useRouter()
 
   const logoutHandler = async () => {
     try {
@@ -18,11 +16,12 @@ const ForceLogoutPage = () => {
       // clearing BEFORE signing out, to make sure it happens (singOut redirects)
       removeAllCookiesAndClearLocalStorage()
       // shouldn't be needed, but to be sure that we clear also the in-memory session
-      // in worst case this throws, which is fine - we still cleared everything on the previous line & we'll redirect
+      // in worst case this throws, which is fine - we still cleared everything on the previous line
       await signOut()
     } catch (error) {
       logger.error('[AUTH] Error during forced sign out - redirecting to login', error)
-      replace('/prihlasenie')
+      // this also causes the app to reload, clearing any in memory state if signOut failed
+      window.location.replace('/prihlasenie')
     }
   }
 

--- a/next/pages/force-logout.tsx
+++ b/next/pages/force-logout.tsx
@@ -1,0 +1,38 @@
+import logger from 'frontend/utils/logger'
+import { useRouter } from 'next/router'
+import { useEffectOnce } from 'usehooks-ts'
+
+import { removeAllCookiesAndClearLocalStorage, useSignOut } from '../frontend/utils/amplifyClient'
+
+const ForceLogoutPage = () => {
+  const { signOut } = useSignOut()
+  const { replace } = useRouter()
+
+  const logoutHandler = async () => {
+    try {
+      logger.error(`[AUTH] Forced sign out`)
+      // give a short moment to show the user what is happening
+      await new Promise((resolve) => {
+        setTimeout(resolve, 2000)
+      })
+      // clearing BEFORE signing out, to make sure it happens (singOut redirects)
+      removeAllCookiesAndClearLocalStorage()
+      // shouldn't be needed, but to be sure that we clear also the in-memory session
+      // in worst case this throws, which is fine - we still cleared everything on the previous line & we'll redirect
+      await signOut()
+    } catch (error) {
+      logger.error('[AUTH] Error during forced sign out - redirecting to login', error)
+      replace('/prihlasenie')
+    }
+  }
+
+  useEffectOnce(() => {
+    logoutHandler().catch((error) => {
+      logger.error('Unexpected error when forcing logout - this should never happen', error)
+    })
+  })
+
+  return 'Neokávaná chyba, prosím znovu sa prihláste.'
+}
+
+export default ForceLogoutPage

--- a/next/pages/force-logout.tsx
+++ b/next/pages/force-logout.tsx
@@ -31,7 +31,7 @@ const ForceLogoutPage = () => {
     })
   })
 
-  return 'Neokávaná chyba, prosím znovu sa prihláste.'
+  return 'Neočakávaná chyba, prosím znovu sa prihláste.'
 }
 
 export default ForceLogoutPage

--- a/next/pages/prihlasenie.tsx
+++ b/next/pages/prihlasenie.tsx
@@ -2,6 +2,7 @@ import { AuthError, resendSignUpCode, signIn } from 'aws-amplify/auth'
 import AccountContainer from 'components/forms/segments/AccountContainer/AccountContainer'
 import LoginForm from 'components/forms/segments/LoginForm/LoginForm'
 import LoginRegisterLayout from 'components/layouts/LoginRegisterLayout'
+import { removeAllCookiesAndClearLocalStorage } from 'frontend/utils/amplifyClient'
 import { GENERIC_ERROR_MESSAGE, isError } from 'frontend/utils/errors'
 import logger from 'frontend/utils/logger'
 import { useRouter } from 'next/router'
@@ -12,19 +13,6 @@ import { ROUTES } from '../frontend/api/constants'
 import { useQueryParamRedirect } from '../frontend/hooks/useQueryParamRedirect'
 import { amplifyGetServerSideProps } from '../frontend/utils/amplifyServer'
 import { slovakServerSideTranslations } from '../frontend/utils/slovakServerSideTranslations'
-
-// Attempts to fix https://github.com/aws-amplify/amplify-js/issues/13182
-function removeAllCookiesAndClearLocalStorage() {
-  const cookies = document.cookie.split(';').map((cookie) => cookie.trim())
-  cookies.forEach((cookie) => {
-    const cookieName = cookie.split('=')[0]
-    if (cookieName !== 'gdpr-consents') {
-      // https://stackoverflow.com/questions/179355/clearing-all-cookies-with-javascript
-      document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
-    }
-  })
-  localStorage.clear()
-}
 
 export const getServerSideProps = amplifyGetServerSideProps(
   async () => {


### PR DESCRIPTION
Instead of just throwing a 500 on failed asserts, redirect to page which forces client-side code to clear cookies & local storage and log out.

Having a page such as force-logout isn't good practice, keeping it only temporarily until the present issue is resolved.