### PR TITLE
Deploy to dev on PR merge

### DIFF
--- a/.github/workflows/cluster-deploy-conditions-konto.yml
+++ b/.github/workflows/cluster-deploy-conditions-konto.yml
@@ -98,7 +98,7 @@ jobs:
 
       - id: dev
         name: Check for deployment of whole project to dev
-        if: startsWith(github.ref, 'refs/tags/dev') && startsWith(github.ref, 'refs/tags/dev-strapi') == false && startsWith(github.ref, 'refs/tags/dev-next') == false && startsWith(github.ref, 'refs/tags/dev-nest-forms-backend') == false
+        if: (startsWith(github.ref, 'refs/tags/dev') && startsWith(github.ref, 'refs/tags/dev-strapi') == false && startsWith(github.ref, 'refs/tags/dev-next') == false && startsWith(github.ref, 'refs/tags/dev-nest-forms-backend') == false) || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         run: |
           echo "COUNT=0" >> $GITHUB_ENV
           echo "condition=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
For proper testing we need to have dev in sync with latest changes. When PR is merged to master, it is also deployed to dev.