### PR TITLE
Clean whitespace from base64 form data before sending

### DIFF
--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.spec.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.spec.ts
@@ -177,7 +177,7 @@ describe('NasesUtilsService', () => {
         formDataJson: null,
         formDataGinis: null,
         // eslint-disable-next-line xss/no-mixed-html
-        formDataBase64: 'L:UHIOQWALIUil<tag>uh<\tag>liaUWHDL====',
+        formDataBase64: String.raw`L:UHIOQWALIUil<tag>uh<\tag>liaUWHDL====`,
         ginisDocumentId: null,
         senderId: null,
         recipientId: null,
@@ -219,7 +219,7 @@ describe('NasesUtilsService', () => {
             `          <Object Id="id-file0001" IsSigned="false" Name="file0001.pdf" Description="ATTACHMENT" Class="ATTACHMENT" MimeType="application/pdf" Encoding="Base64">TW9jayBmaWxlIGRhdGEgPHRhZz4gc3RyaW5nIDwvdGFnPj4=</Object>\n` +
             `          <Object Id="id-file0002" IsSigned="false" Name="file0002.pdf" Description="ATTACHMENT" Class="ATTACHMENT" MimeType="application/pdf" Encoding="Base64">TW9jayBmaWxlIGRhdGEgPHRhZz4gc3RyaW5nIDwvdGFnPj4=</Object>\n` +
             `          <Object Id="12345678-1234-1234-1234-123456789012" IsSigned="false" Name="printed-form.pdf" Description="ATTACHMENT" Class="ATTACHMENT" MimeType="application/pdf" Encoding="Base64">AWUKDHLAIUWDHU=====</Object>\n` +
-            `          <Object Id="123456678901234567890" IsSigned="true" Name="Priznanie k dani z nehnuteľností" Description="" Class="FORM" MimeType="application/vnd.etsi.asic-e+zip" Encoding="Base64">L:UHIOQWALIUil&lt;tag&gt;uh&lt;\tag&gt;liaUWHDL====</Object>\n` +
+            `          <Object Id="123456678901234567890" IsSigned="true" Name="Priznanie k dani z nehnuteľností" Description="" Class="FORM" MimeType="application/vnd.etsi.asic-e+zip" Encoding="Base64">L:UHIOQWALIUil&lt;tag&gt;uh&lt;\\tag&gt;liaUWHDL====</Object>\n` +
             `        </MessageContainer>\n` +
             `      </Body>\n` +
             `    </SKTalkMessage>`,
@@ -247,7 +247,7 @@ describe('NasesUtilsService', () => {
         formDataJson: null,
         formDataGinis: null,
         // eslint-disable-next-line xss/no-mixed-html
-        formDataBase64: 'L:UHIOQWALIUil<tag>uh<\tag>liaUWHDL====',
+        formDataBase64: String.raw`L:UHIOQWALIUil<tag>uh<\tag>liaUWHDL====`,
         ginisDocumentId: null,
         senderId: null,
         recipientId: null,

--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
@@ -307,7 +307,8 @@ export default class NasesUtilsService {
     let message: string | object | null = null
 
     if (form.formDataBase64) {
-      message = form.formDataBase64
+      // Remove any whitespace characters - data saved from signer software may contain those & slovensko.sk can't handle them
+      message = form.formDataBase64.replaceAll(/\s/g, '')
     }
 
     if (!isSigned) {


### PR DESCRIPTION
This seems to be the problem with the failed tax form from couple of weeks ago. After removing whitespace UPVS accepts.

I've taken a fair bit of time thinking about where this removal should happen. Settled on "just before sending", but other legit options are:
- right when we get the data from the signer
- before the data is stored in db

For now I've figured I'd like to see unchanged data in db, so that if anything else (weird) starts coming from the signer we can investigate more easily.