### PR TITLE
Form playground

### DIFF
--- a/forms-shared/src/form-utils/getObjectFieldInfo.ts
+++ b/forms-shared/src/form-utils/getObjectFieldInfo.ts
@@ -1,0 +1,15 @@
+import { IdSchema } from '@rjsf/utils'
+
+export const getObjectFieldInfo = (idSchema: IdSchema) => {
+  const id = idSchema.$id
+  const splitId = id.split('_')
+  const isFormObject = splitId.length === 1 && splitId[0] === 'root'
+  const isStepObject = splitId.length === 2 && splitId[0] === 'root'
+
+  return {
+    id,
+    splitId,
+    isFormObject,
+    isStepObject,
+  }
+}

--- a/forms-shared/src/summary-json/SummaryXmlForm.tsx
+++ b/forms-shared/src/summary-json/SummaryXmlForm.tsx
@@ -19,6 +19,7 @@ import { getArrayItemTitle } from '../form-utils/getArrayItemTitle'
 import { ArrayFieldUiOptions, BaWidgetType } from '../generator/uiOptionsTypes'
 import { getSummaryDisplayValues } from './getSummaryDisplayValue'
 import { baFormDefaults } from '../form-utils/formDefaults'
+import { getObjectFieldInfo } from '../form-utils/getObjectFieldInfo'
 
 export enum SummaryXmlFormTag {
   Form = 'summary-form',
@@ -132,10 +133,7 @@ const ArrayFieldTemplate = ({
 }
 
 const ObjectFieldTemplate = ({ schema, properties, idSchema, title }: ObjectFieldTemplateProps) => {
-  const id = idSchema.$id
-  const splitId = id.split('_')
-  const isFormObject = splitId.length === 1 && splitId[0] === 'root'
-  const isStepObject = splitId.length === 2 && splitId[0] === 'root'
+  const { id, splitId, isFormObject, isStepObject } = getObjectFieldInfo(idSchema)
 
   const content = properties.map((element, index) => (
     <Fragment key={index}>{element.content}</Fragment>

--- a/next/components/forms/FormPage.tsx
+++ b/next/components/forms/FormPage.tsx
@@ -66,45 +66,37 @@ const FormPage = () => {
           {currentStepperStep.index === 'summary' ? (
             <FormSummary />
           ) : (
-            <>
-              <div className="mb-8 flex flex-col gap-4">
-                <h2 className="text-h2 font-semibold">{currentStepperStep.title}</h2>
-                {currentStepperStep.description && (
-                  <p className="text-p1">{currentStepperStep.description}</p>
-                )}
-              </div>
-              <ThemedForm
-                // This is a hack to force the form to re-render when the step changes, it's hard to say whether it
-                // is needed or not, but ensures 100% safety.
-                key={`form-step-${currentStepperStep.index}`}
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                schema={currentStepSchema!}
-                uiSchema={uiSchema}
-                formData={formData}
-                readonly={isReadonly}
-                onSubmit={(e) => {
-                  handleFormOnSubmit(e.formData)
-                }}
-                onChange={(e) => {
-                  handleFormOnChange(e.formData)
-                }}
-                transformErrors={transformErrors}
-                showErrorList={false}
-                // This removes the extra conditional data for the current step, for removing the steps themselves see
-                // `handleFormOnChange` implementation.
-                omitExtraData
-                liveOmit
-                // HTML validation doesn't work for our use case, therefore it's turned off.
-                noHtml5Validate
-                {...baFormDefaults}
-              >
-                {
-                  // returning null would make RJSF render the default submit button
-                  // eslint-disable-next-line react/jsx-no-useless-fragment
-                  isReadonly ? <></> : <FormControls />
-                }
-              </ThemedForm>
-            </>
+            <ThemedForm
+              // This is a hack to force the form to re-render when the step changes, it's hard to say whether it
+              // is needed or not, but ensures 100% safety.
+              key={`form-step-${currentStepperStep.index}`}
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              schema={currentStepSchema!}
+              uiSchema={uiSchema}
+              formData={formData}
+              readonly={isReadonly}
+              onSubmit={(e) => {
+                handleFormOnSubmit(e.formData)
+              }}
+              onChange={(e) => {
+                handleFormOnChange(e.formData)
+              }}
+              transformErrors={transformErrors}
+              showErrorList={false}
+              // This removes the extra conditional data for the current step, for removing the steps themselves see
+              // `handleFormOnChange` implementation.
+              omitExtraData
+              liveOmit
+              // HTML validation doesn't work for our use case, therefore it's turned off.
+              noHtml5Validate
+              {...baFormDefaults}
+            >
+              {
+                // returning null would make RJSF render the default submit button
+                // eslint-disable-next-line react/jsx-no-useless-fragment
+                isReadonly ? <></> : <FormControls />
+              }
+            </ThemedForm>
           )}
           {displayHeaderAndMenu && <MenuList />}
         </div>

--- a/next/components/forms/FormPage.tsx
+++ b/next/components/forms/FormPage.tsx
@@ -12,6 +12,7 @@ import StepperView from './steps/StepperView'
 import FormSummary from './steps/Summary/FormSummary'
 import ThemedForm from './ThemedForm'
 import { useFormContext } from './useFormContext'
+import { useFormData } from './useFormData'
 import { useFormErrorTranslations } from './useFormErrorTranslations'
 import { useFormState } from './useFormState'
 
@@ -24,11 +25,11 @@ const FormPage = () => {
     displayHeaderAndMenu,
     isEmbedded,
   } = useFormContext()
+  const { formData } = useFormData()
   const {
     currentStepIndex,
     currentStepperStep,
     currentStepSchema,
-    formData,
     handleFormOnSubmit,
     handleFormOnChange,
     popScrollToFieldId,

--- a/next/components/forms/FormProviders.tsx
+++ b/next/components/forms/FormProviders.tsx
@@ -5,6 +5,7 @@ import { FormSignatureProvider } from './signer/useFormSignature'
 import { FormSignerLoaderProvider } from './signer/useFormSignerLoader'
 import { FormSummaryProvider } from './steps/Summary/useFormSummary'
 import { FormContextProvider, FormServerContext } from './useFormContext'
+import { FormDataProvider } from './useFormData'
 import { FormFileUploadProvider } from './useFormFileUpload'
 import { FormLeaveProtectionProvider } from './useFormLeaveProtection'
 import { FormModalsProvider } from './useFormModals'
@@ -23,17 +24,19 @@ const FormProviders = ({ formServerContext, children }: PropsWithChildren<FormPr
         <FormLeaveProtectionProvider>
           <FormModalsProvider>
             <FormSignerLoaderProvider>
-              <FormStateProvider>
-                <FormSignatureProvider>
-                  <FormRedirectsProvider>
-                    <FormSummaryProvider>
-                      <FormSendProvider>
-                        <FormExportImportProvider>{children}</FormExportImportProvider>
-                      </FormSendProvider>
-                    </FormSummaryProvider>
-                  </FormRedirectsProvider>
-                </FormSignatureProvider>
-              </FormStateProvider>
+              <FormDataProvider>
+                <FormStateProvider>
+                  <FormSignatureProvider>
+                    <FormRedirectsProvider>
+                      <FormSummaryProvider>
+                        <FormSendProvider>
+                          <FormExportImportProvider>{children}</FormExportImportProvider>
+                        </FormSendProvider>
+                      </FormSummaryProvider>
+                    </FormRedirectsProvider>
+                  </FormSignatureProvider>
+                </FormStateProvider>
+              </FormDataProvider>
             </FormSignerLoaderProvider>
           </FormModalsProvider>
         </FormLeaveProtectionProvider>

--- a/next/components/forms/FormsPlayground.tsx
+++ b/next/components/forms/FormsPlayground.tsx
@@ -1,0 +1,382 @@
+import { DownloadIcon, UploadIcon } from '@assets/ui-icons'
+import Editor from '@monaco-editor/react'
+import Form from '@rjsf/core'
+import { GenericObjectType } from '@rjsf/utils'
+import { FormDefinition } from 'forms-shared/definitions/formDefinitionTypes'
+import { exampleDevForms, exampleForms } from 'forms-shared/example-forms/exampleForms'
+import { FileInfo, FileStatusType } from 'forms-shared/form-files/fileStatus'
+import { mergeClientAndServerFiles } from 'forms-shared/form-files/mergeClientAndServerFiles'
+import { baGetDefaultFormStateStable } from 'forms-shared/form-utils/defaultFormState'
+import { baFormDefaults } from 'forms-shared/form-utils/formDefaults'
+import { useTranslation } from 'next-i18next'
+import { useQueryState } from 'nuqs'
+import React, { ContextType, createRef, useMemo, useRef, useState } from 'react'
+import { useEffectOnce } from 'usehooks-ts'
+import { v4 as uuidv4 } from 'uuid'
+
+import useSnackbar from '../../frontend/hooks/useSnackbar'
+import { downloadBlob } from '../../frontend/utils/general'
+import Button from './simple-components/ButtonNew'
+import ThemedForm from './ThemedForm'
+import { FormDataContext } from './useFormData'
+import { useFormErrorTranslations } from './useFormErrorTranslations'
+import { FormFileUploadContext } from './useFormFileUpload'
+import SelectField, { SelectOption } from './widget-components/SelectField/SelectField'
+
+export type FormsPlaygroundProps = {
+  formDefinitions: FormDefinition[]
+  devFormDefinitions: FormDefinition[]
+  exampleForms: typeof exampleForms
+  exampleDevForms: typeof exampleDevForms
+}
+
+type FormPlaygroundProvidersProps = {
+  formData: GenericObjectType
+  setFormData: React.Dispatch<React.SetStateAction<GenericObjectType>>
+  files: Record<string, FileInfo>
+  setFiles: React.Dispatch<React.SetStateAction<Record<string, FileInfo>>>
+  children: React.ReactNode
+}
+
+const FormPlaygroundProviders = ({
+  formData,
+  setFormData,
+  files,
+  setFiles,
+  children,
+}: FormPlaygroundProvidersProps) => {
+  const formFileUploadContextValue = useMemo(
+    () =>
+      ({
+        removeFiles: (fileIds: string[]) => {
+          setFiles((prevFiles) => {
+            const newFiles = { ...prevFiles }
+            fileIds.forEach((fileId) => {
+              delete newFiles[fileId]
+            })
+            return newFiles
+          })
+        },
+        uploadFiles: (filesInner: File[]) => {
+          const newFiles: Record<string, FileInfo> = {}
+          filesInner.forEach((file) => {
+            const id = uuidv4()
+            newFiles[id] = {
+              fileName: file.name,
+              fileSize: file.size,
+              status: { type: FileStatusType.ScanDone },
+            }
+          })
+          setFiles((prevFiles) => ({ ...prevFiles, ...newFiles }))
+          return Object.keys(newFiles)
+        },
+        getFileInfoById: (fileId: string): FileInfo => {
+          const file = files[fileId]
+          if (!file) {
+            return {
+              status: { type: FileStatusType.UnknownFile },
+              fileName: fileId,
+              fileSize: null,
+            }
+          }
+          return file
+        },
+      }) as Partial<ContextType<typeof FormFileUploadContext>>,
+    [files, setFiles],
+  )
+
+  const formDataContextValue = useMemo(
+    () => ({ formData, setFormData }) as Partial<ContextType<typeof FormDataContext>>,
+    [formData, setFormData],
+  )
+
+  return (
+    <FormFileUploadContext.Provider
+      value={formFileUploadContextValue as ContextType<typeof FormFileUploadContext>}
+    >
+      <FormDataContext.Provider value={formDataContextValue as ContextType<typeof FormDataContext>}>
+        {children}
+      </FormDataContext.Provider>
+    </FormFileUploadContext.Provider>
+  )
+}
+
+const FormsPlayground = ({ formDefinitions, devFormDefinitions }: FormsPlaygroundProps) => {
+  const { transformErrors } = useFormErrorTranslations()
+  const formRef = createRef<Form>()
+  const allForms = useMemo(
+    () => [...formDefinitions, ...devFormDefinitions],
+    [formDefinitions, devFormDefinitions],
+  )
+  const [formInstanceIndex, setFormInstanceIndex] = useState(0)
+  const forceReset = () => setFormInstanceIndex((prev) => prev + 1)
+
+  const [slug, setSlug] = useQueryState('slug', { defaultValue: allForms[0].slug })
+  useEffectOnce(() => {
+    // Initially if the query param is not present this sets it (`currentStepIndex` already contains default value)
+    // https://github.com/47ng/nuqs/issues/405
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    setSlug(slug, { history: 'replace' })
+  })
+
+  const [selectedExampleName, setSelectedExampleName] = useState<string>('')
+  const [files, setFiles] = useState<Record<string, FileInfo>>({})
+
+  const selectedForm = useMemo(() => {
+    return allForms.find((form) => form.slug === slug) || null
+  }, [allForms, slug])
+
+  const defaultFormData = useMemo(
+    () => (selectedForm ? baGetDefaultFormStateStable(selectedForm.schemas.schema, {}) : {}),
+    [selectedForm],
+  )
+
+  const [formData, setFormData] = useState(defaultFormData)
+  const [jsonInput, setJsonInput] = useState(JSON.stringify(defaultFormData, null, 2))
+
+  const [openSnackbarSuccess] = useSnackbar({ variant: 'success' })
+  const [openSnackbarError] = useSnackbar({ variant: 'error' })
+  const { t } = useTranslation('forms')
+  const importJsonInputRef = useRef<HTMLInputElement>(null)
+
+  const handleFormSelect = (option: SelectOption | null) => {
+    if (option) {
+      const newSlug = option.value
+      setSlug(newSlug)
+      setSelectedExampleName('')
+      const newForm = allForms.find((form) => form.slug === newSlug)
+      if (newForm) {
+        const newDefaultData = baGetDefaultFormStateStable(newForm.schemas.schema, {})
+        setFormData(newDefaultData)
+        setJsonInput(JSON.stringify(newDefaultData, null, 2))
+        setFiles({})
+      }
+      forceReset()
+    }
+  }
+
+  const handleExampleSelect = (selectedValue: string | null) => {
+    if (selectedValue == null) {
+      return
+    }
+    setSelectedExampleName(selectedValue)
+
+    if (selectedValue === '') {
+      setFormData(defaultFormData)
+      setJsonInput(JSON.stringify(defaultFormData, null, 2))
+      setFiles({})
+      forceReset()
+
+      return
+    }
+
+    if (selectedForm) {
+      const currentFormExamples = exampleForms[selectedForm.slug] || []
+      const selectedExample = currentFormExamples.find((ex) => ex.name === selectedValue)
+
+      if (selectedExample) {
+        setFormData(selectedExample.formData)
+        setJsonInput(JSON.stringify(selectedExample.formData, null, 2))
+        setFiles(
+          mergeClientAndServerFiles(
+            selectedExample.clientFiles || [],
+            selectedExample.serverFiles || [],
+          ),
+        )
+        forceReset()
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(`Example "${selectedValue}" not found for form "${selectedForm.slug}"`)
+        setFormData(defaultFormData)
+        setJsonInput(JSON.stringify(defaultFormData, null, 2))
+        setFiles({})
+        forceReset()
+      }
+    }
+  }
+
+  const handleJsonInputChange = (value: string | undefined) => {
+    if (value) {
+      setJsonInput(value)
+    }
+  }
+
+  const handleJsonInputBlur = () => {
+    try {
+      const parsedData = JSON.parse(jsonInput)
+      setFormData(parsedData)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Invalid JSON input')
+      setJsonInput(JSON.stringify(formData, null, 2))
+    }
+  }
+
+  const exportJson = () => {
+    const fileName = `${selectedForm?.slug}_output.json`
+    const jsonBlob = new Blob([JSON.stringify(formData, null, 2)], { type: 'application/json' })
+    downloadBlob(jsonBlob, fileName)
+    openSnackbarSuccess(t('success_messages.json_export'))
+  }
+
+  const triggerImportJson = () => {
+    importJsonInputRef.current?.click()
+  }
+
+  const handleImportJson = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    try {
+      const jsonForm = await file.text()
+      const parsed = JSON.parse(jsonForm)
+      setFormData(parsed)
+      setJsonInput(JSON.stringify(parsed, null, 2))
+      openSnackbarSuccess(t('success_messages.json_import'))
+    } catch (error) {
+      openSnackbarError(t('errors.json_import'))
+    }
+
+    // Reset the file input
+    if (importJsonInputRef.current) {
+      importJsonInputRef.current.value = ''
+    }
+  }
+
+  const handleValidateForm = () => {
+    formRef.current?.submit()
+  }
+
+  const formOptions = useMemo(
+    () => [
+      {
+        label: 'Forms',
+        options: formDefinitions.map((form) => ({
+          value: form.slug,
+          label: form.title || form.slug,
+        })),
+      },
+      {
+        label: 'Dev Forms',
+        options: devFormDefinitions.map((form) => ({
+          value: form.slug,
+          label: form.title || form.slug,
+        })),
+      },
+    ],
+    [formDefinitions, devFormDefinitions],
+  )
+
+  const exampleOptions: SelectOption[] = useMemo(() => {
+    if (!selectedForm) return []
+    const currentFormExamples = exampleForms[selectedForm.slug] || []
+    return [
+      { value: '', label: 'Prázdny formulár' },
+      ...currentFormExamples.map((example) => ({
+        value: example.name,
+        label: example.name,
+      })),
+    ]
+  }, [selectedForm])
+
+  return (
+    <FormPlaygroundProviders
+      formData={formData}
+      setFormData={setFormData}
+      files={files}
+      setFiles={setFiles}
+    >
+      <div className="flex flex-col lg:flex-row">
+        <div className="w-full p-4 lg:sticky lg:top-0 lg:h-screen lg:w-1/3 lg:overflow-y-auto">
+          <SelectField
+            options={formOptions}
+            value={
+              selectedForm
+                ? formOptions
+                    .flatMap((group) => group.options)
+                    .find((option) => option.value === selectedForm.slug)
+                : null
+            }
+            onChange={handleFormSelect}
+            label="Zvoliť formulár"
+            className="mb-4"
+          />
+
+          <SelectField
+            options={exampleOptions}
+            value={exampleOptions.find((option) => option.value === selectedExampleName)}
+            onChange={(option) => handleExampleSelect(option?.value ?? null)}
+            label="Zvoliť data"
+            className="mb-4"
+          />
+
+          <Editor
+            height="400px"
+            defaultLanguage="json"
+            value={jsonInput}
+            onChange={handleJsonInputChange}
+            onMount={(editor) => {
+              editor.onDidBlurEditorWidget(() => handleJsonInputBlur())
+            }}
+            options={{
+              minimap: { enabled: false },
+              formatOnPaste: true,
+              formatOnType: true,
+            }}
+          />
+
+          <div className="mt-4 flex gap-2">
+            <Button onPress={exportJson} variant="black-solid" startIcon={<DownloadIcon />}>
+              {t('menu_list.download_json')}
+            </Button>
+            <Button onPress={triggerImportJson} variant="black-outline" startIcon={<UploadIcon />}>
+              {t('menu_list.upload_json')}
+            </Button>
+            <input
+              type="file"
+              ref={importJsonInputRef}
+              onChange={handleImportJson}
+              accept=".json"
+              className="hidden"
+            />
+          </div>
+
+          <div className="mt-4 flex gap-2">
+            <Button onPress={handleValidateForm} variant="black-outline">
+              Validovať formulár
+            </Button>
+            <Button onPress={forceReset} variant="black-outline">
+              Reštartovať formulár
+            </Button>
+          </div>
+        </div>
+        <div className="w-full p-4 lg:mx-auto lg:w-2/3 lg:max-w-[800px]">
+          {selectedForm ? (
+            <ThemedForm
+              key={`form-instance-${formInstanceIndex}`}
+              schema={selectedForm.schemas.schema}
+              uiSchema={selectedForm.schemas.uiSchema}
+              formData={formData}
+              onChange={(e) => {
+                setFormData(e.formData)
+                setJsonInput(JSON.stringify(e.formData, null, 2))
+              }}
+              noHtml5Validate
+              showErrorList={false}
+              omitExtraData
+              liveOmit
+              transformErrors={transformErrors}
+              ref={formRef}
+              {...baFormDefaults}
+            >
+              {/* eslint-disable-next-line react/jsx-no-useless-fragment */}
+              <></>
+            </ThemedForm>
+          ) : null}
+        </div>
+      </div>
+    </FormPlaygroundProviders>
+  )
+}
+
+export default FormsPlayground

--- a/next/components/forms/segments/FormCalculator/FormCalculator.tsx
+++ b/next/components/forms/segments/FormCalculator/FormCalculator.tsx
@@ -1,5 +1,6 @@
 import { GenericObjectType } from '@rjsf/utils'
 import cx from 'classnames'
+import { useFormData } from 'components/forms/useFormData'
 import {
   calculateFormCalculatorExpression,
   getFormCalculatorExpression,
@@ -13,7 +14,6 @@ import React, { useMemo } from 'react'
 import { useNumberFormatter } from 'react-aria'
 
 import FormMarkdown from '../../info-components/FormMarkdown'
-import { useFormState } from '../../useFormState'
 import { useFormWidget } from '../../useFormWidget'
 import AccountMarkdown from '../AccountMarkdown/AccountMarkdown'
 
@@ -67,7 +67,7 @@ const Calculator = ({
   variant: CustomComponentCalculatorProps['variant']
 }) => {
   const formatter = useNumberFormatter()
-  const { formData } = useFormState()
+  const { formData } = useFormData()
   const { widget } = useFormWidget()
 
   const expression = useMemo(() => getFormCalculatorExpression(formula, true), [formula])

--- a/next/components/forms/segments/FormModals/FormModals.tsx
+++ b/next/components/forms/segments/FormModals/FormModals.tsx
@@ -1,4 +1,5 @@
 import { getUiOptions } from '@rjsf/utils'
+import { useFormData } from 'components/forms/useFormData'
 import { getFormTitle } from 'frontend/utils/general'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
@@ -9,7 +10,6 @@ import Button from '../../simple-components/ButtonNew'
 import { useFormContext } from '../../useFormContext'
 import { useFormModals } from '../../useFormModals'
 import { useFormRedirects } from '../../useFormRedirects'
-import { useFormState } from '../../useFormState'
 import MessageModal, { MessageModalProps } from '../../widget-components/Modals/MessageModal'
 import AccountMarkdown from '../AccountMarkdown/AccountMarkdown'
 import IdentityVerificationModal from '../IdentityVerificationModal/IdentityVerificationModal'
@@ -73,7 +73,7 @@ const FormModals = () => {
       schemas: { uiSchema },
     },
   } = useFormContext()
-  const { formData } = useFormState()
+  const { formData } = useFormData()
   const uiOptions = getUiOptions(uiSchema)
   const title = getFormTitle(formData, uiOptions, t('form_title_fallback'))
 

--- a/next/components/forms/signer/useFormSignature.tsx
+++ b/next/components/forms/signer/useFormSignature.tsx
@@ -17,9 +17,9 @@ import { useIsClient, useIsMounted } from 'usehooks-ts'
 import useSnackbar from '../../../frontend/hooks/useSnackbar'
 import { createFormSignatureId } from '../../../frontend/utils/formSignature'
 import { useFormContext } from '../useFormContext'
+import { useFormData } from '../useFormData'
 import { useFormLeaveProtection } from '../useFormLeaveProtection'
 import { useFormModals } from '../useFormModals'
-import { useFormState } from '../useFormState'
 import { SignerErrorType } from './mapDitecError'
 // kept while it might be usefull for local testing
 // import { signerExamplePayload } from './signerExamplePayload'
@@ -44,7 +44,7 @@ const useGetContext = () => {
   const [openSnackbarError] = useSnackbar({ variant: 'error' })
   const { setSignerIsDeploying } = useFormModals()
   const { isSigned, initialSignature } = useFormContext()
-  const { formData, formDataRef } = useFormState()
+  const { formData, formDataRef } = useFormData()
   const { turnOnLeaveProtection } = useFormLeaveProtection()
   const { sign: signerSign } = useFormSigner({
     onDeploymentStatusChange: (status) => {

--- a/next/components/forms/steps/Summary/SummaryAdditionalInfo.tsx
+++ b/next/components/forms/steps/Summary/SummaryAdditionalInfo.tsx
@@ -1,15 +1,15 @@
+import { useFormData } from 'components/forms/useFormData'
 import { renderFormAdditionalInfo } from 'forms-shared/string-templates/renderTemplate'
 import { useTranslation } from 'next-i18next'
 import React, { useMemo } from 'react'
 
 import AccountMarkdown from '../../segments/AccountMarkdown/AccountMarkdown'
 import { useFormContext } from '../../useFormContext'
-import { useFormState } from '../../useFormState'
 
 const SummaryAdditionalInfo = () => {
   const { t } = useTranslation('forms')
   const { formDefinition } = useFormContext()
-  const { formData } = useFormState()
+  const { formData } = useFormData()
   const additionalInfo = useMemo(
     () => renderFormAdditionalInfo(formDefinition, formData, true),
     [formDefinition, formData],

--- a/next/components/forms/steps/Summary/SummaryDetails.tsx
+++ b/next/components/forms/steps/Summary/SummaryDetails.tsx
@@ -1,4 +1,5 @@
 import { AlertIcon, ChevronDownIcon } from '@assets/ui-icons'
+import { useFormData } from 'components/forms/useFormData'
 import { getSummaryJsonBrowser } from 'forms-shared/summary-json/getSummaryJsonBrowser'
 import { getSummaryJsonNode } from 'forms-shared/summary-json/getSummaryJsonNode'
 import {
@@ -19,7 +20,6 @@ import { useFormState } from '../../useFormState'
 import SummaryFile from './SummaryFile'
 import SummaryRow from './SummaryRow'
 import { useFormSummary } from './useFormSummary'
-import { useFormData } from 'components/forms/useFormData'
 
 const FormRenderer = ({ children }: SummaryFormRendererProps) => (
   <div className="flex flex-col gap-8">{children}</div>

--- a/next/components/forms/steps/Summary/SummaryDetails.tsx
+++ b/next/components/forms/steps/Summary/SummaryDetails.tsx
@@ -19,6 +19,7 @@ import { useFormState } from '../../useFormState'
 import SummaryFile from './SummaryFile'
 import SummaryRow from './SummaryRow'
 import { useFormSummary } from './useFormSummary'
+import { useFormData } from 'components/forms/useFormData'
 
 const FormRenderer = ({ children }: SummaryFormRendererProps) => (
   <div className="flex flex-col gap-8">{children}</div>
@@ -135,7 +136,7 @@ const ArrayItemRenderer = ({ arrayItem, children, hasError }: SummaryArrayItemRe
 }
 
 const SummaryDetails = () => {
-  const { formData } = useFormState()
+  const { formData } = useFormData()
   const { getValidatedSummary } = useFormSummary()
   const validatedSummary = getValidatedSummary()
   const {

--- a/next/components/forms/steps/Summary/useFormSummary.tsx
+++ b/next/components/forms/steps/Summary/useFormSummary.tsx
@@ -1,4 +1,5 @@
 import { useDeepMemo } from '@react-aria/utils'
+import { useFormData } from 'components/forms/useFormData'
 import {
   FileStatusType,
   isInfectedFileStatusType,
@@ -38,7 +39,8 @@ const useGetContext = () => {
       schemas: { schema },
     },
   } = useFormContext()
-  const { formData, currentStepIndex } = useFormState()
+  const { formData } = useFormData()
+  const { currentStepIndex } = useFormState()
 
   const { clientFiles, serverFiles } = useFormFileUpload()
   // Don't use directly!

--- a/next/components/forms/useFormData.tsx
+++ b/next/components/forms/useFormData.tsx
@@ -1,0 +1,35 @@
+import { GenericObjectType } from '@rjsf/utils'
+import React, { createContext, PropsWithChildren, useContext } from 'react'
+import useStateRef from 'react-usestateref'
+
+import { useFormContext } from './useFormContext'
+
+const useGetContext = () => {
+  const { initialFormDataJson } = useFormContext()
+  const [formData, setFormData, formDataRef] = useStateRef<GenericObjectType>(initialFormDataJson)
+
+  return {
+    formData,
+    formDataRef,
+    setFormData,
+  }
+}
+
+export const FormDataContext = createContext<ReturnType<typeof useGetContext> | undefined>(
+  undefined,
+)
+
+export const FormDataProvider = ({ children }: PropsWithChildren) => {
+  const context = useGetContext()
+
+  return <FormDataContext.Provider value={context}>{children}</FormDataContext.Provider>
+}
+
+export const useFormData = () => {
+  const context = useContext(FormDataContext)
+  if (!context) {
+    throw new Error('useFormState must be used within a FormStateProvider')
+  }
+
+  return context
+}

--- a/next/components/forms/useFormFileUpload.tsx
+++ b/next/components/forms/useFormFileUpload.tsx
@@ -318,7 +318,9 @@ export const useGetContext = () => {
   }
 }
 
-const FormFileUploadContext = createContext<ReturnType<typeof useGetContext> | undefined>(undefined)
+export const FormFileUploadContext = createContext<ReturnType<typeof useGetContext> | undefined>(
+  undefined,
+)
 
 export const FormFileUploadProvider = ({ children }: PropsWithChildren) => {
   const context = useGetContext()

--- a/next/components/forms/useFormRedirects.tsx
+++ b/next/components/forms/useFormRedirects.tsx
@@ -9,14 +9,14 @@ import { useQueryParamRedirect } from '../../frontend/hooks/useQueryParamRedirec
 import useSnackbar from '../../frontend/hooks/useSnackbar'
 import { useFormSignature } from './signer/useFormSignature'
 import { useFormContext } from './useFormContext'
+import { useFormData } from './useFormData'
 import { useFormLeaveProtection } from './useFormLeaveProtection'
-import { useFormState } from './useFormState'
 
 const useGetContext = () => {
   const router = useRouter()
   const { getRouteWithCurrentUrlRedirect } = useQueryParamRedirect()
   const { formId } = useFormContext()
-  const { formData } = useFormState()
+  const { formData } = useFormData()
   const { t } = useTranslation('forms')
   const [openSnackbarInfo, closeSnackbarInfo] = useSnackbar({ variant: 'info' })
   const [openSnackbarError] = useSnackbar({ variant: 'error' })

--- a/next/components/forms/useFormSend.tsx
+++ b/next/components/forms/useFormSend.tsx
@@ -21,10 +21,10 @@ import { RegistrationModalType } from './segments/RegistrationModal/Registration
 import { useFormSignature } from './signer/useFormSignature'
 import { useFormSummary } from './steps/Summary/useFormSummary'
 import { useFormContext } from './useFormContext'
+import { useFormData } from './useFormData'
 import { useFormLeaveProtection } from './useFormLeaveProtection'
 import { useFormModals } from './useFormModals'
 import { useFormSent } from './useFormSent'
-import { useFormState } from './useFormState'
 
 /**
  * This hook controls the sending of the form. The logic is scattered across the app.
@@ -61,7 +61,7 @@ const useGetContext = () => {
     formId,
     formDefinition: { slug },
   } = useFormContext()
-  const { formData } = useFormState()
+  const { formData } = useFormData()
   const { getValidatedSummary, getUploadFiles, getScanFiles } = useFormSummary()
   const {
     isSignedIn,

--- a/next/components/forms/useFormState.tsx
+++ b/next/components/forms/useFormState.tsx
@@ -10,7 +10,6 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import useStateRef from 'react-usestateref'
 import { useIsFirstRender } from 'usehooks-ts'
 
 import {
@@ -23,6 +22,7 @@ import {
 import { FormStepIndex } from './types/Steps'
 import { useFormContext } from './useFormContext'
 import { useFormCurrentStepIndex } from './useFormCurrentStepIndex'
+import { useFormData } from './useFormData'
 import { useFormFileUpload } from './useFormFileUpload'
 import { useFormLeaveProtection } from './useFormLeaveProtection'
 import { useFormModals } from './useFormModals'
@@ -33,15 +33,14 @@ const useGetContext = () => {
       schemas: { schema, uiSchema },
     },
     formMigrationRequired,
-    initialFormDataJson,
     isReadonly,
   } = useFormContext()
+  const { formData, setFormData } = useFormData()
   const { keepFiles, refetchAfterImportIfNeeded, clientFiles, serverFiles } = useFormFileUpload()
   const { turnOnLeaveProtection } = useFormLeaveProtection()
   // eslint-disable-next-line testing-library/render-result-naming-convention
   const isFirst = useIsFirstRender()
 
-  const [formData, setFormData, formDataRef] = useStateRef<GenericObjectType>(initialFormDataJson)
   const stepsSchemas = useMemo(() => getEvaluatedStepsSchemas(schema, formData), [schema, formData])
 
   /**
@@ -205,8 +204,6 @@ const useGetContext = () => {
   }
 
   return {
-    formData,
-    formDataRef,
     currentStepIndex,
     submittedStepsIndexes,
     stepperData,
@@ -225,7 +222,9 @@ const useGetContext = () => {
   }
 }
 
-const FormStateContext = createContext<ReturnType<typeof useGetContext> | undefined>(undefined)
+export const FormStateContext = createContext<ReturnType<typeof useGetContext> | undefined>(
+  undefined,
+)
 
 export const FormStateProvider = ({ children }: PropsWithChildren) => {
   const context = useGetContext()

--- a/next/components/forms/widget-wrappers/BAObjectFieldTemplate.tsx
+++ b/next/components/forms/widget-wrappers/BAObjectFieldTemplate.tsx
@@ -1,5 +1,6 @@
 import { getUiOptions, ObjectFieldTemplateProps } from '@rjsf/utils'
 import cx from 'classnames'
+import { getObjectFieldInfo } from 'forms-shared/form-utils/getObjectFieldInfo'
 import { ObjectFieldUiOptions } from 'forms-shared/generator/uiOptionsTypes'
 import { PropsWithChildren } from 'react'
 
@@ -48,11 +49,20 @@ const ColumnDisplay = ({
  * This implementation removes `TitleFieldTemplate` and `DescriptionFieldTemplate` from the
  * implementation and displays them directly.
  */
-const BAObjectFieldTemplate = ({ idSchema, properties, uiSchema }: ObjectFieldTemplateProps) => {
+const BAObjectFieldTemplate = ({
+  idSchema,
+  properties,
+  schema,
+  uiSchema,
+}: ObjectFieldTemplateProps) => {
   const options = getUiOptions(uiSchema) as ObjectFieldUiOptions
+  const { isStepObject, isFormObject } = getObjectFieldInfo(idSchema)
   const defaultSpacing = {
-    wrapper: {},
-    boxed: { spaceBottom: 'medium' as const, spaceTop: 'medium' as const },
+    wrapper: isFormObject ? { spaceTop: 'none' as const } : {},
+    boxed: {
+      spaceBottom: 'medium' as const,
+      spaceTop: 'medium' as const,
+    },
   }[options.objectDisplay ?? 'wrapper']
 
   const fieldsetClassname = cx({
@@ -62,11 +72,20 @@ const BAObjectFieldTemplate = ({ idSchema, properties, uiSchema }: ObjectFieldTe
   return (
     <WidgetWrapper id={idSchema.$id} options={options} defaultSpacing={defaultSpacing}>
       <fieldset className={fieldsetClassname} data-cy={`fieldset-${idSchema.$id}`}>
-        {options.title && <h3 className="text-h3 mb-3">{options.title}</h3>}
-        {options.description && (
-          <div className="text-p2 mb-3 whitespace-pre-wrap">
-            <FormMarkdown>{options.description}</FormMarkdown>
+        {isStepObject ? (
+          <div className="mb-8 flex flex-col gap-4">
+            <h2 className="text-h2">{schema.title}</h2>
+            {schema.description && <p className="text-p2">{schema.description}</p>}
           </div>
+        ) : (
+          <>
+            {options.title && <h3 className="text-h3 mb-3">{options.title}</h3>}
+            {options.description && (
+              <div className="text-p2 mb-3 whitespace-pre-wrap">
+                <FormMarkdown>{options.description}</FormMarkdown>
+              </div>
+            )}
+          </>
         )}
         <ColumnDisplay uiOptions={options}>
           {properties.map(({ content }, index) => {

--- a/next/frontend/hooks/useFormExportImport.tsx
+++ b/next/frontend/hooks/useFormExportImport.tsx
@@ -12,6 +12,7 @@ import React, { createContext, PropsWithChildren, useContext, useRef } from 'rea
 import { RegistrationModalType } from '../../components/forms/segments/RegistrationModal/RegistrationModal'
 import { useFormSignature } from '../../components/forms/signer/useFormSignature'
 import { useFormContext } from '../../components/forms/useFormContext'
+import { useFormData } from '../../components/forms/useFormData'
 import { useFormFileUpload } from '../../components/forms/useFormFileUpload'
 import { useFormLeaveProtection } from '../../components/forms/useFormLeaveProtection'
 import { useFormModals } from '../../components/forms/useFormModals'
@@ -28,7 +29,8 @@ export const useGetContext = () => {
     formId,
     isTaxForm,
   } = useFormContext()
-  const { formData, setImportedFormData } = useFormState()
+  const { setImportedFormData } = useFormState()
+  const { formData } = useFormData()
   const { setRegistrationModal, setTaxFormPdfExportModal } = useFormModals()
   const { t } = useTranslation('forms')
   const { setConceptSaveErrorModal } = useFormModals()

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -16,6 +16,7 @@
         "@iframe-resizer/child": "^5.2.1",
         "@internationalized/date": "3.5.4",
         "@jest/globals": "^29.5.0",
+        "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-navigation-menu": "^1.1.4",
         "@react-aria/utils": "3.24.1",
@@ -206,7 +207,7 @@
         "@prettier/sync": "^0.5.2",
         "@types/app-root-dir": "^0.1.4",
         "@types/archiver": "^6.0.2",
-        "@types/jest": "^29.5.12",
+        "@types/jest": "^29.5.13",
         "@types/jest-image-snapshot": "^6.4.0",
         "@types/jsdom": "^21.1.6",
         "@types/json-schema": "7.0.15",
@@ -6617,6 +6618,32 @@
       "integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@next/bundle-analyzer": {
       "version": "14.2.3",
@@ -23402,6 +23429,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.51.0.tgz",
+      "integrity": "sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/mrmime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
@@ -27182,6 +27216,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",

--- a/next/package.json
+++ b/next/package.json
@@ -46,6 +46,7 @@
     "@iframe-resizer/child": "^5.2.1",
     "@internationalized/date": "3.5.4",
     "@jest/globals": "^29.5.0",
+    "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@react-aria/utils": "3.24.1",

--- a/next/pages/forms-playground.ts
+++ b/next/pages/forms-playground.ts
@@ -1,0 +1,27 @@
+import { devFormDefinitions } from 'forms-shared/definitions/devFormDefinitions'
+import { formDefinitions } from 'forms-shared/definitions/formDefinitions'
+import { exampleDevForms, exampleForms } from 'forms-shared/example-forms/exampleForms'
+
+import FormsPlayground, { FormsPlaygroundProps } from '../components/forms/FormsPlayground'
+import { SsrAuthProviderHOC } from '../components/logic/SsrAuthContext'
+import { environment } from '../environment'
+import { amplifyGetServerSideProps } from '../frontend/utils/amplifyServer'
+import { slovakServerSideTranslations } from '../frontend/utils/slovakServerSideTranslations'
+
+export const getServerSideProps = amplifyGetServerSideProps<FormsPlaygroundProps>(async () => {
+  if (!environment.featureToggles.developmentForms) {
+    return { notFound: true }
+  }
+
+  return {
+    props: {
+      formDefinitions,
+      devFormDefinitions,
+      exampleForms,
+      exampleDevForms,
+      ...(await slovakServerSideTranslations()),
+    },
+  }
+})
+
+export default SsrAuthProviderHOC(FormsPlayground)


### PR DESCRIPTION
Commit by commit.

- Install @monaco-editor/react
- Extract getting info about object fields to getObjectFieldInfo
- Display form step title and description in object template instead of form wrapper (this is needed for playground and is generally a better place to do so)
- Extract formData from useFormState to its own hook useFormData, this is needed in playground in order to not mock the whole useFormState object
- Export FormFileUploadContext to be mocked
- Create FormsPlayground

![image](https://github.com/user-attachments/assets/2ce3973b-2519-41be-b683-d158b8af7034)
