### PR TITLE
Revert @ts-expect-error

### DIFF
--- a/forms-shared/src/form-utils/validators.ts
+++ b/forms-shared/src/form-utils/validators.ts
@@ -11,6 +11,7 @@ const getBaRjsfValidator = (customKeywords?: Vocabulary) =>
     // The type in @rjsf/validator-ajv8 is wrong.
     customFormats: baAjvFormats as unknown as CustomValidatorOptionsType['customFormats'],
     ajvOptionsOverrides: {
+      // @ts-expect-error RJSF internal type of keywords uses a different version of AJV.
       keywords: customKeywords ?? baAjvKeywords,
     },
   })


### PR DESCRIPTION
It is not needed with npm, but needed with yarn.

So reverting.