### PR TITLE
Generator functions refactor

### DIFF
--- a/forms-shared/src/generator/functions.ts
+++ b/forms-shared/src/generator/functions.ts
@@ -32,8 +32,8 @@ export type Schemas = {
 
 export type Field = {
   property: string
-  schema: () => RJSFSchema
-  uiSchema: () => UiSchema
+  schema: RJSFSchema
+  uiSchema: UiSchema
   required: boolean
   skipUiSchema?: boolean
   skipSchema?: boolean
@@ -46,9 +46,9 @@ type ObjectField = Omit<Field, 'property'> & {
 
 type ConditionalFields = {
   condition: RJSFSchema
-  thenSchema: () => RJSFSchema
-  elseSchema?: () => RJSFSchema
-  uiSchema: () => UiSchema
+  thenSchema: RJSFSchema
+  elseSchema?: RJSFSchema
+  uiSchema: UiSchema
   fieldProperties: string[]
 }
 
@@ -73,7 +73,7 @@ export const select = (
 ): Field => {
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       type: 'string',
       title: options.title,
       // This had to be changed from oneOf to enum because of this bug:
@@ -84,19 +84,17 @@ export const select = (
       enum: options.options.map(({ value }) => value),
       default: options.options.find(({ isDefault }) => isDefault)?.value,
     }),
-    uiSchema: () => {
-      const selectOptionsArray = options.options.map(
-        ({ value, title, description }) => [value, { title, description }] as const,
-      )
-
-      return {
-        'ui:widget': BaWidgetType.Select,
-        'ui:options': {
-          ...uiOptions,
-          selectOptions: Object.fromEntries(selectOptionsArray),
-        },
-      }
-    },
+    uiSchema: removeUndefinedValues({
+      'ui:widget': BaWidgetType.Select,
+      'ui:options': {
+        ...uiOptions,
+        selectOptions: Object.fromEntries(
+          options.options.map(
+            ({ value, title, description }) => [value, { title, description }] as const,
+          ),
+        ),
+      },
+    }),
     required: Boolean(options.required),
   }
 }
@@ -117,7 +115,7 @@ export const selectMultiple = (
 ): Field => {
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       type: 'array',
       title: options.title,
       items: {
@@ -134,20 +132,17 @@ export const selectMultiple = (
       uniqueItems: true,
       default: options.options.filter(({ isDefault }) => isDefault).map(({ value }) => value),
     }),
-
-    uiSchema: () => {
-      const selectOptionsArray = options.options.map(
-        ({ value, title, description }) => [value, { title, description }] as const,
-      )
-
-      return {
-        'ui:widget': BaWidgetType.SelectMultiple,
-        'ui:options': {
-          ...uiOptions,
-          selectOptions: Object.fromEntries(selectOptionsArray),
-        },
-      }
-    },
+    uiSchema: removeUndefinedValues({
+      'ui:widget': BaWidgetType.SelectMultiple,
+      'ui:options': {
+        ...uiOptions,
+        selectOptions: Object.fromEntries(
+          options.options.map(
+            ({ value, title, description }) => [value, { title, description }] as const,
+          ),
+        ),
+      },
+    }),
     required: Boolean(options.required),
   }
 }
