### PR TITLE
fix: use fixed private key format

### DIFF
--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
@@ -130,7 +130,9 @@ export default class NasesUtilsService {
   }
 
   createUserJwtToken(oboToken: string): string {
-    const privateKey = process.env.API_TOKEN_PRIVATE ?? ''
+    const privateKey = (process.env.API_TOKEN_PRIVATE ?? '')
+      .split(String.raw`\n`)
+      .join('\n')
     const header = {
       alg: 'RS256',
       cty: 'JWT',
@@ -156,7 +158,9 @@ export default class NasesUtilsService {
   }
 
   createTechnicalAccountJwtToken(): string {
-    const privateKey = process.env.API_TOKEN_PRIVATE ?? ''
+    const privateKey = (process.env.API_TOKEN_PRIVATE ?? '')
+      .split(String.raw`\n`)
+      .join('\n')
     const header = {
       alg: 'RS256',
     }
@@ -182,7 +186,9 @@ export default class NasesUtilsService {
   }
 
   createAdministrationJwtToken(): string {
-    const privateKey = process.env.API_TOKEN_PRIVATE ?? ''
+    const privateKey = (process.env.API_TOKEN_PRIVATE ?? '')
+      .split(String.raw`\n`)
+      .join('\n')
     const header = {
       alg: 'RS256',
     }

--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
@@ -130,6 +130,7 @@ export default class NasesUtilsService {
   }
 
   createUserJwtToken(oboToken: string): string {
+    // https://stackoverflow.com/questions/74131595/error-error1e08010cdecoder-routinesunsupported-with-google-auth-library
     const privateKey = (process.env.API_TOKEN_PRIVATE ?? '')
       .split(String.raw`\n`)
       .join('\n')
@@ -158,6 +159,7 @@ export default class NasesUtilsService {
   }
 
   createTechnicalAccountJwtToken(): string {
+    // https://stackoverflow.com/questions/74131595/error-error1e08010cdecoder-routinesunsupported-with-google-auth-library
     const privateKey = (process.env.API_TOKEN_PRIVATE ?? '')
       .split(String.raw`\n`)
       .join('\n')
@@ -186,6 +188,7 @@ export default class NasesUtilsService {
   }
 
   createAdministrationJwtToken(): string {
+    // https://stackoverflow.com/questions/74131595/error-error1e08010cdecoder-routinesunsupported-with-google-auth-library
     const privateKey = (process.env.API_TOKEN_PRIVATE ?? '')
       .split(String.raw`\n`)
       .join('\n')


### PR DESCRIPTION
Fixes an error when the technical account jwt token could not be generated.
https://stackoverflow.com/questions/74131595/error-error1e08010cdecoder-routinesunsupported-with-google-auth-library