### PR TITLE
added fetch-depth option

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
       directory: forms-shared/
       build_image_no_registry: ''
       tag: '--tag=${{ github.ref_name }}-${{ github.sha }}'
+      fetch-depth: 1
     secrets:
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
 
@@ -35,6 +36,7 @@ jobs:
       url: https://tkg.dev.bratislava.sk
       debug: --debug
       version: beta
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.DEV_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -51,6 +53,7 @@ jobs:
       url: https://tkg.dev.bratislava.sk
       debug: --debug
       version: beta
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.DEV_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -66,6 +69,7 @@ jobs:
       url: https://tkg.dev.bratislava.sk
       debug: --debug
       version: beta
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.DEV_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -82,6 +86,7 @@ jobs:
       url: https://tkg.dev.bratislava.sk
       debug: --debug
       version: beta
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.DEV_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -97,6 +102,7 @@ jobs:
       url: https://tkg.dev.bratislava.sk
       debug: --debug
       version: beta
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.DEV_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -112,6 +118,7 @@ jobs:
       url: https://tkg.dev.bratislava.sk
       debug: --debug
       version: beta
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.DEV_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -127,6 +134,7 @@ jobs:
       url: https://tkg.dev.bratislava.sk
       debug: --debug
       version: beta
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.DEV_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -143,6 +151,7 @@ jobs:
       url: https://tkg.staging.bratislava.sk
       debug: --debug
       flag: --staging
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -159,6 +168,7 @@ jobs:
       url: https://tkg.staging.bratislava.sk
       debug: --debug
       flag: --staging
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -174,6 +184,7 @@ jobs:
       url: https://tkg.staging.bratislava.sk
       debug: --debug
       flag: --staging
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -190,6 +201,7 @@ jobs:
       url: https://tkg.staging.bratislava.sk
       debug: --debug
       flag: --staging
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -205,6 +217,7 @@ jobs:
       url: https://tkg.staging.bratislava.sk
       debug: --debug
       flag: --staging
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -220,6 +233,7 @@ jobs:
       url: https://tkg.staging.bratislava.sk
       debug: --debug
       flag: --staging
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -235,6 +249,7 @@ jobs:
       url: https://tkg.staging.bratislava.sk
       debug: --debug
       flag: --staging
+      fetch-depth: 1
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -250,6 +265,7 @@ jobs:
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
+      fetch-depth: 1
       debug: --debug
     secrets:
       service-account: ${{ secrets.PROD_STANDALONE_TOKEN }}
@@ -266,6 +282,7 @@ jobs:
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
+      fetch-depth: 1
       debug: --debug
     secrets:
       service-account: ${{ secrets.PROD_STANDALONE_TOKEN }}
@@ -281,6 +298,7 @@ jobs:
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
+      fetch-depth: 1
       debug: --debug
     secrets:
       service-account: ${{ secrets.PROD_STANDALONE_TOKEN }}
@@ -297,6 +315,7 @@ jobs:
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
+      fetch-depth: 1
       debug: --debug
     secrets:
       service-account: ${{ secrets.PROD_STANDALONE_TOKEN }}
@@ -312,6 +331,7 @@ jobs:
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
+      fetch-depth: 1
       debug: --debug
     secrets:
       service-account: ${{ secrets.PROD_STANDALONE_TOKEN }}
@@ -327,6 +347,7 @@ jobs:
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
+      fetch-depth: 1
       debug: --debug
     secrets:
       service-account: ${{ secrets.PROD_STANDALONE_TOKEN }}
@@ -342,6 +363,7 @@ jobs:
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
+      fetch-depth: 1
       debug: --debug
     secrets:
       service-account: ${{ secrets.PROD_STANDALONE_TOKEN }}

--- a/.github/workflows/validate-and-build.yml
+++ b/.github/workflows/validate-and-build.yml
@@ -17,6 +17,7 @@ jobs:
       directory: forms-shared/
       build_image_no_registry: ''
       tag: '--tag=${{ github.sha }}'
+      fetch-depth: 1
     secrets:
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
 
@@ -44,6 +45,7 @@ jobs:
       directory: next/
       build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
       debug: --debug
+      fetch-depth: 1
     secrets:
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
     permissions: write-all
@@ -56,6 +58,7 @@ jobs:
     with:
       directory: strapi/
       debug: --debug
+      fetch-depth: 1
     permissions: write-all
 
   validate-nest-forms-backend:
@@ -75,6 +78,7 @@ jobs:
     with:
       directory: nest-forms-backend/
       build_arg: '--build_arg="FORMS_SHARED_TAG=${{ github.sha }}"'
+      fetch-depth: 1
     secrets:
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
     permissions: write-all
@@ -95,6 +99,7 @@ jobs:
     uses: bratislava/github-actions/.github/workflows/build-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: nest-clamav-scanner/
+      fetch-depth: 1
     secrets:
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
     permissions: write-all

--- a/.github/workflows/validate-forms-shared-konto.yml
+++ b/.github/workflows/validate-forms-shared-konto.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Pipelines Version
         run: |


### PR DESCRIPTION
After the shared pipelines were updated with the [fetch-depth option](https://github.com/bratislava/github-actions/pull/31), we can now use it in Konto. We are setting the fetch-depth to 1, which means we are pulling only the current commit, not the entire commit history. This will even more speed up pipeline runs.