### PR TITLE
Cypress hide statusbar env variable

### DIFF
--- a/next/.env
+++ b/next/.env
@@ -22,6 +22,7 @@ NEXT_PUBLIC_FARO_SECRET=4d505d54b9d5c677d4241024d74e4dfefa2174fbdd84252e65d0a5cb
 NEXT_PUBLIC_FEATURE_TOGGLE_DEVELOPMENT_FORMS=true
 NEXT_PUBLIC_FEATURE_TOGGLE_TAX_REPORT_CORRESPONDENCE_ADDRESS=false
 NEXT_PUBLIC_FEATURE_TOGGLE_EID_TAX_WITHOUT_BETA_FLAG=true
+NEXT_PUBLIC_FEATURE_TOGGLE_HIDE_STATUSBAR=false
 
 # Keep in sync with https://github.com/bratislava/nest-forms-backend/ env variables
 NEXT_PUBLIC_FORMS_MIMETYPE_WHITELIST="application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed"

--- a/next/.env.bratiska-cli-build.dev
+++ b/next/.env.bratiska-cli-build.dev
@@ -21,6 +21,7 @@ NEXT_PUBLIC_FARO_SECRET=4d505d54b9d5c677d4241024d74e4dfefa2174fbdd84252e65d0a5cb
 NEXT_PUBLIC_FEATURE_TOGGLE_DEVELOPMENT_FORMS=true
 NEXT_PUBLIC_FEATURE_TOGGLE_TAX_REPORT_CORRESPONDENCE_ADDRESS=false
 NEXT_PUBLIC_FEATURE_TOGGLE_EID_TAX_WITHOUT_BETA_FLAG=true
+NEXT_PUBLIC_FEATURE_TOGGLE_HIDE_STATUSBAR=false
 
 # Keep in sync with https://github.com/bratislava/nest-forms-backend/ env variables
 NEXT_PUBLIC_FORMS_MIMETYPE_WHITELIST="application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed"

--- a/next/.env.bratiska-cli-build.prod
+++ b/next/.env.bratiska-cli-build.prod
@@ -23,6 +23,7 @@ NEXT_PUBLIC_FARO_SECRET=4d505d54b9d5c677d4241024d74e4dfefa2174fbdd84252e65d0a5cb
 NEXT_PUBLIC_FEATURE_TOGGLE_DEVELOPMENT_FORMS=false
 NEXT_PUBLIC_FEATURE_TOGGLE_TAX_REPORT_CORRESPONDENCE_ADDRESS=false
 NEXT_PUBLIC_FEATURE_TOGGLE_EID_TAX_WITHOUT_BETA_FLAG=false
+NEXT_PUBLIC_FEATURE_TOGGLE_HIDE_STATUSBAR=false
 
 # Keep in sync with https://github.com/bratislava/nest-forms-backend/ env variables
 NEXT_PUBLIC_FORMS_MIMETYPE_WHITELIST="application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed"

--- a/next/.env.bratiska-cli-build.staging
+++ b/next/.env.bratiska-cli-build.staging
@@ -21,6 +21,7 @@ NEXT_PUBLIC_FARO_SECRET=4d505d54b9d5c677d4241024d74e4dfefa2174fbdd84252e65d0a5cb
 NEXT_PUBLIC_FEATURE_TOGGLE_DEVELOPMENT_FORMS=true
 NEXT_PUBLIC_FEATURE_TOGGLE_TAX_REPORT_CORRESPONDENCE_ADDRESS=false
 NEXT_PUBLIC_FEATURE_TOGGLE_EID_TAX_WITHOUT_BETA_FLAG=true
+NEXT_PUBLIC_FEATURE_TOGGLE_HIDE_STATUSBAR=false
 
 # Keep in sync with https://github.com/bratislava/nest-forms-backend/ env variables
 NEXT_PUBLIC_FORMS_MIMETYPE_WHITELIST="application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed"

--- a/next/.env.development
+++ b/next/.env.development
@@ -22,6 +22,7 @@ NEXT_PUBLIC_FARO_SECRET=4d505d54b9d5c677d4241024d74e4dfefa2174fbdd84252e65d0a5cb
 NEXT_PUBLIC_FEATURE_TOGGLE_DEVELOPMENT_FORMS=true
 NEXT_PUBLIC_FEATURE_TOGGLE_TAX_REPORT_CORRESPONDENCE_ADDRESS=false
 NEXT_PUBLIC_FEATURE_TOGGLE_EID_TAX_WITHOUT_BETA_FLAG=true
+NEXT_PUBLIC_FEATURE_TOGGLE_HIDE_STATUSBAR=false
 
 # Keep in sync with https://github.com/bratislava/nest-forms-backend/ env variables
 NEXT_PUBLIC_FORMS_MIMETYPE_WHITELIST="application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed"

--- a/next/.env.e2e
+++ b/next/.env.e2e
@@ -19,6 +19,7 @@ NEXT_PUBLIC_FARO_SECRET=4d505d54b9d5c677d4241024d74e4dfefa2174fbdd84252e65d0a5cb
 NEXT_PUBLIC_FEATURE_TOGGLE_DEVELOPMENT_FORMS=true
 NEXT_PUBLIC_FEATURE_TOGGLE_TAX_REPORT_CORRESPONDENCE_ADDRESS=false
 NEXT_PUBLIC_FEATURE_TOGGLE_EID_TAX_WITHOUT_BETA_FLAG=true
+NEXT_PUBLIC_FEATURE_TOGGLE_HIDE_STATUSBAR=true
 
 # Keep in sync with https://github.com/bratislava/nest-forms-backend/ env variables
 NEXT_PUBLIC_FORMS_MIMETYPE_WHITELIST="application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed"

