### PR TITLE
Use only one aggregate call for payments import

### DIFF
--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -330,24 +330,44 @@ export class AdminService {
           )
     const taxesDataMap = await this.getTaxesDataMap(norisPaymentData)
 
+    // Get all tax IDs from taxesDataMap
+    const taxIds = Array.from(taxesDataMap.values()).map(tax => tax.id)
+
+    // Get aggregate data for all taxes at once
+    const aggregateData = await this.prismaService.taxPayment.groupBy({
+      by: ['taxId'],
+      _sum: {
+        amount: true,
+      },
+      _count: {
+        _all: true,
+      },
+      where: {
+        taxId: {
+          in: taxIds
+        },
+        status: PaymentStatus.SUCCESS,
+      },
+    })
+
+    // Create a map of aggregated data for easy lookup
+    const aggregateDataMap = new Map(
+      aggregateData.map(data => [
+        data.taxId,
+        {
+          sum: data._sum.amount || 0,
+          count: data._count._all
+        }
+      ])
+    )
+
     // despite the retype, do not trust the data from Noris & approach as if they were all optional
     await Promise.all(
       norisPaymentData.map(async (norisPayment) => {
         try {
           const taxData = taxesDataMap.get(norisPayment.variabilny_symbol)
           if (taxData) {
-            const payerData = await this.prismaService.taxPayment.aggregate({
-              _sum: {
-                amount: true,
-              },
-              _count: {
-                _all: true,
-              },
-              where: {
-                taxId: taxData.id,
-                status: PaymentStatus.SUCCESS,
-              },
-            })
+            const payerData = aggregateDataMap.get(taxData.id) || { sum: 0, count: 0 }
             const payedFromNoris =
               typeof norisPayment.uhrazeno === 'number'
                 ? currency(norisPayment.uhrazeno).intValue
@@ -358,14 +378,14 @@ export class AdminService {
                 : currency(norisPayment.zbyva_uhradit.replace(',', '.'))
                     .intValue
             if (
-              payerData._sum.amount === null ||
-              payerData._sum.amount < payedFromNoris
+              payerData.sum === null ||
+              payerData.sum < payedFromNoris
             ) {
               created += 1
               const createdTaxPayment =
                 await this.prismaService.taxPayment.create({
                   data: {
-                    amount: payedFromNoris - payerData._sum.amount,
+                    amount: payedFromNoris - payerData.sum,
                     source: 'BANK_ACCOUNT',
                     specificSymbol: norisPayment.specificky_symbol,
                     taxId: taxData.id,
@@ -391,7 +411,7 @@ export class AdminService {
                 payedFromNoris,
                 taxData,
                 forPayment,
-                payerData._count._all,
+                payerData.count,
               )
             } else {
               alreadyCreated += 1


### PR DESCRIPTION
Instead of calling aggregate each time in the loop, call it just once outside of the loop and then retrieve the records by id.