### PR TITLE
Daily task to remove old draft empty forms

### DIFF
--- a/nest-forms-backend/src/forms/forms.module.ts
+++ b/nest-forms-backend/src/forms/forms.module.ts
@@ -11,6 +11,7 @@ import MinioClientSubservice from '../utils/subservices/minio-client.subservice'
 import FormsController from './forms.controller'
 import FormsHelper from './forms.helper'
 import FormsService from './forms.service'
+import FormsTaskSubservice from './subservices/forms-task.subservice'
 
 @Module({
   imports: [PrismaModule, ScannerClientModule, forwardRef(() => FilesModule)],
@@ -21,6 +22,7 @@ import FormsService from './forms.service'
     NasesConsumerHelper,
     ThrowerErrorGuard,
     MinioClientSubservice,
+    FormsTaskSubservice,
   ],
   exports: [FormsService, FormsHelper],
   controllers: [FormsController],

--- a/nest-forms-backend/src/forms/subservices/forms-task.subservice.ts
+++ b/nest-forms-backend/src/forms/subservices/forms-task.subservice.ts
@@ -40,7 +40,7 @@ export default class FormsTaskSubservice {
     const fileIds = forms.flatMap((form) => form.files.map((file) => file.id))
 
     // Delete the forms along with its files
-    this.filesService.deleteFileMany(fileIds)
+    await this.filesService.deleteFileMany(fileIds)
     await this.prismaService.forms.deleteMany({
       where: {
         id: {

--- a/nest-forms-backend/src/forms/subservices/forms-task.subservice.ts
+++ b/nest-forms-backend/src/forms/subservices/forms-task.subservice.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { FormState, Prisma } from '@prisma/client'
+
+import FilesService from '../../files/files.service'
+import PrismaService from '../../prisma/prisma.service'
+
+@Injectable()
+export default class FormsTaskSubservice {
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly filesService: FilesService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_1AM)
+  async deleteOldDraftForms(): Promise<void> {
+    const oneWeekAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7)
+
+    // Get the forms that are in DRAFT state, older than one week and have no data.
+    const forms = await this.prismaService.forms.findMany({
+      select: {
+        id: true,
+        files: {
+          select: {
+            id: true,
+          },
+        },
+      },
+      where: {
+        state: FormState.DRAFT,
+        updatedAt: {
+          lt: oneWeekAgo,
+        },
+        formDataJson: {
+          equals: Prisma.DbNull,
+        },
+      },
+    })
+    const formIds = forms.map((form) => form.id)
+    const fileIds = forms.flatMap((form) => form.files.map((file) => file.id))
+
+    // Delete the forms along with its files
+    this.filesService.deleteFileMany(fileIds)
+    await this.prismaService.forms.deleteMany({
+      where: {
+        id: {
+          in: formIds,
+        },
+      },
+    })
+  }
+}


### PR DESCRIPTION
Creates a task which runs daily and removed all forms (along with its files), which are:
1. Older than 1 week
2. Are in `DRAFT` state
3. Have `null` data

Tested locally and it works, however it should be watched on staging and the first run will contain many forms. 