@@ -167,49 +162,47 @@ export const input = (
     ) & { default?: string },
   uiOptions: Omit<InputUiOptions, 'type'>,
 ): Field => {
+  if ('pattern' in options && 'format' in options) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Input: ${property} has both pattern and format, only one of them can be provided`,
+    )
+  }
+
+  const getFormat = () => {
+    if (options.type == null || options.type === 'text') {
+      return options.format
+    }
+    if (options.type === 'email') {
+      return 'email'
+    }
+    if (options.type === 'tel') {
+      return 'ba-phone-number'
+    }
+
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    return undefined
+  }
+
+  const getPattern = () => {
+    if (options.type == null || options.type === 'text') {
+      return options.pattern?.source
+    }
+
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    return undefined
+  }
+
   return {
     property,
-    schema: () => {
-      if ('pattern' in options && 'format' in options) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `Input: ${property} has both pattern and format, only one of them can be provided`,
-        )
-      }
-
-      const getFormat = () => {
-        if (options.type == null || options.type === 'text') {
-          return options.format
-        }
-        if (options.type === 'email') {
-          return 'email'
-        }
-        if (options.type === 'tel') {
-          return 'ba-phone-number'
-        }
-
-        // eslint-disable-next-line unicorn/no-useless-undefined
-        return undefined
-      }
-
-      const getPattern = () => {
-        if (options.type == null || options.type === 'text') {
-          return options.pattern?.source
-        }
-
-        // eslint-disable-next-line unicorn/no-useless-undefined
-        return undefined
-      }
-
-      return {
-        type: 'string',
-        title: options.title,
-        format: getFormat(),
-        pattern: getPattern(),
-        default: options.default,
-      }
-    },
-    uiSchema: () => ({
+    schema: removeUndefinedValues({
+      type: 'string',
+      title: options.title,
+      format: getFormat(),
+      pattern: getPattern(),
+      default: options.default,
+    }),
+    uiSchema: removeUndefinedValues({
       'ui:widget': BaWidgetType.Input,
       'ui:label': false,
       'ui:options': { ...uiOptions, type: options.type ?? 'text' },
@@ -232,7 +225,7 @@ export const number = (
 ): Field => {
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       type: options.type ?? 'number',
       title: options.title,
       default: options.default,
@@ -241,7 +234,7 @@ export const number = (
       maximum: options.maximum,
       exclusiveMaximum: options.exclusiveMaximum,
     }),
-    uiSchema: () => ({
+    uiSchema: removeUndefinedValues({
       'ui:widget': BaWidgetType.Number,
       'ui:label': false,
       'ui:options': { ...uiOptions },
@@ -273,13 +266,13 @@ export const radioGroup = <T extends 'string' | 'number' | 'boolean'>(
 ): Field => {
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       type: options.type,
       title: options.title,
       default: options.options.find(({ isDefault }) => isDefault)?.value,
       oneOf: options.options.map(({ value, title }) => ({ const: value, title })),
     }),
-    uiSchema: () => ({
+    uiSchema: removeUndefinedValues({
       'ui:widget': BaWidgetType.RadioGroup,
       'ui:options': {
         ...uiOptions,
@@ -300,8 +293,8 @@ export const textArea = (
 ): Field => {
   return {
     property,
-    schema: () => ({ type: 'string', title: options.title }),
-    uiSchema: () => ({
+    schema: removeUndefinedValues({ type: 'string', title: options.title }),
+    uiSchema: removeUndefinedValues({
       'ui:widget': BaWidgetType.TextArea,
       'ui:label': false,
       'ui:options': uiOptions,
@@ -317,12 +310,12 @@ export const checkbox = (
 ): Field => {
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       type: 'boolean',
       title: options.title,
       default: options.default,
     }),
-    uiSchema: () => ({
+    uiSchema: removeUndefinedValues({
       'ui:widget': BaWidgetType.Checkbox,
       'ui:options': uiOptions,
     }),
@@ -346,7 +339,7 @@ export const checkboxGroup = (
 ): Field => {
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       type: 'array',
       title: options.title,
       minItems: options.minItems ?? options.required ? 1 : undefined,
@@ -357,7 +350,7 @@ export const checkboxGroup = (
       },
       default: options.options.filter(({ isDefault }) => isDefault).map(({ value }) => value),
     }),
-    uiSchema: () => ({
+    uiSchema: removeUndefinedValues({
       'ui:widget': BaWidgetType.CheckboxGroup,
       'ui:options': uiOptions,
     }),
@@ -372,32 +365,27 @@ export const fileUpload = (
 ): Field => {
   return {
     property,
-    schema: () => {
-      const base = {
-        title: options.title,
-      }
-      if (options.multiple) {
-        return {
-          ...base,
-          type: 'array',
-          items: {
+    schema: removeUndefinedValues(
+      options.multiple
+        ? {
+            title: options.title,
+            type: 'array',
+            items: {
+              type: 'string',
+              format: 'ba-file-uuid',
+              file: true,
+            },
+            minItems: options.required ? 1 : undefined,
+            default: [],
+          }
+        : {
+            title: options.title,
             type: 'string',
             format: 'ba-file-uuid',
             file: true,
           },
-          minItems: options.required ? 1 : undefined,
-          default: [],
-        }
-      }
-
-      return {
-        ...base,
-        type: 'string',
-        format: 'ba-file-uuid',
-        file: true,
-      }
-    },
-    uiSchema: () => ({
+    ),
+    uiSchema: removeUndefinedValues({
       'ui:widget': options.multiple ? BaWidgetType.FileUploadMultiple : BaWidgetType.FileUpload,
       'ui:options': uiOptions,
     }),
@@ -412,13 +400,13 @@ export const datePicker = (
 ): Field => {
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       type: 'string',
       format: 'date',
       title: options.title,
       default: options.default,
     }),
-    uiSchema: () => ({
+    uiSchema: removeUndefinedValues({
       'ui:widget': BaWidgetType.DatePicker,
       'ui:options': uiOptions,
     }),
@@ -433,13 +421,13 @@ export const timePicker = (
 ): Field => {
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       type: 'string',
       format: 'ba-time',
       title: options.title,
       default: options.default,
     }),
-    uiSchema: () => ({
+    uiSchema: removeUndefinedValues({
       'ui:widget': BaWidgetType.TimePicker,
       'ui:options': uiOptions,
     }),
@@ -461,16 +449,16 @@ export const customComponentsField = (
   return {
     // Random property name to avoid collisions
     property: `customComponent${customComponentCounter}_gRbYIKNcAF`,
-    schema: () => ({
+    schema: removeUndefinedValues({
       anyOf: [{}],
     }),
-    uiSchema: () => {
-      const array = Array.isArray(customComponents) ? customComponents : [customComponents]
-      return {
-        'ui:widget': BaWidgetType.CustomComponents,
-        'ui:options': { ...uiOptions, customComponents: array },
-      }
-    },
+    uiSchema: removeUndefinedValues({
+      'ui:widget': BaWidgetType.CustomComponents,
+      'ui:options': {
+        ...uiOptions,
+        customComponents: Array.isArray(customComponents) ? customComponents : [customComponents],
+      },
+    }),
     required: false,
   }
 }
@@ -501,44 +489,48 @@ export const object = (
       .filter((field) => field !== null) as string[],
   )
 
+  const getSchema = () => {
+    const allOf = conditionalFields.map((field) => ({
+      if: field.condition,
+      then: field.thenSchema,
+      else: field.elseSchema,
+    }))
+
+    return removeUndefinedValues({
+      type: 'object' as const,
+      properties: Object.fromEntries(
+        ordinaryFieldsWithSchema.map((field) => [field.property, field.schema]),
+      ),
+      required: ordinaryFieldsWithSchema
+        .filter((field) => field.required)
+        .map((field) => field.property),
+      allOf: allOf.length > 0 ? allOf : undefined,
+    })
+  }
+
+  const getUiSchema = () => {
+    const ordinaryFieldsUiSchema = Object.fromEntries(
+      ordinaryFieldsWithUiSchema.map((field) => [field.property, field.uiSchema]),
+    )
+    const conditionalFieldsUiSchema = conditionalFields.reduce(
+      (acc, field) => ({ ...acc, ...field.uiSchema }),
+      {},
+    )
+
+    return removeUndefinedValues({
+      ...ordinaryFieldsUiSchema,
+      ...conditionalFieldsUiSchema,
+      // As the order of the properties is not guaranteed in JSON and is lost when having the fields both in `properties`
+      // and `allOf`, we need to provide it manually.
+      'ui:order': fieldProperties,
+      'ui:options': uiOptions,
+    })
+  }
+
   return {
     property,
-    schema: () => {
-      const allOf = conditionalFields.map((field) => ({
-        if: field.condition,
-        then: field.thenSchema(),
-        else: field.elseSchema?.(),
-      }))
-
-      return {
-        type: 'object',
-        properties: Object.fromEntries(
-          ordinaryFieldsWithSchema.map((field) => [field.property, field.schema()]),
-        ),
-        required: ordinaryFieldsWithSchema
-          .filter((field) => field.required)
-          .map((field) => field.property),
-        allOf: allOf.length > 0 ? allOf : undefined,
-      }
-    },
-    uiSchema: () => {
-      const ordinaryFieldsUiSchema = Object.fromEntries(
-        ordinaryFieldsWithUiSchema.map((field) => [field.property, field.uiSchema()]),
-      )
-      const conditionalFieldsUiSchema = conditionalFields.reduce(
-        (acc, field) => ({ ...acc, ...field.uiSchema() }),
-        {},
-      )
-
-      return {
-        ...ordinaryFieldsUiSchema,
-        ...conditionalFieldsUiSchema,
-        // As the order of the properties is not guaranteed in JSON and is lost when having the fields both in `properties`
-        // and `allOf`, we need to provide it manually.
-        'ui:order': fieldProperties,
-        'ui:options': uiOptions,
-      }
-    },
+    schema: getSchema(),
+    uiSchema: getUiSchema(),
     required: Boolean(options.required),
     fieldProperties,
   }
@@ -551,18 +543,19 @@ export const arrayField = (
   fields: (FieldType | null)[],
 ): Field => {
   const { schema: objectSchema, uiSchema: objectUiSchema } = object(null, {}, {}, fields)
+
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       title: options.title,
       type: 'array',
-      items: objectSchema(),
+      items: objectSchema,
       minItems: options.minItems ?? options.required ? 1 : undefined,
       maxItems: options.maxItems,
     }),
-    uiSchema: () => ({
+    uiSchema: removeUndefinedValues({
       'ui:options': uiOptions,
-      items: objectUiSchema(),
+      items: objectUiSchema,
     }),
     required: Boolean(options.required),
   }
@@ -591,21 +584,21 @@ export const step = (
 
   return {
     property,
-    schema: () => ({
+    schema: removeUndefinedValues({
       type: 'object',
       properties: {
         [property]: {
           title: options.title,
           description: options.description,
-          ...schema(),
+          ...schema,
         },
       },
       required: [property],
     }),
-    uiSchema: () => ({
-      ...uiSchema(),
+    uiSchema: removeUndefinedValues({
+      ...uiSchema,
       'ui:options': {
-        ...uiSchema()['ui:options'],
+        ...uiSchema['ui:options'],
         stepperTitle: options.stepperTitle,
         stepQueryParam: getHash(),
       } satisfies StepUiOptions,
@@ -625,8 +618,8 @@ export const conditionalStep = (
   const { schema, uiSchema } = step(property, options, fields)
   return {
     property,
-    schema: () => ({ if: condition, then: schema() }),
-    uiSchema: () => uiSchema(),
+    schema: removeUndefinedValues({ if: condition, then: schema }),
+    uiSchema: uiSchema,
     required: true,
   }
 }
@@ -650,23 +643,24 @@ export const conditionalFields = (
     fieldProperties: elseFieldProperties,
   } = object(null, {}, {}, filteredElseFields)
 
+  const intersectionProperties = intersection(thenFieldProperties, elseFieldProperties)
+  if (intersectionProperties.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Conditional fields: ${intersectionProperties.join(
+        ', ',
+      )} is in both then and else uiSchema, it will be overwritten by the else uiSchema`,
+    )
+  }
+
   return {
     condition,
     thenSchema,
     elseSchema: filteredElseFields.length > 0 ? elseSchema : undefined,
-    uiSchema: () => {
-      const intersectionProperties = intersection(thenFieldProperties, elseFieldProperties)
-      if (intersectionProperties.length > 0) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `Conditional fields: ${intersectionProperties.join(
-            ', ',
-          )} is in both then and else uiSchema, it will be overwritten by the else uiSchema`,
-        )
-      }
-
-      return { ...thenUiSchema(), ...(elseFields.length > 0 ? elseUiSchema() : {}) }
-    },
+    uiSchema: removeUndefinedValues({
+      ...thenUiSchema,
+      ...(elseFields.length > 0 ? elseUiSchema : {}),
+    }),
     fieldProperties: [...thenFieldProperties, ...elseFieldProperties],
   }
 }
