### PR TITLE
Use FINISHED state as final for email and webhook forms

### DIFF
--- a/nest-forms-backend/prisma/migrations/20241115091118_migrate_processing_to_finished/migration.sql
+++ b/nest-forms-backend/prisma/migrations/20241115091118_migrate_processing_to_finished/migration.sql
@@ -1,0 +1,20 @@
+UPDATE "Forms" 
+SET "state" = 'FINISHED'
+WHERE "state" = 'PROCESSING'
+AND "formDefinitionSlug" IN (
+    'olo-mimoriadny-odvoz-a-zhodnotenie-odpadu',
+    'olo-energeticke-zhodnotenie-odpadu-v-zevo',
+    'olo-uzatvorenie-zmluvy-o-nakladani-s-odpadom',
+    'olo-docistenie-stanovista-zbernych-nadob',
+    'olo-odvoz-odpadu-velkokapacitnym-alebo-lisovacim-kontajnerom',
+    'olo-kolo-taxi',
+    'olo-olo-taxi',
+    'olo-podnety-a-pochvaly-obcanov',
+    'olo-odvoz-objemneho-odpadu-valnikom',
+    'olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke-osoby',
+    'olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovske-spolocnosti',
+    'tsb-objednavka-zakresu-sieti',
+    'tsb-objednavka-vytycenia',
+    'tsb-ziadost-o-stanovisko-pd',
+    'tsb-umiestnenie-zariadenia'
+);

--- a/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
@@ -114,7 +114,7 @@ describe('EmailFormsSubservice', () => {
       expect(mailgunService.sendOloEmail).toHaveBeenCalledTimes(2)
       expect(prismaMock.forms.update).toHaveBeenCalledWith({
         where: { id: 'test-form-id' },
-        data: { state: FormState.PROCESSING, error: FormError.NONE },
+        data: { state: FormState.FINISHED, error: FormError.NONE },
       })
     })
 
@@ -162,7 +162,7 @@ describe('EmailFormsSubservice', () => {
       expect(mailgunService.sendOloEmail).toHaveBeenCalledTimes(2)
       expect(prismaMock.forms.update).toHaveBeenCalledWith({
         where: { id: 'test-form-id' },
-        data: { state: FormState.PROCESSING, error: FormError.NONE },
+        data: { state: FormState.FINISHED, error: FormError.NONE },
       })
     })
 

--- a/nest-forms-backend/src/nases-consumer/subservices/__test__/webhook.subservice.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/__test__/webhook.subservice.spec.ts
@@ -95,7 +95,7 @@ describe('WebhookSubservice', () => {
       })
       expect(prismaMock.forms.update).toHaveBeenCalledWith({
         where: { id: 'test-form-id' },
-        data: { state: FormState.PROCESSING },
+        data: { state: FormState.FINISHED },
       })
     })
 

--- a/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
@@ -184,13 +184,13 @@ export default class EmailFormsSubservice {
           id: form.id,
         },
         data: {
-          state: FormState.PROCESSING,
+          state: FormState.FINISHED,
           error: FormError.NONE,
         },
       })
       .catch((error) => {
         alertError(
-          `Setting form state with id ${formId} to PROCESSING failed.`,
+          `Setting form state with id ${formId} to FINISHED failed.`,
           this.logger,
           JSON.stringify(error),
         )

--- a/nest-forms-backend/src/nases-consumer/subservices/webhook.subservice.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/webhook.subservice.ts
@@ -90,12 +90,12 @@ export default class WebhookSubservice {
           id: formId,
         },
         data: {
-          state: FormState.PROCESSING,
+          state: FormState.FINISHED,
         },
       })
     } catch (error) {
       alertError(
-        `Setting form state with id ${formId} to PROCESSING failed.`,
+        `Setting form state with id ${formId} to FINISHED failed.`,
         this.logger,
         JSON.stringify(error),
       )


### PR DESCRIPTION
- for email and webhook forms uses `FINISHED` as the final state instead of `PROCESSING`
- migrates all such forms (email and webhook with `PROCESSING`) to `FINISHED` state.