### PR TITLE
Use sha instead of head_ref or ref_name in pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     with:
       directory: forms-shared/
       build_image_no_registry: ''
-      tag: '--tag=${{ github.head_ref || github.ref_name }}'
+      tag: '--tag=${{ github.sha }}'
     secrets:
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
 
@@ -31,7 +31,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@beta
     with:
       directory: next/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       cluster: tkg-innov-dev
       url: https://tkg.dev.bratislava.sk
       debug: --debug
@@ -47,7 +47,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@beta
     with:
       directory: nest-forms-backend/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       cluster: tkg-innov-dev
       url: https://tkg.dev.bratislava.sk
       debug: --debug
@@ -78,7 +78,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@beta
     with:
       directory: next/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       cluster: tkg-innov-dev
       url: https://tkg.dev.bratislava.sk
       debug: --debug
@@ -94,7 +94,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       cluster: tkg-innov-staging
       url: https://tkg.staging.bratislava.sk
       debug: --debug
@@ -110,7 +110,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: nest-forms-backend/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       cluster: tkg-innov-staging
       url: https://tkg.staging.bratislava.sk
       debug: --debug
@@ -141,7 +141,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       cluster: tkg-innov-staging
       url: https://tkg.staging.bratislava.sk
       debug: --debug
@@ -157,7 +157,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
@@ -173,7 +173,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: nest-forms-backend/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
@@ -205,7 +205,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production

--- a/.github/workflows/validate-and-build.yml
+++ b/.github/workflows/validate-and-build.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       directory: forms-shared/
       build_image_no_registry: ''
-      tag: '--tag=${{ github.head_ref || github.ref_name }}'
+      tag: '--tag=${{ github.sha }}'
     secrets:
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
 
@@ -46,7 +46,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/build-with-bratiska-cli.yml@stable
     with:
       directory: next/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       debug: --debug
     secrets:
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -68,7 +68,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/build-with-bratiska-cli.yml@stable
     with:
       directory: nest-forms-backend/
-      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.head_ref || github.ref_name }}"'
+      build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
     secrets:
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
     permissions: write-all


### PR DESCRIPTION
It seems to fail if not supported characters are used in branch name, I decided to use commit it as id instead.

Example pipeline: https://github.com/bratislava/konto.bratislava.sk/actions/runs/9741337544/job/26880345369