### PR TITLE
Added missing slash to properly mount forms-shared on nest-forms-backend and next

### DIFF
--- a/nest-forms-backend/Dockerfile
+++ b/nest-forms-backend/Dockerfile
@@ -7,7 +7,7 @@ RUN npx playwright install-deps chromium
 # build
 FROM base AS build
 WORKDIR /root/forms-shared
-COPY --from=shared /app ./
+COPY --from=shared /app/ ./
 
 RUN apt-get update && apt-get install git
 
@@ -55,7 +55,7 @@ RUN npx playwright install chromium
 # TODO: Find a way how to use --install-links flag in npm install to avoid this.
 RUN mkdir -p /home/node/forms-shared && chown -R node:node /home/node/forms-shared
 WORKDIR /home/node/forms-shared
-COPY --chown=node:node --from=shared . ./
+COPY --chown=node:node --from=shared /app/ ./
 
 RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 WORKDIR /home/node/app

--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -22,7 +22,7 @@ ENTRYPOINT [ "/sbin/tini", "--" ]
 # used for build-base for building only
 FROM base AS build-base
 WORKDIR /forms-shared
-COPY --from=shared /app ./
+COPY --from=shared /app/ ./
 WORKDIR /build
 COPY ./package.json ./package-lock.json ./
 


### PR DESCRIPTION
added missing `/` after `/app` to make it `/app/`. This makes sure that `forms-shared/app` is copied to desired location without `/app` folder. Also on `prod` build we were missing `/app/` path.

on dev it worked fine and nest-forms-backend and next were deployed https://github.com/bratislava/konto.bratislava.sk/actions/runs/10010292745