### PR TITLE
cypress tests are now dispatched on pull_request

### DIFF
--- a/.github/workflows/cypress-test.yaml
+++ b/.github/workflows/cypress-test.yaml
@@ -1,6 +1,9 @@
 name: Cypress test
 
-on: push
+on:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   cypress-tests:


### PR DESCRIPTION
We don`t need to run cypress test on every push. Now it it will run on every pull-request.