### PR TITLE
Change Ginis assignee, allow ginis org name without person

### DIFF
--- a/forms-shared/src/definitions/formDefinitionTypes.ts
+++ b/forms-shared/src/definitions/formDefinitionTypes.ts
@@ -32,7 +32,7 @@ export type FormDefinitionSlovenskoSkGeneric = FormDefinitionSlovenskoSkBase & {
   type: FormDefinitionType.SlovenskoSkGeneric
   ginisAssignment: {
     ginisOrganizationName: string
-    ginisPersonName: string
+    ginisPersonName?: string
   }
   sharepointData?: SharepointData
 }

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -112,10 +112,8 @@ export const formDefinitions: FormDefinition[] = [
     termsAndConditions: generalTermsAndConditions,
     messageSubjectDefault: 'Žiadosť o nájom bytu',
     sharepointData: ziadostONajomBytuSharepointData,
-    // TODO
     ginisAssignment: {
-      ginisOrganizationName: 'SX',
-      ginisPersonName: 'Pinter Martin',
+      ginisOrganizationName: 'SNB',
     },
     isSigned: false,
     newGovernmentXml: true,

--- a/nest-forms-backend/src/ginis/ginis.service.ts
+++ b/nest-forms-backend/src/ginis/ginis.service.ts
@@ -366,7 +366,7 @@ export default class GinisService {
   async assignSubmission(
     documentId: string,
     organization: string,
-    person: string,
+    person?: string,
   ): Promise<void> {
     this.logger.debug('---- start to assign submission ----')
     await this.prismaService.forms.update({
@@ -383,7 +383,7 @@ export default class GinisService {
       {
         doc_id: documentId,
         organization,
-        person,
+        ...(person ? { person } : {}),
       },
       ASSIGN_QUEUE,
     )


### PR DESCRIPTION
Checked with @vidriduch , ginis-automation service should allow this. This should be the correct production assignment, we want to test it in advance and then revert until monday.