### PR TITLE
Remove Ajv extraction as it is already supported by the library itself

### DIFF
--- a/forms-shared/src/form-utils/validators.ts
+++ b/forms-shared/src/form-utils/validators.ts
@@ -1,7 +1,6 @@
-import { ValidatorType } from '@rjsf/utils'
 import { customizeValidator } from '@rjsf/validator-ajv8'
 import type { CustomValidatorOptionsType } from '@rjsf/validator-ajv8/src/types'
-import Ajv, { SchemaValidateFunction, Vocabulary } from 'ajv'
+import { SchemaValidateFunction, Vocabulary } from 'ajv'
 
 import { baAjvFormats } from './ajvFormats'
 import { baAjvKeywords } from './ajvKeywords'
@@ -19,20 +18,6 @@ const getBaRjsfValidator = (customKeywords?: Vocabulary) =>
  * Default RJSF validator that should be used for all forms.
  */
 export const baRjsfValidator = getBaRjsfValidator()
-
-/**
- * Extracts the AJV validator from the RJSF validator.
- *
- * RJSF uses its custom logic to create AJV instance, easier than mimicking the behaviour is to extract the instance by
- * accessing the private property. If this changes in the future, the tests will fail.
- */
-const extractAjvValidator = (rjsfValidator: ValidatorType) =>
-  (rjsfValidator as unknown as { ajv: Ajv }).ajv
-
-/**
- * Extracted AJV validator from the default RJSF validator.
- */
-export const baAjvValidator = extractAjvValidator(baRjsfValidator)
 
 /**
  * Generates keywords with custom file validation function.

--- a/forms-shared/tests/form-utils/validators.ts
+++ b/forms-shared/tests/form-utils/validators.ts
@@ -1,9 +1,0 @@
-import { baAjvValidator } from '../../src/form-utils/validators'
-
-describe('validators', () => {
-  it('baAjvValidator is extracted correctly', () => {
-    // TODO: `instanceof` stopped working
-    // expect(baAjvValidator instanceof Ajv).toBe(true)
-    expect(baAjvValidator.constructor.name).toBe('Ajv')
-  })
-})

--- a/forms-shared/tests/schemas.ts
+++ b/forms-shared/tests/schemas.ts
@@ -1,7 +1,7 @@
 import priznanieKDaniZNehnutelnosti from '../src/schemas/priznanieKDaniZNehnutelnosti'
 import stanoviskoKInvesticnemuZameru from '../src/schemas/stanoviskoKInvesticnemuZameru'
 import zavazneStanoviskoKInvesticnejCinnosti from '../src/schemas/zavazneStanoviskoKInvesticnejCinnosti'
-import { baAjvValidator, baRjsfValidator } from '../src/form-utils/validators'
+import { baRjsfValidator } from '../src/form-utils/validators'
 import komunitneZahrady from '../src/schemas/komunitneZahrady'
 import predzahradky from '../src/schemas/predzahradky'
 import { exampleTaxForm1 } from '../src/tax-form/examples/exampleTaxForm1'
@@ -50,7 +50,7 @@ definitions.forEach((definition) => {
     })
 
     it('is valid schema', () => {
-      expect(baAjvValidator.validateSchema(definition.schema.schema, true)).toBe(true)
+      expect(baRjsfValidator.ajv.validateSchema(definition.schema.schema, true)).toBe(true)
     })
 
     it('default form state should match snapshot', () => {


### PR DESCRIPTION
https://rjsf-team.github.io/react-jsonschema-form/docs/usage/validation/#using-the-raw-ajv-instance