--- a/next/components/forms/info-components/StatusBar.tsx
+++ b/next/components/forms/info-components/StatusBar.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'next-i18next'
 import React, { createContext, forwardRef, ReactNode, useContext, useState } from 'react'
 import { useEffectOnce, useLocalStorage } from 'usehooks-ts'
 
+import { environment } from '../../../environment'
 import WarningIcon from '../icon-components/WarningIcon'
 import AccountMarkdown from '../segments/AccountMarkdown/AccountMarkdown'
 import { SectionContainer } from '../segments/SectionContainer/SectionContainer'
@@ -73,8 +74,16 @@ export const StatusBar = forwardRef<HTMLDivElement>((props, forwardedRef) => {
   )
 
   const { statusBarConfiguration } = useStatusBarContext()
-  return statusBarTextDissmissed !== statusBarConfiguration.content &&
-    statusBarConfiguration.content ? (
+
+  const displayStatusBar =
+    statusBarConfiguration.content &&
+    statusBarTextDissmissed !== statusBarConfiguration.content &&
+    !environment.featureToggles.hideStatusbar
+  if (!displayStatusBar) {
+    return null
+  }
+
+  return (
     <div
       ref={forwardedRef}
       className={cx('w-full text-white', {
@@ -82,7 +91,6 @@ export const StatusBar = forwardRef<HTMLDivElement>((props, forwardedRef) => {
         'bg-warning-700': statusBarConfiguration.variant === 'warning',
         'bg-gray-700': statusBarConfiguration.variant === 'info',
       })}
-      data-cy="info-bar"
     >
       <SectionContainer>
         <div className="flex justify-between py-4">
@@ -104,5 +112,5 @@ export const StatusBar = forwardRef<HTMLDivElement>((props, forwardedRef) => {
         </div>
       </SectionContainer>
     </div>
-  ) : null
+  )
 })

--- a/next/environment.ts
+++ b/next/environment.ts
@@ -108,6 +108,11 @@ export const environment = {
         'NEXT_PUBLIC_FEATURE_TOGGLE_EID_TAX_WITHOUT_BETA_FLAG',
         process.env.NEXT_PUBLIC_FEATURE_TOGGLE_EID_TAX_WITHOUT_BETA_FLAG,
       ) === 'true',
+    hideStatusbar:
+      assertEnv(
+        'NEXT_PUBLIC_FEATURE_TOGGLE_HIDE_STATUSBAR',
+        process.env.NEXT_PUBLIC_FEATURE_TOGGLE_HIDE_STATUSBAR,
+      ) === 'true',
   },
   formsMimetypes: assertEnv(
     'NEXT_PUBLIC_FORMS_MIMETYPE_WHITELIST',

--- a/tests/cypress/e2e/form/formRegistrationRedirect-mobile.cy.ts
+++ b/tests/cypress/e2e/form/formRegistrationRedirect-mobile.cy.ts
@@ -87,7 +87,6 @@ describe('F04 -', { testIsolation: false }, () => {
         })
 
         it('5. Check that required inputs are not in error state.', () => {
-          cy.hideInfoBar()
           cy.checkFormFieldsNotInErrorState('register-form', errorBorderFields)
           cy.dataCy('registration-container').should('be.visible') //.matchImage()
           cy.wait(500)

--- a/tests/cypress/e2e/form/formRegistrationRedirect.cy.ts
+++ b/tests/cypress/e2e/form/formRegistrationRedirect.cy.ts
@@ -99,7 +99,6 @@ describe('F04 -', { testIsolation: false }, () => {
         })
 
         it('5. Check that required inputs are not in error state.', () => {
-          cy.hideInfoBar()
           cy.checkFormFieldsNotInErrorState('register-form', errorBorderFields)
           cy.dataCy('registration-container').should('be.visible') //.matchImage()
           cy.wait(500)

--- a/tests/cypress/e2e/registration/registration.cy.ts
+++ b/tests/cypress/e2e/registration/registration.cy.ts
@@ -171,7 +171,6 @@ describe('RF01 -', { testIsolation: false }, () => {
           it('1. Submitting wrong value.', () => {
             cy.visit('/zabudnute-heslo')
             cy.hideNavbar(device)
-            cy.hideInfoBar()
 
             cy.dataCy('forgotten-password-form').then((form) => {
               cy.wrap(Cypress.$('[data-cy=input-email]', form)).type('test')

--- a/tests/cypress/support/commands/global.ts
+++ b/tests/cypress/support/commands/global.ts
@@ -20,12 +20,6 @@ declare namespace Cypress {
     hideNavbar(device: string): Chainable<any>
 
     /**
-     * Custom command to hide info bar on device.
-     * @example cy.hideInfoBar()
-     */
-    hideInfoBar(): Chainable<any>
-
-    /**
      * Custom command to show navbar on device.
      * @param device Device type.
      * @example cy.showNavbar('desktop')
@@ -41,12 +35,6 @@ Cypress.Commands.add('dataCy', (attribute, specify) => {
 
 Cypress.Commands.add('hideNavbar', (device) => {
   cy.get(`#${device}-navbar`).invoke('attr', 'style', 'display: none')
-})
-
-Cypress.Commands.add('hideInfoBar', () => {
-  if (cy.dataCy(`info-bar`)) {
-    cy.dataCy(`info-bar`).invoke('attr', 'style', 'display: none')
-  }
 })
 
 Cypress.Commands.add('showNavbar', (device) => {


### PR DESCRIPTION
The Cypress tests depended on status bar being present and hiding it, this disables the status bar completely in the tests.
