### PR TITLE
Fix/escape xml chars

### DIFF
--- a/nest-forms-backend/src/convert/utils-services/json-xml.convert.service.ts
+++ b/nest-forms-backend/src/convert/utils-services/json-xml.convert.service.ts
@@ -5,11 +5,11 @@ import { dropRight, find, last } from 'lodash'
 
 import ThrowerErrorGuard from '../../utils/guards/thrower-error.guard'
 import { JsonSchema } from '../../utils/types/global'
+import escapeXml from '../../utils/xml'
 import {
   ConvertErrorsEnum,
   ConvertErrorsResponseEnum,
 } from '../errors/convert.errors.enum'
-import { escapeXml } from '../../utils/xml'
 
 interface Ciselnik {
   id?: string

--- a/nest-forms-backend/src/convert/utils-services/json-xml.convert.service.ts
+++ b/nest-forms-backend/src/convert/utils-services/json-xml.convert.service.ts
@@ -9,6 +9,7 @@ import {
   ConvertErrorsEnum,
   ConvertErrorsResponseEnum,
 } from '../errors/convert.errors.enum'
+import { escapeXml } from '../../utils/xml'
 
 interface Ciselnik {
   id?: string
@@ -135,7 +136,8 @@ export default class JsonXmlConvertService {
         }
       }
     } else if (node && typeof node === 'string') {
-      let stringNode: string = node
+      const xmlEscapedNode = escapeXml(node)
+      let stringNode: string = xmlEscapedNode
       if (jsonSchema && jsonSchema !== true) {
         const format =
           jsonSchema.type === 'array'
@@ -146,11 +148,11 @@ export default class JsonXmlConvertService {
             typeof jsonSchema !== 'boolean' && 'ciselnik' in jsonSchema
               ? (jsonSchema.ciselnik as Ciselnik)
               : ({} as Ciselnik)
-          stringNode = `<Code>${node}</Code><Name>${node}</Name><WsEnumCode>${String(
+          stringNode = `<Code>${xmlEscapedNode}</Code><Name>${xmlEscapedNode}</Name><WsEnumCode>${String(
             ciselnikProperty?.id,
           )}</WsEnumCode>`
         } else if (format === 'file') {
-          stringNode = `<Nazov>${node}</Nazov><Prilozena>true</Prilozena>`
+          stringNode = `<Nazov>${xmlEscapedNode}</Nazov><Prilozena>true</Prilozena>`
         }
       }
 

--- a/nest-forms-backend/src/utils/__test__/xml.spec.ts
+++ b/nest-forms-backend/src/utils/__test__/xml.spec.ts
@@ -1,10 +1,10 @@
-import { escapeXml } from "../xml"
+import escapeXml from '../xml'
 
 describe('xml.ts', () => {
   describe('escapeXml', () => {
     it('should correctly escape the text', () => {
       const input = 'Test & Test s.r.o, and < " \' >'
-      const expected =  'Test &amp; Test s.r.o, and &lt; &quot; &apos; &gt;'
+      const expected = 'Test &amp; Test s.r.o, and &lt; &quot; &apos; &gt;'
 
       const result = escapeXml(input)
       expect(result).toBe(expected)
@@ -12,7 +12,7 @@ describe('xml.ts', () => {
 
     it('should keep the text as it is', () => {
       const input = 'Test and Test s.r.o, no more text... :)'
-      const expected =  'Test and Test s.r.o, no more text... :)'
+      const expected = 'Test and Test s.r.o, no more text... :)'
 
       const result = escapeXml(input)
       expect(result).toBe(expected)

--- a/nest-forms-backend/src/utils/__test__/xml.spec.ts
+++ b/nest-forms-backend/src/utils/__test__/xml.spec.ts
@@ -1,0 +1,21 @@
+import { escapeXml } from "../xml"
+
+describe('xml.ts', () => {
+  describe('escapeXml', () => {
+    it('should correctly escape the text', () => {
+      const input = 'Test & Test s.r.o, and < " \' >'
+      const expected =  'Test &amp; Test s.r.o, and &lt; &quot; &apos; &gt;'
+
+      const result = escapeXml(input)
+      expect(result).toBe(expected)
+    })
+
+    it('should keep the text as it is', () => {
+      const input = 'Test and Test s.r.o, no more text... :)'
+      const expected =  'Test and Test s.r.o, no more text... :)'
+
+      const result = escapeXml(input)
+      expect(result).toBe(expected)
+    })
+  })
+})

--- a/nest-forms-backend/src/utils/xml.ts
+++ b/nest-forms-backend/src/utils/xml.ts
@@ -1,12 +1,12 @@
 export function escapeXml(unsafe: string): string {
-  return unsafe.replace(/[<>&'"]/g, c => {
-      switch (c) {
+  return unsafe.replace(/[<>&'"]/g, match => {
+      switch (match) {
           case '<': return '&lt;'
           case '>': return '&gt;'
           case '&': return '&amp;'
           case '\'': return '&apos;'
           case '"': return '&quot;'
-          default: return c
+          default: return match
       }
   })
 }

--- a/nest-forms-backend/src/utils/xml.ts
+++ b/nest-forms-backend/src/utils/xml.ts
@@ -1,12 +1,23 @@
-export function escapeXml(unsafe: string): string {
-  return unsafe.replace(/[<>&'"]/g, match => {
-      switch (match) {
-          case '<': return '&lt;'
-          case '>': return '&gt;'
-          case '&': return '&amp;'
-          case '\'': return '&apos;'
-          case '"': return '&quot;'
-          default: return match
-      }
+export default function escapeXml(unsafe: string): string {
+  return unsafe.replaceAll(/["&'<>]/g, (match) => {
+    switch (match) {
+      case '<':
+        return '&lt;'
+
+      case '>':
+        return '&gt;'
+
+      case '&':
+        return '&amp;'
+
+      case "'":
+        return '&apos;'
+
+      case '"':
+        return '&quot;'
+
+      default:
+        return match
+    }
   })
 }

--- a/nest-forms-backend/src/utils/xml.ts
+++ b/nest-forms-backend/src/utils/xml.ts
@@ -1,0 +1,12 @@
+export function escapeXml(unsafe: string): string {
+  return unsafe.replace(/[<>&'"]/g, c => {
+      switch (c) {
+          case '<': return '&lt;'
+          case '>': return '&gt;'
+          case '&': return '&amp;'
+          case '\'': return '&apos;'
+          case '"': return '&quot;'
+          default: return c
+      }
+  })
+}


### PR DESCRIPTION
There is a problem when sending data to Nases containing the symbol "&" (mainly in the name of the company). It is caused by the fact that ampersand (among few other characters) must be encoded in XML files. This PR fixes this problem, by encoding these characters when generating xml from json. This way when sending the form to Nases, it will be properly encoded.