### PR TITLE
added monorepo support for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: '/next' # Location of package manifests
     schedule:
       interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/nest-forms-backend'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/forms-shared'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
This pull request introduces support for managing dependencies in a monorepo setup using Dependabot.
- Modified configuration to enable Dependabot to handle multiple packages within a monorepo (forms-shared, nest-forms-backend).