### PR TITLE
Remove .yarnrc.yml file

### DIFF
--- a/tests/.yarnrc.yml
+++ b/tests/.yarnrc.yml
@@ -1,1 +1,0 @@
-nodeLinker: node-modules


### PR DESCRIPTION
My editor keeps adding this line to package.json whenever I run npm i anywhere in the project.

```
"packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
```
Claude AI says this is because .yarnrc exists in the project. Indeed, when I removed the file it stopped happening.

Don't know if anyone else is encountering these issues, either way, removing the file should be safe as we're using npm on all sub-projects.