### PR TITLE
fix: publish to ginis only if it is slovensko sk generic

### DIFF
--- a/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
@@ -6,7 +6,10 @@ import { CacheModule } from '@nestjs/cache-manager'
 import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 import { FormError, Forms } from '@prisma/client'
-import { FormDefinitionSlovenskoSk, FormDefinitionType } from 'forms-shared/definitions/formDefinitionTypes'
+import {
+  FormDefinitionSlovenskoSk,
+  FormDefinitionType,
+} from 'forms-shared/definitions/formDefinitionTypes'
 
 import prismaMock from '../../test/singleton'
 import ConvertService from '../convert/convert.service'
@@ -196,7 +199,7 @@ describe('NasesConsumerService', () => {
           },
         },
         {
-          type: FormDefinitionType.SlovenskoSkGeneric
+          type: FormDefinitionType.SlovenskoSkGeneric,
         } as FormDefinitionSlovenskoSk,
         '',
       )

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
@@ -177,7 +177,7 @@ describe('NasesConsumerService', () => {
       const spyDelay = jest.spyOn(service as any, 'queueDelayedForm')
       const spyPublish = jest.spyOn(
         service['rabbitmqClientService'],
-        'publishNasesCheck',
+        'publishToGinis',
       )
 
       const convertSpy = jest

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
@@ -6,7 +6,7 @@ import { CacheModule } from '@nestjs/cache-manager'
 import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 import { FormError, Forms } from '@prisma/client'
-import { FormDefinitionSlovenskoSk } from 'forms-shared/definitions/formDefinitionTypes'
+import { FormDefinitionSlovenskoSk, FormDefinitionType } from 'forms-shared/definitions/formDefinitionTypes'
 
 import prismaMock from '../../test/singleton'
 import ConvertService from '../convert/convert.service'
@@ -195,7 +195,9 @@ describe('NasesConsumerService', () => {
             firstName: 'Tester',
           },
         },
-        {} as FormDefinitionSlovenskoSk,
+        {
+          type: FormDefinitionType.SlovenskoSkGeneric
+        } as FormDefinitionSlovenskoSk,
         '',
       )
 

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.service.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.service.ts
@@ -214,7 +214,7 @@ export default class NasesConsumerService {
       error: FormError.NONE,
     })
 
-    // Start checking if the message is in Nases
+    // Send the form to ginis if should be sent
     if (isSlovenskoSkGenericFormDefinition(formDefinition)) {
       await this.rabbitmqClientService.publishToGinis({
         formId: data.formId,

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.service.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.service.ts
@@ -7,6 +7,7 @@ import {
   FormDefinition,
   FormDefinitionSlovenskoSk,
   isSlovenskoSkFormDefinition,
+  isSlovenskoSkGenericFormDefinition,
 } from 'forms-shared/definitions/formDefinitionTypes'
 import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinitionBySlug'
 
@@ -214,10 +215,8 @@ export default class NasesConsumerService {
     })
 
     // Start checking if the message is in Nases
-
-    // TODO this is only because of is signed is only for tax from properties, (this if should be removed after integration ginis / noris)
-    if (!formDefinition.isSigned) {
-      await this.rabbitmqClientService.publishNasesCheck({
+    if (isSlovenskoSkGenericFormDefinition(formDefinition)) {
+      await this.rabbitmqClientService.publishToGinis({
         formId: data.formId,
         tries: 0,
         userData: data.userData,

--- a/nest-forms-backend/src/rabbitmq-client/rabbitmq-client.service.ts
+++ b/nest-forms-backend/src/rabbitmq-client/rabbitmq-client.service.ts
@@ -53,11 +53,11 @@ export default class RabbitmqClientService {
     )
   }
 
-  public async publishNasesCheck(
+  public async publishToGinis(
     message: GinisCheckNasesPayloadDto,
   ): Promise<Replies.Empty> {
     this.logger.debug(
-      `Publishing nases check message to: ${RABBIT_MQ.EXCHANGE} with routing key: ${RABBIT_NASES.ROUTING_KEY}`,
+      `Publishing send to ginis message to: ${RABBIT_MQ.EXCHANGE} with routing key: ${RABBIT_NASES.ROUTING_KEY}`,
     )
     return this.amqpConnection.publish(
       RABBIT_MQ.EXCHANGE,


### PR DESCRIPTION
In [ginis.service](https://github.com/bratislava/konto.bratislava.sk/blob/a1444adf2fd2413c6eab76c0a1b129857aa51364/nest-forms-backend/src/ginis/ginis.service.ts#L440) we throw error if the formDefinition for the form is not slovenskoSkGeneric. For this reason, we should only send to ginis such forms, which fulfill this. Along with this change there is one naming change.