### PR TITLE
fix: correct mapping in sharepoint for other members of household

### DIFF
--- a/forms-shared/src/sharepoint/mappings/ziadostONajomnyByt.ts
+++ b/forms-shared/src/sharepoint/mappings/ziadostONajomnyByt.ts
@@ -336,27 +336,27 @@ const defaultColumnMapNajomneByvanieIniClenovia: Record<string, SharepointColumn
   },
   ZamestnaniePrijem: {
     type: 'json_path',
-    info: 'ziadatelZiadatelka.prijem.zamestnaniePrijem',
+    info: 'prijem.zamestnaniePrijem',
   },
   SamostatnaZarobkovaCinnostPrijem: {
     type: 'json_path',
-    info: 'ziadatelZiadatelka.prijem.samostatnaZarobkovaCinnostPrijem',
+    info: 'prijem.samostatnaZarobkovaCinnostPrijem',
   },
   DochodokVyska: {
     type: 'json_path',
-    info: 'ziadatelZiadatelka.prijem.dochodokVyska',
+    info: 'prijem.dochodokVyska',
   },
   VyzivneVyska: {
     type: 'json_path',
-    info: 'ziadatelZiadatelka.prijem.vyzivneVyska',
+    info: 'prijem.vyzivneVyska',
   },
   DavkaVNezamestnanostiVyska: {
     type: 'json_path',
-    info: 'ziadatelZiadatelka.prijem.davkaVNezamestnanostiVyska',
+    info: 'prijem.davkaVNezamestnanostiVyska',
   },
   InePrijmyVyska: {
     type: 'json_path',
-    info: 'ziadatelZiadatelka.prijem.inePrijmyVyska',
+    info: 'prijem.inePrijmyVyska',
   },
   TzpPreukaz: {
     type: 'json_path',

--- a/forms-shared/tests/sharepoint/__snapshots__/getValuesForSharepoint.ts.snap
+++ b/forms-shared/tests/sharepoint/__snapshots__/getValuesForSharepoint.ts.snap
@@ -110,6 +110,7 @@ exports[`getValuesForFields should match snapshots 5`] = `
 
 exports[`getValuesForFields should match snapshots 6`] = `
 {
+  "DochodokVyska": 550,
   "GinisID": "MAG123",
   "MieraFunkcnejPoruchy": "50az74",
   "SucasneByvanieRovnakeAkoVase": true,


### PR DESCRIPTION
There was an error when sending income data to sharepoint for other members of the household. In the path there was extra `ziadatelZiadatelka`.