### PR TITLE
Allowing dependabot to run pipelines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,9 @@ updates:
     directory: '/nest-clamav-scanner'
     schedule:
       interval: 'weekly'
+
+# Specify permissions for Dependabot
+permissions:
+  pull-requests: write
+  contents: write
+  issues: write


### PR DESCRIPTION
This PR updates permissions on pipelines to make it possible run when invoked by dependabot.

