### PR TITLE
Filter GINIS details in form detail page

### DIFF
--- a/next/frontend/utils/ginis.ts
+++ b/next/frontend/utils/ginis.ts
@@ -1,24 +1,37 @@
 import { GinisDocumentDetailResponseDto } from '@clients/openapi-forms'
 
+// TODO the whole detail page needs rethinking, currently we barely show anything relevant
 // any filtering or changes to GINIS data that happen before we "reveal" them to browser
 export const modifyGinisDataForSchemaSlug = (
   data: GinisDocumentDetailResponseDto | null,
   schemaSlug: string | undefined,
 ): GinisDocumentDetailResponseDto | null => {
   if (!data || !schemaSlug) return data
-  // schemas for which we filter out contact of the person processing them
-  // this is usually because we don't want the subjects who submit the form to contact the person processing them directly
-  // instead we want to direct the requests through a single support channel
+  // dossierId coming from data is always incorrect - TODO fix this together with the rest of the detail page
+  const prefilteredData = { ...data, dossierId: '' }
+  // SUR forms want to direct support through single support email
   if (
     ['stanovisko-k-investicnemu-zameru', 'zavazne-stanovisko-k-investicnej-cinnosti'].includes(
       schemaSlug,
     )
-  )
+  ) {
     return {
-      ...data,
+      ...prefilteredData,
+
       ownerEmail: 'usmernovanievystavby@bratislava.sk',
       ownerName: '',
       ownerPhone: '',
     }
-  return data
+  }
+  // taxes want to share the contact for referents (as far as we know)
+  if (schemaSlug === 'priznanie-k-dani-z-nehnutelnosti') {
+    return prefilteredData
+  }
+  // we don't have any direction for other schemas, but we have a few complaints, so playing it safe until the details page is fixed
+  return {
+    ...prefilteredData,
+    ownerEmail: 'info@bratislava.sk',
+    ownerName: '',
+    ownerPhone: '',
+  }
 }


### PR DESCRIPTION
DossierId was always incorrect, prefer showing nothing.

In general, the detail page needs some love - this fixes incorrect data and prevents from showing data people from rental housing don't want to show - as well as assuming other clerks outside of taxes department will want to keep their emails and contacts hidden. But otherwise keeps the status quo until this page is looked at.