@@ -679,14 +673,17 @@ export const schema = (
   uiOptions: SchemaUiOptions,
   steps: ReturnType<typeof step | typeof conditionalStep>[],
 ): Schemas => {
-  return removeUndefinedValues({
-    schema: { ...options, allOf: steps.map((stepInner) => stepInner.schema()) } as RJSFSchema,
-    uiSchema: {
-      ...Object.fromEntries(steps.map((stepInner) => [stepInner.property, stepInner.uiSchema()])),
+  return {
+    schema: removeUndefinedValues({
+      ...options,
+      allOf: steps.map((stepInner) => stepInner.schema),
+    }) as RJSFSchema,
+    uiSchema: removeUndefinedValues({
+      ...Object.fromEntries(steps.map((stepInner) => [stepInner.property, stepInner.uiSchema])),
       'ui:options': uiOptions,
       'ui:hideError': true,
-    } as UiSchema,
-  })
+    }) as UiSchema,
+  }
 }
 
 // TODO: Document

--- a/forms-shared/src/generator/helpers.ts
+++ b/forms-shared/src/generator/helpers.ts
@@ -181,6 +181,10 @@ export const createCamelCaseOptionsV2 = <Option extends { title: string }>(
   return result
 }
 
+/**
+ * All generated schemas must not have `undefined` values in objects, RJSF relies on checks like `'oneOf' in schema`
+ * which returns `true` for `{ oneOf: undefined }`.
+ */
 export const removeUndefinedValues = <T>(obj: T) => {
   return JSON.parse(JSON.stringify(obj)) as T
 }

