### PR TITLE
Change access token policy when sending form

### DIFF
--- a/next/components/forms/useFormSend.tsx
+++ b/next/components/forms/useFormSend.tsx
@@ -99,7 +99,7 @@ const useGetContext = () => {
         {
           formDataJson: formData,
         },
-        { accessToken: 'always' },
+        { accessToken: 'onlyAuthenticated' },
       ),
     networkMode: 'always',
     onSuccess: () => {


### PR DESCRIPTION
It was not possible to send the form beforehand as unauthenticated, this strips the requirement of being logged in.