### PR TITLE
Configure resources limits for clamav

### DIFF
--- a/clamav/kubernetes/base/deployment.yml
+++ b/clamav/kubernetes/base/deployment.yml
@@ -26,10 +26,11 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 8Gi
+              cpu: ${CPU_LIMITS}
+              memory: ${MEMORY_LIMITS}
             requests:
-              cpu: 100m
-              memory: 2Gi
+              cpu: ${CPU_REQUESTS}
+              memory: ${MEMORY_REQUESTS}
           volumeMounts:
             - name: data-vol
               mountPath: /data

--- a/clamav/kubernetes/envs/Dev/config.json
+++ b/clamav/kubernetes/envs/Dev/config.json
@@ -1,5 +1,9 @@
 {
   "envs": {
-    "REPLICAS": "1"
+    "REPLICAS": "1",
+    "CPU_LIMITS": "0",
+    "MEMORY_LIMITS": "0",
+    "CPU_REQUESTS": "0",
+    "MEMORY_REQUESTS": "0"
   }
 }

--- a/clamav/kubernetes/envs/Prod/config.json
+++ b/clamav/kubernetes/envs/Prod/config.json
@@ -1,5 +1,9 @@
 {
   "envs": {
-    "REPLICAS": "1"
+    "REPLICAS": "1",
+    "CPU_LIMITS": "1",
+    "MEMORY_LIMITS": "8Gi",
+    "CPU_REQUESTS": "100m",
+    "MEMORY_REQUESTS": "2Gi"
   }
 }

--- a/clamav/kubernetes/envs/Staging/config.json
+++ b/clamav/kubernetes/envs/Staging/config.json
@@ -1,5 +1,9 @@
 {
   "envs": {
-    "REPLICAS": "1"
+    "REPLICAS": "1",
+    "CPU_LIMITS": "0",
+    "MEMORY_LIMITS": "0",
+    "CPU_REQUESTS": "0",
+    "MEMORY_REQUESTS": "0"
   }
 }


### PR DESCRIPTION
On staging kubernetes for last clamav deploymen we got this error:
`0/5 nodes are available: 1 Insufficient memory, 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 3 Insufficient cpu.`
I added option to configure resources per cluster. Now on dev and staging are resources on `best-effort` with is done by setting a value to `0`