--- a/forms-shared/tests/form-utils/defaultFormState.ts
+++ b/forms-shared/tests/form-utils/defaultFormState.ts
@@ -14,13 +14,13 @@ describe('defaultFormState', () => {
   it('isFileMultipleSchema should return true for file array schema', () => {
     const definition = fileUpload('file', { title: 'File', multiple: true }, {})
 
-    expect(isFileMultipleSchema(definition.schema())).toBe(true)
+    expect(isFileMultipleSchema(definition.schema)).toBe(true)
   })
 
   it('isFileMultipleSchema should return false for any other schema', () => {
     const definition = arrayField('array', { title: 'Array' }, {} as ArrayFieldUiOptions, [])
 
-    expect(isFileMultipleSchema(definition.schema())).toBe(false)
+    expect(isFileMultipleSchema(definition.schema)).toBe(false)
   })
 
   it('getDefaultForm should return default values for arrays consistent with expected behavior', () => {
@@ -88,7 +88,7 @@ describe('defaultFormState', () => {
       (message) =>
         typeof message === 'string' && message.includes('could not merge subschemas in allOf'),
     )
-    expect(baGetDefaultFormState(definition.schema(), {})).toEqual({
+    expect(baGetDefaultFormState(definition.schema, {})).toEqual({
       fileMultiple: [],
       fileMultipleRequired: [],
       select: [],

--- a/forms-shared/tests/form-utils/fileUtils.ts
+++ b/forms-shared/tests/form-utils/fileUtils.ts
@@ -44,7 +44,7 @@ describe('fileUtils', () => {
   })
 
   it('getFileUuidsNaive should return only file ids from the data', () => {
-    expect(getFileUuids(fileUploadSchema.schema(), data)).toEqual([
+    expect(getFileUuids(fileUploadSchema.schema, data)).toEqual([
       'f3603d59-49f4-4059-9a3d-555184217357',
       '7459535f-96c2-47ed-bf32-55143e52a4ea',
     ])

--- a/forms-shared/tests/form-utils/omitExtraData.ts
+++ b/forms-shared/tests/form-utils/omitExtraData.ts
@@ -14,9 +14,9 @@ describe('omitExtraData', () => {
   })
 
   it('should omit extra data for simple schema', () => {
-    const schema = object('wrapper', {}, {}, [input('input', { title: 'Input title' }, {})])
+    const { schema } = object('wrapper', {}, {}, [input('input', { title: 'Input title' }, {})])
 
-    const result = omitExtraData(schema.schema(), {
+    const result = omitExtraData(schema, {
       input: 'value',
       extraField: 'extra value',
     })

--- a/forms-shared/tests/summary-json/getSummaryDisplayValue.tsx
+++ b/forms-shared/tests/summary-json/getSummaryDisplayValue.tsx
@@ -30,7 +30,7 @@ import { baFormDefaults } from '../../src/form-utils/formDefaults'
  * the values.
  */
 const retrieveRuntimeValues = ({ schema, uiSchema }: Field) => {
-  const widgetType = uiSchema()['ui:widget'] as BaWidgetType
+  const widgetType = uiSchema['ui:widget'] as BaWidgetType
 
   let retrievedSchema: RJSFSchema
   let retrievedOptions: WidgetProps['options']
@@ -45,7 +45,7 @@ const retrieveRuntimeValues = ({ schema, uiSchema }: Field) => {
     },
   })
 
-  renderToString(<Form schema={schema()} uiSchema={uiSchema()} {...baFormDefaults} />)
+  renderToString(<Form schema={schema} uiSchema={uiSchema} {...baFormDefaults} />)
 
   // @ts-expect-error TypeScript cannot detect that `retrievedSchema` and `retrievedOptions` are set in the widget
   if (!retrievedSchema || !retrievedOptions) {

--- a/forms-shared/tests/summary-renderer/validateSummary.ts
+++ b/forms-shared/tests/summary-renderer/validateSummary.ts
@@ -19,7 +19,7 @@ describe('validateSummary', () => {
     ])
 
     it('should validate successfully when required field is provided', () => {
-      const result = validateSummary(schema(), { requiredInput: 'some value' }, {})
+      const result = validateSummary(schema, { requiredInput: 'some value' }, {})
 
       expect(result.hasErrors).toBe(false)
       expect(result.pathHasError('root_requiredInput')).toBe(false)
@@ -28,7 +28,7 @@ describe('validateSummary', () => {
     })
 
     it('should report errors for missing required field', () => {
-      const result = validateSummary(schema(), {}, {})
+      const result = validateSummary(schema, {}, {})
 
       expect(result.hasErrors).toBe(true)
       expect(result.pathHasError('root_requiredInput')).toBe(true)
@@ -42,7 +42,7 @@ describe('validateSummary', () => {
 
     it('should validate successfully for valid file status', () => {
       const result = validateSummary(
-        schema(),
+        schema,
         { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' },
         {
           'e37359e2-2547-42a9-82d6-d40054f17da0': {
@@ -62,7 +62,7 @@ describe('validateSummary', () => {
 
     it('should report errors for files with errors', () => {
       const result = validateSummary(
-        schema(),
+        schema,
         { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' },
         {
           'e37359e2-2547-42a9-82d6-d40054f17da0': {
@@ -81,7 +81,7 @@ describe('validateSummary', () => {
     })
 
     it('should report errors for missing file information', () => {
-      const result = validateSummary(schema(), { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' }, {})
+      const result = validateSummary(schema, { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' }, {})
 
       expect(result.hasErrors).toBe(true)
       expect(result.pathHasError('root_file')).toBe(true)
@@ -98,7 +98,7 @@ describe('validateSummary', () => {
 
     it('should handle multiple file upload scenario', () => {
       const result = validateSummary(
-        schema(),
+        schema,
         {
           files: [
             'e37359e2-2547-42a9-82d6-d40054f17da0',


### PR DESCRIPTION
Commit by commit.

- Add comment for removeUndefinedValues
- Wrap all generated schemas in `removeUndefinedValues`, fields were generated with `schema` and `uiSchema` as functions, this makes the generated output unserializable, so it needed to be reworked to return simple JSON
- Replace usages
