### PR TITLE
fix: take only successful payments into account

### DIFF
--- a/nest-tax-backend/src/tasks/tasks.service.ts
+++ b/nest-tax-backend/src/tasks/tasks.service.ts
@@ -27,6 +27,7 @@ export class TasksService {
     WITH total_payments AS (
       SELECT "taxId", SUM("amount") AS totalPayments
       FROM "TaxPayment"
+      WHERE "status" = 'SUCCESS'
       GROUP BY "taxId"
     )
     SELECT t."variableSymbol", t."id"


### PR DESCRIPTION
If there are some failed payments, do not take them into aggregate.