### PR TITLE
Send confirmation pdf as attachment to user in OLO forms

### DIFF
--- a/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
@@ -10,6 +10,7 @@ import * as renderSummaryEmail from 'forms-shared/summary-email/renderSummaryEma
 import * as jwt from 'jsonwebtoken'
 
 import prismaMock from '../../../../test/singleton'
+import ConvertService from '../../../convert/convert.service'
 import { FormsErrorsResponseEnum } from '../../../forms/forms.errors.enum'
 import PrismaService from '../../../prisma/prisma.service'
 import MailgunService from '../../../utils/global-services/mailgun/mailgun.service'
@@ -44,6 +45,10 @@ describe('EmailFormsSubservice', () => {
         {
           provide: ConfigService,
           useValue: createMock<ConfigService>(),
+        },
+        {
+          provide: ConvertService,
+          useValue: createMock<ConvertService>(),
         },
         ThrowerErrorGuard,
       ],

--- a/nest-forms-backend/src/utils/global-services/mailgun/mailgun.service.ts
+++ b/nest-forms-backend/src/utils/global-services/mailgun/mailgun.service.ts
@@ -134,8 +134,12 @@ export default class MailgunService {
   /**
    * Sends an email using OLO SMTP instead of Mailgun.
    * @param data Object containing the email data which should be sent.
+   * @param attachments Optional array of attachments to be sent with the email.
    */
-  async sendOloEmail(data: SendEmailInputDto): Promise<void> {
+  async sendOloEmail(
+    data: SendEmailInputDto,
+    attachments?: nodemailer.SendMailOptions['attachments'],
+  ): Promise<void> {
     try {
       const mailBody = await this.getFilledTemplate(
         MAILGUN_CONFIG[data.template].template,
@@ -147,6 +151,7 @@ export default class MailgunService {
         subject: MAILGUN_CONFIG[data.template].subject,
         // eslint-disable-next-line xss/no-mixed-html
         html: mailBody,
+        attachments,
       })
     } catch (error) {
       this.throwerErrorGuard.InternalServerErrorException(


### PR DESCRIPTION
Adds a file `potvrdenie.pdf` with the filled-in data to the confirmation email to user after sending OLO form.