### PR TITLE
Release Žiadost o nájomné byvanie

### DIFF
--- a/forms-shared/src/definitions/devFormDefinitions.ts
+++ b/forms-shared/src/definitions/devFormDefinitions.ts
@@ -1,27 +1,8 @@
 import { FormDefinition, FormDefinitionType } from './formDefinitionTypes'
 import { generalTermsAndConditions } from './termsAndConditions'
-import ziadostONajomnyByt from '../schemas/ziadostONajomnyByt'
 import mimoriadnyOdvozALikvidaciaOdpadu from '../schemas/olo/mimoriadnyOdvozALikvidaciaOdpadu'
 
 export const devFormDefinitions: FormDefinition[] = [
-  {
-    type: FormDefinitionType.SlovenskoSkGeneric,
-    slug: 'ziadost-o-najomny-byt',
-    title: 'Žiadosť o nájomný byt',
-    schemas: ziadostONajomnyByt,
-    pospID: '00603481.ziadostONajomnyByt',
-    pospVersion: '1.0',
-    publisher: 'ico://sk/00603481',
-    gestor: 'Pinter Martin',
-    termsAndConditions: generalTermsAndConditions,
-    messageSubjectDefault: '',
-    messageSubjectFormat: '',
-    ginisAssignment: {
-      ginisOrganizationName: '',
-      ginisPersonName: '',
-    },
-    isSigned: false,
-  },
   {
     type: FormDefinitionType.Email,
     slug: 'olo-mimoriadny-odvoz-a-likvidacia-odpadu',

--- a/forms-shared/src/definitions/formDefinitionTypes.ts
+++ b/forms-shared/src/definitions/formDefinitionTypes.ts
@@ -22,6 +22,8 @@ type FormDefinitionSlovenskoSkBase = FormDefinitionBase & {
   publisher: string
   gestor: string
   isSigned: boolean
+  // Temporary flag until all forms are converted to new government XMLs
+  newGovernmentXml?: boolean
 }
 
 export type FormDefinitionSlovenskoSkGeneric = FormDefinitionSlovenskoSkBase & {

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -99,14 +99,14 @@ export const formDefinitions: FormDefinition[] = [
   {
     type: FormDefinitionType.SlovenskoSkGeneric,
     slug: 'ziadost-o-najomny-byt',
-    title: 'Žiadosť o nájomný byt',
+    title: 'Žiadosť o nájomný byt (TESTOVACIA VERZIA)',
     schemas: ziadostONajomnyByt,
     pospID: '00603481.ziadostONajomnyByt',
     pospVersion: '1.0',
     publisher: 'ico://sk/00603481',
     gestor: 'Pinter Martin',
     termsAndConditions: generalTermsAndConditions,
-    messageSubjectDefault: 'Žiadosť o nájomný byt',
+    messageSubjectDefault: 'Žiadosť o nájomný byt (TESTOVACIA VERZIA)',
     // TODO
     ginisAssignment: {
       ginisOrganizationName: 'SX',

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -5,6 +5,7 @@ import { generalTermsAndConditions, taxTermsAndConditions } from './termsAndCond
 import zavazneStanoviskoKInvesticnejCinnosti from '../schemas/zavazneStanoviskoKInvesticnejCinnosti'
 import komunitneZahrady from '../schemas/komunitneZahrady'
 import { FormDefinition, FormDefinitionType } from './formDefinitionTypes'
+import ziadostONajomnyByt from '../schemas/ziadostONajomnyByt'
 
 export const formDefinitions: FormDefinition[] = [
   {
@@ -94,5 +95,23 @@ export const formDefinitions: FormDefinition[] = [
     termsAndConditions: taxTermsAndConditions,
     messageSubjectDefault: 'Priznanie k dani z nehnuteľností',
     isSigned: true,
+  },
+  {
+    type: FormDefinitionType.SlovenskoSkGeneric,
+    slug: 'ziadost-o-najomny-byt',
+    title: 'Žiadosť o nájomný byt',
+    schemas: ziadostONajomnyByt,
+    pospID: '00603481.ziadostONajomnyByt',
+    pospVersion: '1.0',
+    publisher: 'ico://sk/00603481',
+    gestor: 'Pinter Martin',
+    termsAndConditions: generalTermsAndConditions,
+    messageSubjectDefault: 'Žiadosť o nájomný byt',
+    // TODO
+    ginisAssignment: {
+      ginisOrganizationName: 'SX',
+      ginisPersonName: 'Pinter Martin',
+    },
+    isSigned: false,
   },
 ]

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -113,5 +113,6 @@ export const formDefinitions: FormDefinition[] = [
       ginisPersonName: 'Pinter Martin',
     },
     isSigned: false,
+    newGovernmentXml: true,
   },
 ]

--- a/forms-shared/src/slovensko-sk/generateXml.ts
+++ b/forms-shared/src/slovensko-sk/generateXml.ts
@@ -4,7 +4,7 @@ import { renderSlovenskoXmlSummary } from './renderXmlSummary'
 import removeMarkdown from 'remove-markdown'
 import { FormsBackendFile } from '../form-files/serverFilesTypes'
 import { getSlovenskoSkXmlns } from './urls'
-import { slovenskoSkXmlBuilder } from './xmlBuilder'
+import { slovenskoSkXmlBuilder, slovenskoSkXmlBuilderHeadless } from './xmlBuilder'
 
 function getSlovenskoSkXmlBase(formDefinition: FormDefinitionSlovenskoSk, body: GenericObjectType) {
   return {
@@ -38,6 +38,7 @@ export async function generateSlovenskoSkXml(
   formDefinition: FormDefinitionSlovenskoSk,
   formData: GenericObjectType,
   serverFiles?: FormsBackendFile[],
+  headless = false,
 ) {
   const xml = getSlovenskoSkXmlBase(formDefinition, {
     Json: JSON.stringify(formData),
@@ -45,5 +46,6 @@ export async function generateSlovenskoSkXml(
     TermsAndConditions: removeMarkdown(formDefinition.termsAndConditions),
   })
 
-  return slovenskoSkXmlBuilder.buildObject(xml)
+  const builder = headless ? slovenskoSkXmlBuilderHeadless : slovenskoSkXmlBuilder
+  return builder.buildObject(xml)
 }

--- a/forms-shared/src/slovensko-sk/xmlBuilder.ts
+++ b/forms-shared/src/slovensko-sk/xmlBuilder.ts
@@ -1,6 +1,6 @@
 import { Builder } from 'xml2js'
 
-export const slovenskoSkXmlBuilder = new Builder({
+const builderOptionsBase = {
   xmldec: {
     version: '1.0',
     encoding: 'UTF-8',
@@ -8,4 +8,8 @@ export const slovenskoSkXmlBuilder = new Builder({
   renderOpts: {
     pretty: true,
   },
-})
+}
+
+export const slovenskoSkXmlBuilder = new Builder(builderOptionsBase)
+
+export const slovenskoSkXmlBuilderHeadless = new Builder({ ...builderOptionsBase, headless: true })

--- a/forms-shared/tests/definitions/formDefinitions.ts
+++ b/forms-shared/tests/definitions/formDefinitions.ts
@@ -7,6 +7,11 @@ import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs
 
 describe('Form definitions', () => {
   formDefinitions.forEach((formDefinition) => {
+    // "Žiadosť o nájomné bývanie" is skipped until fully implemented
+    if (formDefinition.slug === 'ziadost-o-najomny-byt') {
+      return
+    }
+
     describe(formDefinition.slug, () => {
       it('schemas match snapshot', () => {
         expect(formDefinition.schemas).toMatchSnapshot()

--- a/nest-forms-backend/src/convert/convert.controller.ts
+++ b/nest-forms-backend/src/convert/convert.controller.ts
@@ -39,10 +39,7 @@ import {
   XmlToJsonRequestDto,
   XmlToJsonResponseDto,
 } from './dtos/form.dto'
-import {
-  FormIdMissingErrorDto,
-  PdfGenerationFailedErrorDto,
-} from './errors/convert.errors.dto'
+import { PdfGenerationFailedErrorDto } from './errors/convert.errors.dto'
 
 @ApiTags('convert')
 @ApiBearerAuth()
@@ -51,9 +48,9 @@ export default class ConvertController {
   constructor(private readonly convertService: ConvertService) {}
 
   @ApiOperation({
-    summary: '',
+    summary: 'Convert JSON to XML',
     description:
-      'Generates XML form from given JSON data and form definition slug. At least one of `formId` and `jsonData` must be provided.',
+      'Generates XML form from given JSON data or form data stored in the database. If jsonData is not provided, the form data from the database will be used.',
   })
   @ApiResponse({
     status: 200,
@@ -64,11 +61,6 @@ export default class ConvertController {
     status: HttpStatusCode.NotFound,
     description: 'Form definition was not found',
     type: FormDefinitionNotFoundErrorDto,
-  })
-  @ApiBadRequestResponse({
-    status: HttpStatusCode.BadRequest,
-    description: 'If there is no form data, form id must be provided.',
-    type: FormIdMissingErrorDto,
   })
   @ApiForbiddenResponse({
     status: HttpStatusCode.Forbidden,

--- a/nest-forms-backend/src/convert/convert.controller.ts
+++ b/nest-forms-backend/src/convert/convert.controller.ts
@@ -90,6 +90,7 @@ export default class ConvertController {
     return this.convertService.convertJsonToXmlV2(
       data,
       userInfo?.ico ?? null,
+      false,
       user,
     )
   }

--- a/nest-forms-backend/src/convert/convert.service.ts
+++ b/nest-forms-backend/src/convert/convert.service.ts
@@ -75,22 +75,19 @@ export default class ConvertService {
       )
     }
 
-    let jsonFormData = data.jsonData
-    if (jsonFormData === undefined) {
-      if (data.formId === undefined) {
-        throw this.throwerErrorGuard.BadRequestException(
-          ConvertErrorsEnum.FORM_ID_MISSING,
-          ConvertErrorsResponseEnum.FORM_ID_MISSING,
-        )
-      }
-
-      const form = await this.formsService.getFormWithAccessCheck(
-        data.formId,
-        user?.sub ?? null,
-        ico,
+    if (data.formId === undefined) {
+      throw this.throwerErrorGuard.BadRequestException(
+        ConvertErrorsEnum.FORM_ID_MISSING,
+        ConvertErrorsResponseEnum.FORM_ID_MISSING,
       )
-      jsonFormData = form.formDataJson
     }
+
+    const form = await this.formsService.getFormWithAccessCheck(
+      data.formId,
+      user?.sub ?? null,
+      ico,
+    )
+    const jsonFormData = data.jsonData ?? form.formDataJson
 
     const xmlTemplate = createXmlTemplate(formDefinition)
     const $ = cheerio.load(xmlTemplate, {

--- a/nest-forms-backend/src/convert/convert.service.ts
+++ b/nest-forms-backend/src/convert/convert.service.ts
@@ -7,6 +7,7 @@ import * as cheerio from 'cheerio'
 import { Response } from 'express'
 import {
   FormDefinition,
+  FormDefinitionSlovenskoSk,
   isSlovenskoSkFormDefinition,
   isSlovenskoSkTaxFormDefinition,
 } from 'forms-shared/definitions/formDefinitionTypes'
@@ -61,32 +62,25 @@ export default class ConvertService {
     ico: string | null,
     user?: CognitoGetUserData,
   ): Promise<string> {
-    const formDefinition = getFormDefinitionBySlug(data.slug)
-    if (formDefinition === null) {
-      throw this.throwerErrorGuard.NotFoundException(
-        FormsErrorsEnum.FORM_DEFINITION_NOT_FOUND,
-        `${FormsErrorsResponseEnum.FORM_DEFINITION_NOT_FOUND} ${data.slug}`,
-      )
-    }
-    if (!isSlovenskoSkFormDefinition(formDefinition)) {
-      throw this.throwerErrorGuard.UnprocessableEntityException(
-        FormsErrorsEnum.FORM_DEFINITION_NOT_SUPPORTED_TYPE,
-        `convertJsonToXmlv2: ${FormsErrorsResponseEnum.FORM_DEFINITION_NOT_SUPPORTED_TYPE}: ${formDefinition.type}, slug: ${data.slug}`,
-      )
-    }
-
-    if (data.formId === undefined) {
-      throw this.throwerErrorGuard.BadRequestException(
-        ConvertErrorsEnum.FORM_ID_MISSING,
-        ConvertErrorsResponseEnum.FORM_ID_MISSING,
-      )
-    }
-
     const form = await this.formsService.getFormWithAccessCheck(
       data.formId,
       user?.sub ?? null,
       ico,
     )
+
+    const formDefinition = getFormDefinitionBySlug(form.formDefinitionSlug)
+    if (formDefinition === null) {
+      throw this.throwerErrorGuard.NotFoundException(
+        FormsErrorsEnum.FORM_DEFINITION_NOT_FOUND,
+        `${FormsErrorsResponseEnum.FORM_DEFINITION_NOT_FOUND} ${form.formDefinitionSlug}`,
+      )
+    }
+    if (!isSlovenskoSkFormDefinition(formDefinition)) {
+      throw this.throwerErrorGuard.UnprocessableEntityException(
+        FormsErrorsEnum.FORM_DEFINITION_NOT_SUPPORTED_TYPE,
+        `convertJsonToXmlv2: ${FormsErrorsResponseEnum.FORM_DEFINITION_NOT_SUPPORTED_TYPE}: ${formDefinition.type}, slug: ${form.formDefinitionSlug}`,
+      )
+    }
     const jsonFormData = data.jsonData ?? form.formDataJson
 
     const xmlTemplate = createXmlTemplate(formDefinition)

--- a/nest-forms-backend/src/convert/dtos/form.dto.ts
+++ b/nest-forms-backend/src/convert/dtos/form.dto.ts
@@ -30,13 +30,6 @@ export class JsonToXmlV2RequestDto {
   @IsUUID()
   formId: string
 
-  @ApiProperty({
-    description: 'Slug of the form definition',
-    example: 'zavazne-stanovisko-k-investicnej-cinnosti',
-  })
-  @IsString()
-  slug: string
-
   @IsObject()
   @ApiPropertyOptional({
     description:

--- a/nest-forms-backend/src/convert/dtos/form.dto.ts
+++ b/nest-forms-backend/src/convert/dtos/form.dto.ts
@@ -24,12 +24,11 @@ export class JsonConvertRequestDto {
 
 export class JsonToXmlV2RequestDto {
   @ApiPropertyOptional({
-    description: 'Form id. If jsonData is not provided, this is required.',
+    description: 'Form id',
     example: 'f69559da-5eca-4ed7-80fd-370d09dc3632',
   })
   @IsUUID()
-  @IsOptional()
-  formId?: string
+  formId: string
 
   @ApiProperty({
     description: 'Slug of the form definition',
@@ -40,7 +39,8 @@ export class JsonToXmlV2RequestDto {
 
   @IsObject()
   @ApiPropertyOptional({
-    description: 'Form values in JSON',
+    description:
+      'JSON form values, if not provided the form data from the database will be used.',
     example: JSON_FORM_EXAMPLE,
   })
   @IsNotEmpty()

--- a/nest-forms-backend/src/convert/errors/convert.errors.dto.ts
+++ b/nest-forms-backend/src/convert/errors/convert.errors.dto.ts
@@ -19,17 +19,3 @@ export class PdfGenerationFailedErrorDto extends BadRequestErrorDto {
   })
   declare message: string
 }
-
-export class FormIdMissingErrorDto extends BadRequestErrorDto {
-  @ApiProperty({
-    example: ConvertErrorsEnum.FORM_ID_MISSING,
-    default: ConvertErrorsEnum.FORM_ID_MISSING,
-  })
-  declare errorName: string
-
-  @ApiProperty({
-    example: ConvertErrorsResponseEnum.FORM_ID_MISSING,
-    default: ConvertErrorsResponseEnum.FORM_ID_MISSING,
-  })
-  declare message: string
-}

--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
@@ -350,10 +350,10 @@ export default class NasesUtilsService {
         message = await this.convertService.convertJsonToXmlV2(
           {
             formId: form.id,
-            slug: form.formDefinitionSlug,
             jsonData: form.formDataJson,
           },
           null,
+          true,
         )
       } catch (error) {
         throw this.throwerErrorGuard.InternalServerErrorException(

--- a/next/clients/openapi-forms/api.ts
+++ b/next/clients/openapi-forms/api.ts
@@ -105,10 +105,10 @@ export interface ConvertToPdfRequestDto {
   jsonData?: object
   /**
    * Used only in the FE requests to display files not yet uploaded to the server.
-   * @type {Array<object>}
+   * @type {Array<SimplifiedClientFileInfoDto>}
    * @memberof ConvertToPdfRequestDto
    */
-  clientFiles?: Array<object>
+  clientFiles?: Array<SimplifiedClientFileInfoDto>
 }
 /**
  *
@@ -1637,56 +1637,6 @@ export type FormDefinitionNotSupportedTypeErrorDtoErrorNameEnum =
 /**
  *
  * @export
- * @interface FormIdMissingErrorDto
- */
-export interface FormIdMissingErrorDto {
-  /**
-   * Status Code
-   * @type {number}
-   * @memberof FormIdMissingErrorDto
-   */
-  statusCode: number
-  /**
-   * Detail error message
-   * @type {string}
-   * @memberof FormIdMissingErrorDto
-   */
-  message: string
-  /**
-   * status in text
-   * @type {string}
-   * @memberof FormIdMissingErrorDto
-   */
-  status: string
-  /**
-   * Exact error name
-   * @type {string}
-   * @memberof FormIdMissingErrorDto
-   */
-  errorName: FormIdMissingErrorDtoErrorNameEnum
-  /**
-   * Helper for sending additional data in error
-   * @type {object}
-   * @memberof FormIdMissingErrorDto
-   */
-  object?: object
-}
-
-export const FormIdMissingErrorDtoErrorNameEnum = {
-  NotFoundError: 'NOT_FOUND_ERROR',
-  DatabaseError: 'DATABASE_ERROR',
-  InternalServerError: 'INTERNAL_SERVER_ERROR',
-  UnauthorizedError: 'UNAUTHORIZED_ERROR',
-  UnprocessableEntityError: 'UNPROCESSABLE_ENTITY_ERROR',
-  BadRequestError: 'BAD_REQUEST_ERROR',
-} as const
-
-export type FormIdMissingErrorDtoErrorNameEnum =
-  (typeof FormIdMissingErrorDtoErrorNameEnum)[keyof typeof FormIdMissingErrorDtoErrorNameEnum]
-
-/**
- *
- * @export
  * @interface FormIsOwnedBySomeoneElseErrorDto
  */
 export interface FormIsOwnedBySomeoneElseErrorDto {
@@ -2573,19 +2523,13 @@ export interface JsonConvertRequestDto {
  */
 export interface JsonToXmlV2RequestDto {
   /**
-   * Form id. If jsonData is not provided, this is required.
+   * Form id
    * @type {string}
    * @memberof JsonToXmlV2RequestDto
    */
   formId?: string
   /**
-   * Slug of the form definition
-   * @type {string}
-   * @memberof JsonToXmlV2RequestDto
-   */
-  slug: string
-  /**
-   * Form values in JSON
+   * JSON form values, if not provided the form data from the database will be used.
    * @type {object}
    * @memberof JsonToXmlV2RequestDto
    */
@@ -3221,6 +3165,31 @@ export interface SimpleBadRequestErrorDto {
    * @memberof SimpleBadRequestErrorDto
    */
   message: string
+}
+/**
+ *
+ * @export
+ * @interface SimplifiedClientFileInfoDto
+ */
+export interface SimplifiedClientFileInfoDto {
+  /**
+   *
+   * @type {string}
+   * @memberof SimplifiedClientFileInfoDto
+   */
+  id: string
+  /**
+   *
+   * @type {object}
+   * @memberof SimplifiedClientFileInfoDto
+   */
+  file: object
+  /**
+   *
+   * @type {object}
+   * @memberof SimplifiedClientFileInfoDto
+   */
+  status: object
 }
 /**
  *
@@ -3957,8 +3926,8 @@ export class ADMINApi extends BaseAPI {
 export const ConvertApiAxiosParamCreator = function (configuration?: Configuration) {
   return {
     /**
-     * Generates XML form from given JSON data and form definition slug. At least one of `formId` and `jsonData` must be provided.
-     * @summary
+     * Generates XML form from given JSON data or form data stored in the database. If jsonData is not provided, the form data from the database will be used.
+     * @summary Convert JSON to XML
      * @param {JsonToXmlV2RequestDto} jsonToXmlV2RequestDto
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4133,8 +4102,8 @@ export const ConvertApiFp = function (configuration?: Configuration) {
   const localVarAxiosParamCreator = ConvertApiAxiosParamCreator(configuration)
   return {
     /**
-     * Generates XML form from given JSON data and form definition slug. At least one of `formId` and `jsonData` must be provided.
-     * @summary
+     * Generates XML form from given JSON data or form data stored in the database. If jsonData is not provided, the form data from the database will be used.
+     * @summary Convert JSON to XML
      * @param {JsonToXmlV2RequestDto} jsonToXmlV2RequestDto
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4234,8 +4203,8 @@ export const ConvertApiFactory = function (
   const localVarFp = ConvertApiFp(configuration)
   return {
     /**
-     * Generates XML form from given JSON data and form definition slug. At least one of `formId` and `jsonData` must be provided.
-     * @summary
+     * Generates XML form from given JSON data or form data stored in the database. If jsonData is not provided, the form data from the database will be used.
+     * @summary Convert JSON to XML
      * @param {JsonToXmlV2RequestDto} jsonToXmlV2RequestDto
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4291,8 +4260,8 @@ export const ConvertApiFactory = function (
  */
 export class ConvertApi extends BaseAPI {
   /**
-   * Generates XML form from given JSON data and form definition slug. At least one of `formId` and `jsonData` must be provided.
-   * @summary
+   * Generates XML form from given JSON data or form data stored in the database. If jsonData is not provided, the form data from the database will be used.
+   * @summary Convert JSON to XML
    * @param {JsonToXmlV2RequestDto} jsonToXmlV2RequestDto
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}

--- a/next/components/forms/segments/AccountSections/MyApplicationsSection/MyApplicationsCard.tsx
+++ b/next/components/forms/segments/AccountSections/MyApplicationsSection/MyApplicationsCard.tsx
@@ -97,15 +97,10 @@ const MyApplicationsCard = ({
   const exportXml = async () => {
     openSnackbarInfo(ft('info_messages.xml_export'))
     try {
-      if (!formSlug || !formId)
-        throw new Error(
-          // eslint-disable-next-line sonarjs/no-nested-template-literals
-          `No formSlug or form id ${formId && `for form id: ${formId}`}`,
-        )
+      if (!formId) throw new Error('No form id provided for exportXml')
       const response = await formsApi.convertControllerConvertJsonToXmlV2(
         {
           formId,
-          slug: formSlug,
         },
         { accessToken: 'onlyAuthenticated' },
       )

--- a/next/frontend/hooks/useFormExportImport.tsx
+++ b/next/frontend/hooks/useFormExportImport.tsx
@@ -111,7 +111,6 @@ export const useGetContext = () => {
         {
           formId,
           jsonData: formData,
-          slug,
         },
         { accessToken: 'onlyAuthenticated' },
       )

--- a/next/generateOpenApiClient.ts
+++ b/next/generateOpenApiClient.ts
@@ -27,6 +27,7 @@ async function replaceOptionsType(filePath: string) {
 
 const validTypes = ['forms', 'tax', 'city-account']
 
+// To generate client from locally running backend, use 'http://host.docker.internal:3000/api-json'
 const endpoints = {
   forms: 'https://nest-forms-backend.staging.bratislava.sk/api-json',
   tax: 'https://nest-tax-backend.staging.bratislava.sk/api-json',


### PR DESCRIPTION
Commit by commit

- Moves Žiadost o nájomné byvanie to production forms, but with `(TESTOVACIA VERZIA)` in form name
- Creates new `newGovernmentXml` flag that is used in `ConvertService` to use new XML generation for this form
- Refactored `convertJsonToXmlV2` to have form id required 
  - there was no use case where it was not provided
  - it is needed, because new XMLs need files to be generated (which are not possible to fetch without form id)
  - it matches how PDFs are generated
  - form slug can be removed from request payload
  - this is TODO version and will be refactored soon (when we migrate all the forms to the new XML)