### PR TITLE
Run CI version of Jest tests in the pipeline

### DIFF
--- a/forms-shared/Dockerfile
+++ b/forms-shared/Dockerfile
@@ -56,4 +56,4 @@ ENV SAXON_JAR=/opt/saxon/saxon-he-12.5.jar
 RUN npx playwright install chromium --with-deps
 # COPY needs to be after Playwright installation to make it more cache friendly.
 COPY . ./
-CMD [ "npm", "run", "test" ]
+CMD [ "npm", "run", "test:ci" ]

--- a/forms-shared/package.json
+++ b/forms-shared/package.json
@@ -11,6 +11,7 @@
     "test:update": "jest --u",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:ci": "jest --ci",
     "update-rjsf": "npm install @rjsf/core@latest @rjsf/utils@latest @rjsf/validator-ajv8@latest ajv@latest ajv-formats@latest -E",
     "generate-assets": "ts-node scripts/assets/generate.ts",
     "build": "rimraf dist && tsc --project tsconfig.build.json",


### PR DESCRIPTION
>> When this option is provided, Jest will assume it is running in a CI environment. This changes the behavior when a new snapshot is encountered. Instead of the regular behavior of storing a new snapshot automatically, **it will fail the test and require Jest to be run** with --updateSnapshot.
https://jestjs.io/docs/cli#--ci