### PR TITLE
Moving to stable tag on pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-forms-shared:
     name: Build and push forms-shared image
-    uses: bratislava/github-actions/.github/workflows/build-with-bratiska-cli.yml@beta
+    uses: bratislava/github-actions/.github/workflows/build-with-bratiska-cli.yml@stable
     with:
       directory: forms-shared/
       build_image_no_registry: ''
@@ -22,7 +22,7 @@ jobs:
   conditions:
     name: Check for cluster conditions
     needs: build-forms-shared
-    uses: bratislava/konto.bratislava.sk/.github/workflows/cluster-deploy-conditions-konto.yml@beta
+    uses: bratislava/konto.bratislava.sk/.github/workflows/cluster-deploy-conditions-konto.yml@stable
 
   deploy-dev:
     name: after dev Backends deploy Next

--- a/.github/workflows/validate-and-build.yml
+++ b/.github/workflows/validate-and-build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-forms-shared:
     name: Build and push forms shared image
-    uses: bratislava/github-actions/.github/workflows/build-with-bratiska-cli.yml@beta
+    uses: bratislava/github-actions/.github/workflows/build-with-bratiska-cli.yml@stable
     with:
       directory: forms-shared/
       build_image_no_registry: ''
@@ -17,7 +17,7 @@ jobs:
   conditions:
     name: Check for conditions
     needs: build-forms-shared
-    uses: bratislava/konto.bratislava.sk/.github/workflows/build-conditions-konto.yml@beta
+    uses: bratislava/konto.bratislava.sk/.github/workflows/build-conditions-konto.yml@stable
     permissions: write-all
 
   build-strapi:
@@ -34,7 +34,7 @@ jobs:
     name: validate next
     needs: conditions
     if: needs.conditions.outputs.next == 'true'
-    uses: bratislava/github-actions/.github/workflows/validate-typescript.yml@beta
+    uses: bratislava/github-actions/.github/workflows/validate-typescript.yml@stable
     with:
       directory: next/
     permissions: write-all
@@ -43,7 +43,7 @@ jobs:
     name: build next
     needs: [conditions, validate-next]
     if: needs.conditions.outputs.next == 'true'
-    uses: bratislava/github-actions/.github/workflows/build-with-bratiska-cli.yml@beta
+    uses: bratislava/github-actions/.github/workflows/build-with-bratiska-cli.yml@stable
     with:
       directory: next/
       debug: --debug
@@ -55,7 +55,7 @@ jobs:
     name: validate nest-forms-backend
     needs: conditions
     if: needs.conditions.outputs.nest-forms-backend == 'true'
-    uses: bratislava/konto.bratislava.sk/.github/workflows/validate-nest-prisma-konto.yml@beta
+    uses: bratislava/konto.bratislava.sk/.github/workflows/validate-nest-prisma-konto.yml@stable
     with:
       directory: nest-forms-backend/
     permissions: write-all


### PR DESCRIPTION
This PR replacing dev tag on pipelines to stable tag. This change is needed that we can use dev tag for development and testing of new versions of pipelines.