### PR TITLE
Handle errors in sendMessageNases

### DIFF
--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
@@ -6,7 +6,7 @@ import { Stream } from 'node:stream'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { Forms } from '@prisma/client'
-import axios, { AxiosResponse } from 'axios'
+import axios, { AxiosError, AxiosResponse } from 'axios'
 import {
   FormDefinitionSlovenskoSk,
   isSlovenskoSkFormDefinition,
@@ -32,7 +32,6 @@ import alertError from '../../utils/logging'
 import MinioClientSubservice from '../../utils/subservices/minio-client.subservice'
 import {
   NasesIsMessageDeliveredDto,
-  NasesSendFormDataDto,
   NasesSendResponse,
   ResponseGdprDataDto,
 } from '../dtos/responses.dto'
@@ -43,7 +42,6 @@ import {
   NasesErrorsEnum,
   NasesErrorsResponseEnum,
 } from '../nases.errors.enum'
-import { AxiosError } from 'axios'
 
 @Injectable()
 export default class NasesUtilsService {

--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
@@ -462,12 +462,20 @@ export default class NasesUtilsService {
     }`
   }
 
+  // TODO nicer error handling, for now it is assumed this function never throws and a lot of code relies on that
   async sendMessageNases(
     jwtToken: string,
     data: Forms,
     senderUri?: string,
   ): Promise<NasesSendResponse> {
-    const message = await this.createEnvelopeSendMessage(data, senderUri)
+    const message = await this.createEnvelopeSendMessage(data, senderUri).catch(
+      (error) => ({
+        status: 500,
+        data: {
+          message: `Failed to create envelope for nases message: ${error?.message || 'Unknown error'}. Details: ${JSON.stringify(error)}`,
+        },
+      }),
+    )
     const result = await axios
       .post(
         `${this.configService.getOrThrow<string>(

--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
@@ -43,6 +43,7 @@ import {
   NasesErrorsEnum,
   NasesErrorsResponseEnum,
 } from '../nases.errors.enum'
+import { AxiosError } from 'axios'
 
 @Injectable()
 export default class NasesUtilsService {
@@ -468,16 +469,19 @@ export default class NasesUtilsService {
     data: Forms,
     senderUri?: string,
   ): Promise<NasesSendResponse> {
-    const message = await this.createEnvelopeSendMessage(data, senderUri).catch(
-      (error) => ({
+    let message
+    try {
+      message = await this.createEnvelopeSendMessage(data, senderUri)
+    } catch (error) {
+      return {
         status: 500,
         data: {
-          message: `Failed to create envelope for nases message: ${error?.message || 'Unknown error'}. Details: ${JSON.stringify(error)}`,
+          message: `Failed to create envelope for nases message: ${(error as Error)?.message || 'Unknown error'}. Details: ${JSON.stringify(error)}`,
         },
-      }),
-    )
-    const result = await axios
-      .post(
+      }
+    }
+    try {
+      const response = await axios.post(
         `${this.configService.getOrThrow<string>(
           'SLOVENSKO_SK_CONTAINER_URI',
         )}/api/sktalk/receive_and_save_to_outbox`,
@@ -490,18 +494,8 @@ export default class NasesUtilsService {
           },
         },
       )
-      .then((response: AxiosResponse<NasesSendFormDataDto>) => {
-        if (response.data) {
-          if (response.data.receive_result !== 0) {
-            return {
-              status: 422,
-              data: {
-                message: this.getNasesError(response.data.receive_result),
-              },
-            }
-          }
-          return { status: 200, data: response.data }
-        }
+
+      if (!response.data) {
         return {
           status: 422,
           data: {
@@ -509,21 +503,29 @@ export default class NasesUtilsService {
               'Server error in response data, please contact administrator',
           },
         }
-      })
-      .catch((error) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (error.response && error.response.data) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-          return { status: error.response.status, data: error.response.data }
-        }
+      }
+
+      if (response.data.receive_result !== 0) {
         return {
-          status: 400,
+          status: 422,
           data: {
-            message: 'Other server error, please contact administrator',
+            message: this.getNasesError(response.data.receive_result),
           },
         }
-      })
-    return result
+      }
+
+      return { status: 200, data: response.data }
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.data) {
+        return { status: error.response.status, data: error.response.data }
+      }
+      return {
+        status: 400,
+        data: {
+          message: 'Other server error, please contact administrator',
+        },
+      }
+    }
   }
 
   async isNasesMessageDelivered(formId: string): Promise<boolean> {


### PR DESCRIPTION
See comment in code. I'm not sure if this is the reason, but I couldn't find any erroneous logs for the forms linked below. I assume it's because if the function below throws it does not get logged anywhere ? But the user should correctly receive error, so they should not end up with "success" message, but we are blind to what happened. This should locally fix that until we roll better logging.

A few erroneous forms [here](https://metabase.bratislava.sk/question#eyJuYW1lIjoiRm9ybXMiLCJkZXNjcmlwdGlvbiI6IkEgYmFzaWMgbG9vayBhdCB0aGUgRm9ybXMgdGFibGUiLCJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJxdWVyeSIsImRhdGFiYXNlIjo2LCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOiJjYXJkX18xNzkiLCJmaWx0ZXIiOlsiYW5kIixbIj0iLFsiZmllbGQiLCJGb3JtVHlwZSIseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQifV0sInByaXpuYW5pZSBrIGRhbmkgeiBuZWhudXRlbG5vc3RpIl0sWyI9IixbImZpZWxkIiwyOTAzNyxudWxsXSwiU0VORElOR19UT19OQVNFUyJdXSwib3JkZXItYnkiOltbImRlc2MiLFsiZmllbGQiLDI5MDU3LG51bGxdXV19fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsidGFibGUucGl2b3RfY29sdW1uIjoiZXh0ZXJuYWxJZCIsInRhYmxlLmNlbGxfY29sdW1uIjoiYXJjaGl2ZWQiLCJ0YWJsZS5jb2x1bW5fd2lkdGhzIjpbbnVsbCxudWxsLG51bGwsbnVsbCxudWxsLG51bGwsbnVsbCxudWxsLDI4N119LCJvcmlnaW5hbF9jYXJkX2lkIjoxNzl9)

Edit - rewritten the whole fn into try-catch

