### PR TITLE
fixing cypress test

### DIFF
--- a/.github/workflows/cypress-test.yaml
+++ b/.github/workflows/cypress-test.yaml
@@ -19,6 +19,11 @@ jobs:
         with:
           node-version: '20.x'
 
+      - name: Install dependencies in forms-shared
+        working-directory: forms-shared
+        run: |
+          yarn install
+
       - name: Install and build application
         working-directory: next
         run: |


### PR DESCRIPTION
before running yarn install on app, we first install dependencies on `forms-shared`