### PR TITLE
change emails in schema to unified format

### DIFF
--- a/forms-shared/src/example-forms/examples/oloKoloTaxiExample.ts
+++ b/forms-shared/src/example-forms/examples/oloKoloTaxiExample.ts
@@ -20,7 +20,7 @@ const exampleForm: ExampleForm = {
       zastupeny: 'Alexander Macedónsky',
       menoKontaktnejOsoby: 'Jozef Druhý',
       telefonPravnickaOsoba: '+421944555444',
-      emailPravnickaOsoba: 'test@email.com',
+      email: 'test@email.com',
       fakturacia: {
         iban: 'SK3112000000198742637541',
         elektronickaFaktura: true,

--- a/forms-shared/src/example-forms/examples/oloMimoriadnyOdvozAZhodnotenieOdpaduExample.ts
+++ b/forms-shared/src/example-forms/examples/oloMimoriadnyOdvozAZhodnotenieOdpaduExample.ts
@@ -17,7 +17,7 @@ const exampleForm: ExampleForm = {
           psc: '84101',
         },
       },
-      emailObyvatel: 'test@email.com',
+      email: 'test@email.com',
     },
     sluzba: {
       infoOOdpade: [

--- a/forms-shared/src/schemas/olo/docisteniStanovistaZbernychNadob.ts
+++ b/forms-shared/src/schemas/olo/docisteniStanovistaZbernychNadob.ts
@@ -90,7 +90,7 @@ export default schema({ title: 'Dočistenie stanovišťa zberných nádob' }, {}
       [input('email', { title: 'E-mail', required: true, type: 'email' }, {})],
     ),
     conditionalFields(createCondition([[['ziadatelTyp'], { enum: ['Fyzická osoba'] }]]), [
-      input('emailObyvatel', { title: 'E-mail', type: 'email' }, {}),
+      input('email', { title: 'E-mail', type: 'email' }, {}),
     ]),
     object('fakturacia', { required: true }, { objectDisplay: 'boxed', title: 'Fakturácia' }, [
       input('iban', { type: 'ba-iban', title: 'IBAN', required: true }, {}),

--- a/forms-shared/src/schemas/olo/koloTaxi.ts
+++ b/forms-shared/src/schemas/olo/koloTaxi.ts
@@ -39,7 +39,7 @@ export default schema({ title: 'KOLO Taxi' }, {}, [
       ),
       sharedAddressField('adresaTrvalehoPobytu', 'Adresa trvalého pobytu', true),
       sharedPhoneNumberField('telefonPravnickaOsoba', true),
-      input('emailFyzickaOsoba', { title: 'Email', required: false, type: 'email' }, {}),
+      input('email', { title: 'Email', required: false, type: 'email' }, {}),
     ]),
     conditionalFields(createCondition([[['ziadatelTyp'], { const: 'Právnická osoba' }]]), [
       input('nazovOrganizacie', { type: 'text', title: 'Názov organizácie', required: true }, {}),
@@ -70,7 +70,7 @@ export default schema({ title: 'KOLO Taxi' }, {}, [
         {},
       ),
       sharedPhoneNumberField('telefonPravnickaOsoba', true),
-      input('emailPravnickaOsoba', { title: 'Email', required: true, type: 'email' }, {}),
+      input('email', { title: 'Email', required: true, type: 'email' }, {}),
       object('fakturacia', { required: true }, { objectDisplay: 'boxed', title: 'Fakturácia' }, [
         input('iban', { type: 'ba-iban', title: 'IBAN', required: true }, {}),
         checkbox(

--- a/forms-shared/src/schemas/olo/mimoriadnyOdvozAZhodnotenieOdpadu.ts
+++ b/forms-shared/src/schemas/olo/mimoriadnyOdvozAZhodnotenieOdpadu.ts
@@ -103,7 +103,7 @@ export default schema(
         [input('email', { title: 'E-mail', required: true, type: 'email' }, {})],
       ),
       conditionalFields(createCondition([[['ziadatelTyp'], { enum: ['Fyzická osoba'] }]]), [
-        input('emailObyvatel', { title: 'E-mail', type: 'email' }, {}),
+        input('email', { title: 'E-mail', type: 'email' }, {}),
       ]),
       conditionalFields(
         createCondition([

--- a/forms-shared/src/schemas/olo/odvozOdpaduVelkokapacitnymAleboLisovacimKontajnerom.ts
+++ b/forms-shared/src/schemas/olo/odvozOdpaduVelkokapacitnymAleboLisovacimKontajnerom.ts
@@ -91,7 +91,7 @@ export default schema({ title: 'Odvoz odpadu veľkokapacitným alebo lisovacím 
       [input('email', { title: 'E-mail', required: true, type: 'email' }, {})],
     ),
     conditionalFields(createCondition([[['ziadatelTyp'], { enum: ['Fyzická osoba'] }]]), [
-      input('emailObyvatel', { title: 'E-mail', type: 'email' }, {}),
+      input('email', { title: 'E-mail', type: 'email' }, {}),
     ]),
     object('fakturacia', { required: true }, { objectDisplay: 'boxed', title: 'Fakturácia' }, [
       input('iban', { type: 'ba-iban', title: 'IBAN', required: true }, {}),

--- a/forms-shared/src/schemas/olo/triedenyZberPapieraPlastovASklaPreSpravcovskeSpolocnosti.ts
+++ b/forms-shared/src/schemas/olo/triedenyZberPapieraPlastovASklaPreSpravcovskeSpolocnosti.ts
@@ -134,7 +134,6 @@ export default schema(
             { type: 'ba-phone-number', title: 'Nové telefónne číslo', required: true },
             { size: 'medium', helptextHeader: '+421' },
           ),
-          input('emailNovehoOdberatela', { title: 'Email', required: true, type: 'email' }, {}),
         ],
         [
           input(
@@ -142,9 +141,9 @@ export default schema(
             { type: 'ba-phone-number', title: 'Telefónne číslo', required: true },
             { size: 'medium', helptextHeader: '+421' },
           ),
-          input('email', { title: 'Email', required: true, type: 'email' }, {}),
         ],
       ),
+      input('email', { title: 'Email', required: true, type: 'email' }, {}),
 
       object('fakturacia', { required: true }, { objectDisplay: 'boxed', title: 'Fakturácia' }, [
         conditionalFields(

--- a/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
+++ b/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
@@ -1254,7 +1254,7 @@ exports[`Form definitions olo-docistenie-stanovista-zbernych-nadob schemas match
                 },
                 "then": {
                   "properties": {
-                    "emailObyvatel": {
+                    "email": {
                       "format": "email",
                       "title": "E-mail",
                       "type": "string",
@@ -1615,13 +1615,6 @@ exports[`Form definitions olo-docistenie-stanovista-zbernych-nadob schemas match
         },
         "ui:widget": "Input",
       },
-      "emailObyvatel": {
-        "ui:label": false,
-        "ui:options": {
-          "inputType": "email",
-        },
-        "ui:widget": "Input",
-      },
       "fakturacia": {
         "elektronickaFaktura": {
           "ui:options": {
@@ -1748,7 +1741,6 @@ exports[`Form definitions olo-docistenie-stanovista-zbernych-nadob schemas match
         "kontaktnaOsoba",
         "telefon",
         "email",
-        "emailObyvatel",
         "fakturacia",
       ],
       "zastupeny": {
@@ -4657,7 +4649,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
                       ],
                       "type": "object",
                     },
-                    "emailFyzickaOsoba": {
+                    "email": {
                       "format": "email",
                       "title": "Email",
                       "type": "string",
@@ -4769,7 +4761,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
                       "title": "DIČ",
                       "type": "string",
                     },
-                    "emailPravnickaOsoba": {
+                    "email": {
                       "format": "email",
                       "title": "Email",
                       "type": "string",
@@ -4857,7 +4849,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
                     "zastupeny",
                     "menoKontaktnejOsoby",
                     "telefonPravnickaOsoba",
-                    "emailPravnickaOsoba",
+                    "email",
                     "fakturacia",
                   ],
                   "type": "object",
@@ -5073,14 +5065,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
         },
         "ui:widget": "Input",
       },
-      "emailFyzickaOsoba": {
-        "ui:label": false,
-        "ui:options": {
-          "inputType": "email",
-        },
-        "ui:widget": "Input",
-      },
-      "emailPravnickaOsoba": {
+      "email": {
         "ui:label": false,
         "ui:options": {
           "inputType": "email",
@@ -5203,7 +5188,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
         "menoPriezvisko",
         "adresaTrvalehoPobytu",
         "telefonPravnickaOsoba",
-        "emailFyzickaOsoba",
+        "email",
         "nazovOrganizacie",
         "adresaSidlaOrganizacie",
         "ico",
@@ -5213,7 +5198,6 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
         "konatel",
         "zastupeny",
         "menoKontaktnejOsoby",
-        "emailPravnickaOsoba",
         "fakturacia",
       ],
       "zastupeny": {
@@ -5534,7 +5518,7 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
                 },
                 "then": {
                   "properties": {
-                    "emailObyvatel": {
+                    "email": {
                       "format": "email",
                       "title": "E-mail",
                       "type": "string",
@@ -6309,13 +6293,6 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
         },
         "ui:widget": "Input",
       },
-      "emailObyvatel": {
-        "ui:label": false,
-        "ui:options": {
-          "inputType": "email",
-        },
-        "ui:widget": "Input",
-      },
       "fakturacia": {
         "elektronickaFaktura": {
           "ui:options": {
@@ -6442,7 +6419,6 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
         "kontaktnaOsoba",
         "telefon",
         "email",
-        "emailObyvatel",
         "fakturacia",
       ],
       "zastupeny": {
@@ -7276,7 +7252,7 @@ exports[`Form definitions olo-odvoz-odpadu-velkokapacitnym-alebo-lisovacim-konta
                 },
                 "then": {
                   "properties": {
-                    "emailObyvatel": {
+                    "email": {
                       "format": "email",
                       "title": "E-mail",
                       "type": "string",
@@ -7729,13 +7705,6 @@ exports[`Form definitions olo-odvoz-odpadu-velkokapacitnym-alebo-lisovacim-konta
         },
         "ui:widget": "Input",
       },
-      "emailObyvatel": {
-        "ui:label": false,
-        "ui:options": {
-          "inputType": "email",
-        },
-        "ui:widget": "Input",
-      },
       "fakturacia": {
         "elektronickaFaktura": {
           "ui:options": {
@@ -7862,7 +7831,6 @@ exports[`Form definitions olo-odvoz-odpadu-velkokapacitnym-alebo-lisovacim-konta
         "kontaktnaOsoba",
         "telefon",
         "email",
-        "emailObyvatel",
         "fakturacia",
       ],
       "zastupeny": {
@@ -10034,11 +10002,6 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
               {
                 "else": {
                   "properties": {
-                    "email": {
-                      "format": "email",
-                      "title": "Email",
-                      "type": "string",
-                    },
                     "telefon": {
                       "format": "ba-phone-number",
                       "title": "Telefónne číslo",
@@ -10047,7 +10010,6 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
                   },
                   "required": [
                     "telefon",
-                    "email",
                   ],
                   "type": "object",
                 },
@@ -10066,11 +10028,6 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
                 },
                 "then": {
                   "properties": {
-                    "emailNovehoOdberatela": {
-                      "format": "email",
-                      "title": "Email",
-                      "type": "string",
-                    },
                     "telefonNovehoOdberatela": {
                       "format": "ba-phone-number",
                       "title": "Nové telefónne číslo",
@@ -10079,7 +10036,6 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
                   },
                   "required": [
                     "telefonNovehoOdberatela",
-                    "emailNovehoOdberatela",
                   ],
                   "type": "object",
                 },
@@ -10123,6 +10079,11 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
               },
             ],
             "properties": {
+              "email": {
+                "format": "email",
+                "title": "Email",
+                "type": "string",
+              },
               "fakturacia": {
                 "allOf": [
                   {
@@ -10232,6 +10193,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
             "required": [
               "typOdberatela",
               "menoKontaktnejOsoby",
+              "email",
               "fakturacia",
             ],
             "title": "Žiadateľ",
@@ -10726,13 +10688,6 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
         },
         "ui:widget": "Input",
       },
-      "emailNovehoOdberatela": {
-        "ui:label": false,
-        "ui:options": {
-          "inputType": "email",
-        },
-        "ui:widget": "Input",
-      },
       "fakturacia": {
         "elektronickaFaktura": {
           "ui:options": {
@@ -10926,7 +10881,6 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
         "icDph",
         "menoKontaktnejOsoby",
         "telefonNovehoOdberatela",
-        "emailNovehoOdberatela",
         "telefon",
         "email",
         "fakturacia",

--- a/forms-shared/tests/summary-json/__snapshots__/getSummaryJson.ts.snap
+++ b/forms-shared/tests/summary-json/__snapshots__/getSummaryJson.ts.snap
@@ -453,7 +453,7 @@ exports[`getSummaryJson oloDocistenieStanovistaZbernychNadobExample summary JSON
               "type": "None",
             },
           ],
-          "id": "root_ziadatel_emailObyvatel",
+          "id": "root_ziadatel_email",
           "label": "E-mail",
           "type": "Field",
         },
@@ -1470,6 +1470,18 @@ exports[`getSummaryJson oloKoloTaxiExample summary JSON should match snapshot 1`
           "displayValues": [
             {
               "type": "String",
+              "value": "test@email.com",
+            },
+          ],
+          "id": "root_ziadatel_email",
+          "label": "Email",
+          "type": "Field",
+          "value": "test@email.com",
+        },
+        {
+          "displayValues": [
+            {
+              "type": "String",
               "value": "Odpad s.r.o.",
             },
           ],
@@ -1584,18 +1596,6 @@ exports[`getSummaryJson oloKoloTaxiExample summary JSON should match snapshot 1`
           "label": "Meno kontaktnej osoby",
           "type": "Field",
           "value": "Jozef Druhý",
-        },
-        {
-          "displayValues": [
-            {
-              "type": "String",
-              "value": "test@email.com",
-            },
-          ],
-          "id": "root_ziadatel_emailPravnickaOsoba",
-          "label": "Email",
-          "type": "Field",
-          "value": "test@email.com",
         },
         {
           "displayValues": [
@@ -1798,7 +1798,7 @@ exports[`getSummaryJson oloMimoriadnyOdvozAZhodnotenieOdpaduExample summary JSON
               "value": "test@email.com",
             },
           ],
-          "id": "root_ziadatel_emailObyvatel",
+          "id": "root_ziadatel_email",
           "label": "E-mail",
           "type": "Field",
           "value": "test@email.com",


### PR DESCRIPTION
To correctly fill in data like `userEmailPath` and `userNamePath`, there should be the same path of email between physical and legal entity.