### PR TITLE
Forms helptext improvements

### DIFF
--- a/forms-shared/src/generator/functions.ts
+++ b/forms-shared/src/generator/functions.ts
@@ -14,7 +14,6 @@ import {
   DatePickerUiOptions,
   FileUploadUiOptions,
   InputUiOptions,
-  markdownTextPrefix,
   NumberUiOptions,
   ObjectFieldUiOptions,
   RadioGroupUiOptions,
@@ -655,9 +654,3 @@ export const skipUiSchema = <F extends Field | ObjectField>(field: F): F => {
 export const skipSchema = <F extends Field | ObjectField>(field: F): F => {
   return { ...field, skipSchema: true }
 }
-
-/**
- * If text contains markdown, it is still string, to distinguish it from normal text, we need to prefix it in order to
- * detect that it is markdown when used in component.
- */
-export const markdownText = (text: string) => `${markdownTextPrefix}${text}`

--- a/forms-shared/src/generator/uiOptionsTypes.ts
+++ b/forms-shared/src/generator/uiOptionsTypes.ts
@@ -66,7 +66,7 @@ export type WidgetSpacing = {
 export type WidgetUiOptions = WidgetSpacing & {
   tooltip?: string
   helptext?: string
-  helptextHeader?: string
+  helptextFooter?: string
   className?: string
   belowComponents?: CustomComponentType[]
   rightComponents?: CustomComponentType[]

--- a/forms-shared/src/generator/uiOptionsTypes.ts
+++ b/forms-shared/src/generator/uiOptionsTypes.ts
@@ -17,6 +17,7 @@ export type CustomComponentCalculator = {
   formula: string
   missingFieldsMessage: string
   unit: string
+  unitMarkdown?: boolean
   /**
    * The dataContextLevelsUp is an optional parameter that specifies the number of levels to go up in the JSON data
    * context for formula in hierarchy from the current position. This is useful when you want to retrieve or access data
@@ -127,6 +128,7 @@ export type CustomComponentFieldUiOptions = Pick<WidgetUiOptions, 'spaceTop' | '
 export type ArrayFieldUiOptions = Pick<WidgetUiOptions, 'spaceTop' | 'spaceBottom'> & {
   hideTitle?: boolean
   description?: string
+  descriptionMarkdown?: boolean
   addButtonLabel: string
   itemTitle?: string
   cannotAddItemMessage?: string
@@ -147,6 +149,7 @@ export type ObjectFieldUiOptions = Pick<WidgetUiOptions, 'spaceTop' | 'spaceBott
     objectDisplay?: 'wrapper' | 'boxed'
     title?: string
     description?: string
+    descriptionMarkdown?: boolean
   } & (
     | {
         columns?: false

--- a/forms-shared/src/generator/uiOptionsTypes.ts
+++ b/forms-shared/src/generator/uiOptionsTypes.ts
@@ -66,7 +66,9 @@ export type WidgetSpacing = {
 export type WidgetUiOptions = WidgetSpacing & {
   tooltip?: string
   helptext?: string
+  helptextMarkdown?: boolean
   helptextFooter?: string
+  helptextFooterMarkdown?: boolean
   className?: string
   belowComponents?: CustomComponentType[]
   rightComponents?: CustomComponentType[]

--- a/forms-shared/src/schemas/komunitneZahrady.ts
+++ b/forms-shared/src/schemas/komunitneZahrady.ts
@@ -23,7 +23,7 @@ const umiestnenieADizajn = [
     },
     {
       type: 'dragAndDrop',
-      helptextHeader: markdownText(
+      helptext: markdownText(
         'Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.',
       ),
     },
@@ -36,7 +36,7 @@ const umiestnenieADizajn = [
     },
     {
       type: 'dragAndDrop',
-      helptextHeader: markdownText(
+      helptext: markdownText(
         'Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.\n\n Napríklad, záhony či pestovacie boxy, výsadbu akejkoľvek trvalkovej zelene, kríkov a stromov spolu s druhovým špecifikovaním tejto zelene, kompost, mobiliár, priestor na uskladnenie náradia a zariadenia záhrady, priestor pre využívanie grilu, spôsob zabezpečenia vody a jej distribúcie.',
       ),
     },
@@ -145,7 +145,7 @@ export default schema(
               ),
             },
             {
-              helptextHeader: markdownText(
+              helptext: markdownText(
                 'Pre zaistenie kvalitného verejného priestoru sme na niektorých mestských pozemkoch zaviedli zopár [podmienok](https://bratislava.sk/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/komunitne-zahrady) pre vznik komunitnej záhrady.',
               ),
             },
@@ -200,7 +200,7 @@ export default schema(
             },
             {
               size: 'medium',
-              helptextHeader: markdownText(
+              helptext: markdownText(
                 'Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13).',
               ),
             },
@@ -222,7 +222,7 @@ export default schema(
           },
           {
             placeholder: 'Popíšte',
-            helptextHeader: markdownText(
+            helptext: markdownText(
               'Vysvetlite, prečo považujete za vhodné zabrať daný verejný priestor a vytvoriť na ňom záhradu s menej verejným režimom (predpokladáme, že záhrady sú oplotené a poloverejné). Argumentmi môže byť doterajšie nevyužívanie alebo nevhodné využívanie priestoru, napríklad, nelegálne parkovisko na zeleni, zeleň bez udržiavaných sadových úprav, neprístupný/nevyužívaný priestor.',
             ),
           },
@@ -232,7 +232,7 @@ export default schema(
           { title: 'Súhlas miestnej komunity', required: true },
           {
             placeholder: 'Popíšte',
-            helptextHeader:
+            helptext:
               'Dôležitý aspekt legitimity je zapojenie okolitej komunity – organizačný tím by mal získať súhlas miestnych obyvateľov a obyvateliek, ktorí priestor v súčasnosti využívajú.',
           },
         ),
@@ -252,7 +252,7 @@ export default schema(
           },
           {
             placeholder: 'Popíšte',
-            helptextHeader:
+            helptext:
               'Kto a akým spôsobom bude zabezpečovať prevádzku záhrady z hľadiska údržby zelene (napríklad kosenie) a starostlivosti o poriadok? Ako bude zabezpečený odpad? Ideálne je, napríklad, zaviazať sa ku zero-waste režimu a každý, kto vytvorí odpad bude zodpovedný za jeho likvidáciu.',
           },
         ),
@@ -264,7 +264,7 @@ export default schema(
           },
           {
             placeholder: 'Popíšte',
-            helptextHeader:
+            helptext:
               'Ako zabezpečíte otvorenosť projektu, kto bude mať priamy či nepriamy úžitok z projektu, ako vyberiete, kto bude záhradkár? Ako sa vysporiadate so situáciou, ak budete mať väčší záujem o záhradkárčenie, než budete mať kapacitu nasýtiť?',
           },
         ),
@@ -276,7 +276,7 @@ export default schema(
           },
           {
             placeholder: 'Popíšte',
-            helptextHeader:
+            helptext:
               'Aké budete mať členské poplatky? Využijete na tvorbu záhrady granty? Aké zdroje už máte a aké plánujete získať? V prípade, že už máte (predbežný) rozpočet, nahrajte ho do poľa nižšie.',
           },
         ),
@@ -327,7 +327,7 @@ export default schema(
           },
           {
             type: 'dragAndDrop',
-            helptextHeader:
+            helptext:
               'Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.',
           },
         ),

--- a/forms-shared/src/schemas/komunitneZahrady.ts
+++ b/forms-shared/src/schemas/komunitneZahrady.ts
@@ -3,7 +3,6 @@ import {
   conditionalStep,
   fileUpload,
   input,
-  markdownText,
   object,
   radioGroup,
   schema,
@@ -23,9 +22,9 @@ const umiestnenieADizajn = [
     },
     {
       type: 'dragAndDrop',
-      helptext: markdownText(
+      helptext:
         'Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.',
-      ),
+      helptextMarkdown: true,
     },
   ),
   fileUpload(
@@ -36,9 +35,9 @@ const umiestnenieADizajn = [
     },
     {
       type: 'dragAndDrop',
-      helptext: markdownText(
+      helptext:
         'Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.\n\n Napríklad, záhony či pestovacie boxy, výsadbu akejkoľvek trvalkovej zelene, kríkov a stromov spolu s druhovým špecifikovaním tejto zelene, kompost, mobiliár, priestor na uskladnenie náradia a zariadenia záhrady, priestor pre využívanie grilu, spôsob zabezpečenia vody a jej distribúcie.',
-      ),
+      helptextMarkdown: true,
     },
   ),
 ]
@@ -145,9 +144,9 @@ export default schema(
               ),
             },
             {
-              helptext: markdownText(
+              helptext:
                 'Pre zaistenie kvalitného verejného priestoru sme na niektorých mestských pozemkoch zaviedli zopár [podmienok](https://bratislava.sk/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/komunitne-zahrady) pre vznik komunitnej záhrady.',
-              ),
+              helptextMarkdown: true,
             },
           ),
         ]),
@@ -200,9 +199,10 @@ export default schema(
             },
             {
               size: 'medium',
-              helptext: markdownText(
+              helptext:
                 'Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13).',
-              ),
+
+              helptextMarkdown: true,
             },
           ),
         ]),
@@ -222,9 +222,9 @@ export default schema(
           },
           {
             placeholder: 'Popíšte',
-            helptext: markdownText(
+            helptext:
               'Vysvetlite, prečo považujete za vhodné zabrať daný verejný priestor a vytvoriť na ňom záhradu s menej verejným režimom (predpokladáme, že záhrady sú oplotené a poloverejné). Argumentmi môže byť doterajšie nevyužívanie alebo nevhodné využívanie priestoru, napríklad, nelegálne parkovisko na zeleni, zeleň bez udržiavaných sadových úprav, neprístupný/nevyužívaný priestor.',
-            ),
+            helptextMarkdown: true,
           },
         ),
         textArea(

--- a/forms-shared/src/schemas/olo/docisteniStanovistaZbernychNadob.ts
+++ b/forms-shared/src/schemas/olo/docisteniStanovistaZbernychNadob.ts
@@ -64,7 +64,7 @@ export default schema({ title: 'Dočistenie stanovišťa zberných nádob' }, {}
       input(
         'konatel',
         { type: 'text', title: 'Konateľ', required: true },
-        { helptextHeader: 'Uveďte meno a priezvisko konateľa' },
+        { helptext: 'Uveďte meno a priezvisko konateľa' },
       ),
       input(
         'zastupeny',
@@ -73,7 +73,7 @@ export default schema({ title: 'Dočistenie stanovišťa zberných nádob' }, {}
           title: 'Zastúpený - na základe splnomocnenia',
           required: true,
         },
-        { helptextHeader: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
+        { helptext: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
       ),
     ]),
     conditionalFields(
@@ -97,7 +97,7 @@ export default schema({ title: 'Dočistenie stanovišťa zberných nádob' }, {}
           required: true,
         },
         {
-          helptextHeader:
+          helptext:
             'V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.',
           checkboxLabel: 'Súhlasím so zaslaním elektronickej fakúry',
           variant: 'boxed',
@@ -125,7 +125,7 @@ export default schema({ title: 'Dočistenie stanovišťa zberných nádob' }, {}
         required: true,
       },
       {
-        helptextHeader: 'Vyplňte vo formáte ulica a číslo',
+        helptext: 'Vyplňte vo formáte ulica a číslo',
       },
     ),
     select(
@@ -145,7 +145,7 @@ export default schema({ title: 'Dočistenie stanovišťa zberných nádob' }, {}
         ),
       },
       {
-        helptextHeader: 'Poplatok je účtovaný za množstvo naložených a vysypaných nádob',
+        helptext: 'Poplatok je účtovaný za množstvo naložených a vysypaných nádob',
       },
     ),
     datePicker(
@@ -155,7 +155,7 @@ export default schema({ title: 'Dočistenie stanovišťa zberných nádob' }, {}
         required: true,
       },
       {
-        helptextHeader:
+        helptext:
           'Vami zvolený dátum má iba informačný charakter. Objednávku je potrebné podať minimálne 2 pracovné dni pred zvoleným termínom. V prípade, ak vami zvolený termín nebude voľný, budeme vás kontaktovať.',
         size: 'medium',
       },
@@ -167,7 +167,7 @@ export default schema({ title: 'Dočistenie stanovišťa zberných nádob' }, {}
         required: false,
       },
       {
-        helptextHeader: 'Špecifikujte individuálne požiadavky.',
+        helptext: 'Špecifikujte individuálne požiadavky.',
       },
     ),
   ]),

--- a/forms-shared/src/schemas/olo/koloTaxi.ts
+++ b/forms-shared/src/schemas/olo/koloTaxi.ts
@@ -58,7 +58,7 @@ export default schema({ title: 'KOLO Taxi' }, {}, [
       input(
         'konatel',
         { type: 'text', title: 'Konateľ', required: true },
-        { helptextHeader: 'Uveďte meno a priezvisko konateľa' },
+        { helptext: 'Uveďte meno a priezvisko konateľa' },
       ),
       input(
         'zastupeny',
@@ -67,7 +67,7 @@ export default schema({ title: 'KOLO Taxi' }, {}, [
           title: 'Zastúpený - na základe splnomocnenia',
           required: true,
         },
-        { helptextHeader: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
+        { helptext: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
       ),
       input(
         'menoKontaktnejOsoby',
@@ -86,7 +86,7 @@ export default schema({ title: 'KOLO Taxi' }, {}, [
             title: 'Súhlasím so zaslaním elektronickej faktúry',
           },
           {
-            helptextHeader:
+            helptext:
               'V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH.',
             checkboxLabel: 'Súhlasím so zaslaním elektronickej faktúry',
             variant: 'boxed',
@@ -115,7 +115,7 @@ export default schema({ title: 'KOLO Taxi' }, {}, [
         required: true,
       },
       {
-        helptextHeader: 'Vyplňte vo formáte ulica a číslo',
+        helptext: 'Vyplňte vo formáte ulica a číslo',
       },
     ),
     textArea(
@@ -125,7 +125,7 @@ export default schema({ title: 'KOLO Taxi' }, {}, [
         required: true,
       },
       {
-        helptextHeader: 'Okrem čalúneného nábytku a elektrospotrebičov',
+        helptext: 'Okrem čalúneného nábytku a elektrospotrebičov',
       },
     ),
     fileUpload(
@@ -137,7 +137,7 @@ export default schema({ title: 'KOLO Taxi' }, {}, [
       },
       {
         type: 'dragAndDrop',
-        helptextHeader: 'Nahrajte fotografiu vecí, ktoré chcete darovať (jpg, jpeg, png, max. 5MB)',
+        helptext: 'Nahrajte fotografiu vecí, ktoré chcete darovať (jpg, jpeg, png, max. 5MB)',
       },
     ),
     checkbox(

--- a/forms-shared/src/schemas/olo/mimoriadnyOdvozAZhodnotenieOdpadu.ts
+++ b/forms-shared/src/schemas/olo/mimoriadnyOdvozAZhodnotenieOdpadu.ts
@@ -5,7 +5,6 @@ import {
   customComponentsField,
   datePicker,
   input,
-  markdownText,
   object,
   radioGroup,
   schema,
@@ -222,9 +221,9 @@ export default schema(
                 items: createStringItems(['120 l zberná nádoba']),
               },
               {
-                helptext: markdownText(
+                helptext:
                   'Služba sa poskytuje iba pre bytové doby a firmy. Pre rodinné domy sú určené nádoby na [zberné hniezda](https://www.olo.sk/zberne-hniezda/).',
-                ),
+                helptextMarkdown: true,
               },
             ),
           ]),

--- a/forms-shared/src/schemas/olo/mimoriadnyOdvozAZhodnotenieOdpadu.ts
+++ b/forms-shared/src/schemas/olo/mimoriadnyOdvozAZhodnotenieOdpadu.ts
@@ -73,7 +73,7 @@ export default schema(
         input(
           'konatel',
           { type: 'text', title: 'Konateľ', required: true },
-          { helptextHeader: 'Uveďte meno a priezvisko konateľa' },
+          { helptext: 'Uveďte meno a priezvisko konateľa' },
         ),
         input(
           'zastupeny',
@@ -83,7 +83,7 @@ export default schema(
             required: true,
           },
           {
-            helptextHeader: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia',
+            helptext: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia',
           },
         ),
       ]),
@@ -118,7 +118,7 @@ export default schema(
                   title: 'Zasielanie faktúry elektronicky',
                 },
                 {
-                  helptextHeader:
+                  helptext:
                     'V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.',
                   checkboxLabel: 'Súhlasím so zaslaním elektronickej faktúry',
                   variant: 'boxed',
@@ -153,7 +153,7 @@ export default schema(
           input(
             'miestoDodania',
             { type: 'text', title: 'Miesto dodania / výkonu služby', required: true },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
           select(
             'druhOdpadu',
@@ -208,8 +208,7 @@ export default schema(
                   ]),
                 },
                 {
-                  helptextHeader:
-                    '23 l zberná nádoba sa poskytuje iba pre odvoz z rodinných domov.',
+                  helptext: '23 l zberná nádoba sa poskytuje iba pre odvoz z rodinných domov.',
                 },
               ),
             ],
@@ -223,7 +222,7 @@ export default schema(
                 items: createStringItems(['120 l zberná nádoba']),
               },
               {
-                helptextHeader: markdownText(
+                helptext: markdownText(
                   'Služba sa poskytuje iba pre bytové doby a firmy. Pre rodinné domy sú určené nádoby na [zberné hniezda](https://www.olo.sk/zberne-hniezda/).',
                 ),
               },
@@ -309,7 +308,7 @@ export default schema(
           required: true,
         },
         {
-          helptextHeader:
+          helptext:
             'Vami zvolený dátum má iba informačný charakter. Objednávku je potrebné podať minimálne 2 pracovné dni pred zvoleným termínom. V prípade, ak vami zvolený termín nebude voľný, budeme vás kontaktovať.',
         },
       ),
@@ -320,7 +319,7 @@ export default schema(
           required: false,
         },
         {
-          helptextHeader: 'Špecifikujte individuálne požiadavky.',
+          helptext: 'Špecifikujte individuálne požiadavky.',
         },
       ),
     ]),

--- a/forms-shared/src/schemas/olo/odvozObjemnehoOdpaduValnikom.ts
+++ b/forms-shared/src/schemas/olo/odvozObjemnehoOdpaduValnikom.ts
@@ -42,7 +42,7 @@ export default schema({ title: 'Odvoz objemného odpadu valníkom' }, {}, [
       input(
         'konatel',
         { type: 'text', title: 'Konateľ', required: true },
-        { helptextHeader: 'Uveďte meno a priezvisko konateľa' },
+        { helptext: 'Uveďte meno a priezvisko konateľa' },
       ),
       input(
         'zastupeny',
@@ -51,7 +51,7 @@ export default schema({ title: 'Odvoz objemného odpadu valníkom' }, {}, [
           title: 'Zastúpený - na základe splnomocnenia',
           required: true,
         },
-        { helptextHeader: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
+        { helptext: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
       ),
     ]),
     input('kontaktnaOsoba', { type: 'text', title: 'Meno kontaktnej osoby', required: true }, {}),
@@ -65,7 +65,7 @@ export default schema({ title: 'Odvoz objemného odpadu valníkom' }, {}, [
           title: 'Súhlasím so zaslaním elektronickej faktúry',
         },
         {
-          helptextHeader:
+          helptext:
             'V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.',
           checkboxLabel: 'Súhlasím so zaslaním elektronickej faktúry',
           variant: 'boxed',
@@ -93,7 +93,7 @@ export default schema({ title: 'Odvoz objemného odpadu valníkom' }, {}, [
         required: true,
       },
       {
-        helptextHeader: 'Vyplňte vo formáte ulica a číslo',
+        helptext: 'Vyplňte vo formáte ulica a číslo',
       },
     ),
     datePicker(

--- a/forms-shared/src/schemas/olo/odvozOdpaduVelkokapacitnymAleboLisovacimKontajnerom.ts
+++ b/forms-shared/src/schemas/olo/odvozOdpaduVelkokapacitnymAleboLisovacimKontajnerom.ts
@@ -65,7 +65,7 @@ export default schema({ title: 'Odvoz odpadu veľkokapacitným alebo lisovacím 
       input(
         'konatel',
         { type: 'text', title: 'Konateľ', required: true },
-        { helptextHeader: 'Uveďte meno a priezvisko konateľa' },
+        { helptext: 'Uveďte meno a priezvisko konateľa' },
       ),
       input(
         'zastupeny',
@@ -74,7 +74,7 @@ export default schema({ title: 'Odvoz odpadu veľkokapacitným alebo lisovacím 
           title: 'Zastúpený - na základe splnomocnenia',
           required: true,
         },
-        { helptextHeader: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
+        { helptext: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
       ),
     ]),
     conditionalFields(
@@ -98,7 +98,7 @@ export default schema({ title: 'Odvoz odpadu veľkokapacitným alebo lisovacím 
           required: true,
         },
         {
-          helptextHeader:
+          helptext:
             'V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.',
           checkboxLabel: 'Súhlasím so zaslaním elektronickej fakúry',
           variant: 'boxed',
@@ -121,7 +121,7 @@ export default schema({ title: 'Odvoz odpadu veľkokapacitným alebo lisovacím 
     input(
       'miestoDodania',
       { type: 'text', title: 'Miesto dodania / výkonu služby', required: true },
-      { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+      { helptext: 'Vyplňte vo formáte ulica a číslo' },
     ),
     select(
       'druhOdpadu',
@@ -175,7 +175,7 @@ export default schema({ title: 'Odvoz odpadu veľkokapacitným alebo lisovacím 
         required: true,
       },
       {
-        helptextHeader: 'V pracovné dni od 7.00 - 12.30',
+        helptext: 'V pracovné dni od 7.00 - 12.30',
         size: 'medium',
       },
     ),
@@ -194,7 +194,7 @@ export default schema({ title: 'Odvoz odpadu veľkokapacitným alebo lisovacím 
         required: true,
       },
       {
-        helptextHeader: 'V pracovné dni od 7.00 - 12.30',
+        helptext: 'V pracovné dni od 7.00 - 12.30',
         size: 'medium',
       },
     ),

--- a/forms-shared/src/schemas/olo/oloTaxi.ts
+++ b/forms-shared/src/schemas/olo/oloTaxi.ts
@@ -58,7 +58,7 @@ export default schema(
         },
         {
           placeholder: 'Zadajte presnú adresu',
-          helptextHeader: 'Vyplňte vo formáte ulica a číslo',
+          helptext: 'Vyplňte vo formáte ulica a číslo',
         },
       ),
       datePicker(
@@ -68,7 +68,7 @@ export default schema(
           required: true,
         },
         {
-          helptextHeader:
+          helptext:
             'Vami zvolený dátum má iba informačný charakter. Objednávku je potrebné podať minimálne 2 pracovné dni pred zvoleným termínom. V prípade, ak vami zvolený termín nebude voľný, budeme vás kontaktovať.',
         },
       ),
@@ -96,7 +96,7 @@ export default schema(
           required: true,
         },
         {
-          helptextHeader: 'Špecifikujte druh odpadu, uveďte počet kusov alebo množstvo v m³.',
+          helptext: 'Špecifikujte druh odpadu, uveďte počet kusov alebo množstvo v m³.',
         },
       ),
       checkbox(

--- a/forms-shared/src/schemas/olo/podnetyAPochvalyObcanov.ts
+++ b/forms-shared/src/schemas/olo/podnetyAPochvalyObcanov.ts
@@ -61,7 +61,7 @@ export default schema({ title: 'Podnety a pochvaly občanov' }, {}, [
         },
         {
           variant: 'boxed',
-          helptextHeader: 'Vyberte aspoň jednu možnosť',
+          helptext: 'Vyberte aspoň jednu možnosť',
         },
       ),
       input(
@@ -72,7 +72,7 @@ export default schema({ title: 'Podnety a pochvaly občanov' }, {}, [
           required: true,
         },
         {
-          helptextHeader: 'Vyplňte vo formáte ulica a číslo',
+          helptext: 'Vyplňte vo formáte ulica a číslo',
         },
       ),
     ]),
@@ -90,11 +90,7 @@ export default schema({ title: 'Podnety a pochvaly občanov' }, {}, [
     input('priezvisko', { type: 'text', title: 'Priezvisko', required: true }, {}),
     sharedPhoneNumberField('telefon', true),
     input('email', { title: 'Email', required: true, type: 'email' }, {}),
-    textArea(
-      'sprava',
-      { title: 'Správa', required: true },
-      { helptextHeader: 'Napíšte svoje podnety' },
-    ),
+    textArea('sprava', { title: 'Správa', required: true }, { helptext: 'Napíšte svoje podnety' }),
     fileUpload(
       'prilohy',
       {

--- a/forms-shared/src/schemas/olo/shared/zevoShared.ts
+++ b/forms-shared/src/schemas/olo/shared/zevoShared.ts
@@ -71,8 +71,7 @@ export const getZevoSchema = (type: ZevoType) => [
               'cisloPovoleniaNaVstup',
               { type: 'text', title: 'Číslo povolenia na vstup', required: true },
               {
-                helptextHeader:
-                  'Vo formáte: 123/45 alebo 1234/45/2026 (číslo Objednávky alebo Zmluvy)',
+                helptext: 'Vo formáte: 123/45 alebo 1234/45/2026 (číslo Objednávky alebo Zmluvy)',
               },
             ),
           ],
@@ -91,7 +90,7 @@ export const getZevoSchema = (type: ZevoType) => [
         input(
           'konatel',
           { type: 'text', title: 'Konateľ', required: true },
-          { helptextHeader: 'Uveďte meno a priezvisko konateľa' },
+          { helptext: 'Uveďte meno a priezvisko konateľa' },
         ),
         input(
           'zastupeny',
@@ -101,7 +100,7 @@ export const getZevoSchema = (type: ZevoType) => [
             required: true,
           },
           {
-            helptextHeader: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia',
+            helptext: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia',
           },
         ),
         input(
@@ -272,7 +271,7 @@ export const getZevoSchema = (type: ZevoType) => [
                 title: 'Súhlasím so zaslaním elektronickej faktúry',
               },
               {
-                helptextHeader:
+                helptext:
                   'V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.',
                 checkboxLabel: 'Súhlasím so zaslaním elektronickej faktúry',
                 variant: 'boxed',
@@ -310,7 +309,7 @@ export const getZevoSchema = (type: ZevoType) => [
           {
             variant: 'boxed',
             orientations: 'row',
-            helptextHeader:
+            helptext:
               'Definícia zo Zákona č. 79/2015 Z. z. o odpadoch v znení neskorších predpisov',
           },
         ),
@@ -366,7 +365,7 @@ export const getZevoSchema = (type: ZevoType) => [
           {
             variant: 'boxed',
             orientations: 'row',
-            helptextHeader:
+            helptext:
               'Definícia zo Zákona č. 79/2015 Z. z. o odpadoch v znení neskorších predpisov',
           },
         ),
@@ -1007,7 +1006,7 @@ export const getZevoSchema = (type: ZevoType) => [
           },
           {
             type: 'dragAndDrop',
-            helptextHeader:
+            helptext:
               'Nahrajte fotografie odpadu, ktorý priveziete na zhodnotenie (povolené typy súborov jpg, gif, png, max. veľkosť 1 súboru 10 MB, maximálne 5 súborov.)',
           },
         ),

--- a/forms-shared/src/schemas/olo/triedenyZberPapieraPlastovASklaPrePravnickeOsoby.ts
+++ b/forms-shared/src/schemas/olo/triedenyZberPapieraPlastovASklaPrePravnickeOsoby.ts
@@ -34,7 +34,7 @@ const getFakturacia = (novyOdberatel: boolean) =>
           title: 'Súhlasím so zaslaním elektronickej faktúry',
         },
         {
-          helptextHeader:
+          helptext:
             'V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.',
           checkboxLabel: 'Súhlasím so zaslaním elektronickej faktúry',
           variant: 'boxed',
@@ -113,7 +113,7 @@ export default schema(
           datePicker(
             'datumZmeny',
             { title: 'Dátum zmeny', required: true },
-            { helptextHeader: 'Uveďte dátum predpokladanej zmeny odberateľa' },
+            { helptext: 'Uveďte dátum predpokladanej zmeny odberateľa' },
           ),
         ],
         [
@@ -132,7 +132,7 @@ export default schema(
       input(
         'konatel',
         { type: 'text', title: 'Konateľ', required: true },
-        { helptextHeader: 'Uveďte meno a priezvisko konateľa' },
+        { helptext: 'Uveďte meno a priezvisko konateľa' },
       ),
       input(
         'zastupeny',
@@ -141,7 +141,7 @@ export default schema(
           title: 'Zastúpený - na základe splnomocnenia',
           required: true,
         },
-        { helptextHeader: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
+        { helptext: 'Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia' },
       ),
       input(
         'menoKontaktnejOsoby',
@@ -207,7 +207,7 @@ export default schema(
           input(
             'miestoDodania',
             { type: 'text', title: 'Miesto dodania / výkonu služby', required: true },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
           select(
             'druhOdpadu',
@@ -224,7 +224,7 @@ export default schema(
                 'Kuchynský biologicky rozložiteľný odpad (Pravidelný odvoz vytriedených zložiek komunálneho odpadu kat. číslo 20)',
               ]),
             },
-            { helptextHeader: 'Vyberte len 1 komoditu' },
+            { helptext: 'Vyberte len 1 komoditu' },
           ),
           conditionalFields(
             createCondition([
@@ -386,7 +386,7 @@ export default schema(
                   ]),
                 },
                 {
-                  helptextHeader:
+                  helptext:
                     '23 l zberná nádoba je možná vybrať iba pre právnické osoby, ktoré majú sídlo v rodinných domoch',
                 },
               ),
@@ -398,7 +398,7 @@ export default schema(
                   items: createStringItems(['1 x do týždňa', '2 x do týždňa']),
                 },
                 {
-                  helptextHeader:
+                  helptext:
                     'Kuchynský biologicky rozložiteľný odpad sa v Bratislave zbiera celoročne. Interval odvozov sa mení sezónne, a to dvakrát ročne. Od začiatku marca do konca novembra je zber realizovaný 2x za 7 dní. Od začiatku decembra do konca februára bude zber 1x do týždňa.',
                 },
               ),
@@ -407,7 +407,7 @@ export default schema(
           number(
             'pocetNadob',
             { type: 'number', title: 'Počet nádob', required: true },
-            { helptextHeader: 'Uveďte počet nádob' },
+            { helptext: 'Uveďte počet nádob' },
           ),
         ],
       ),

--- a/forms-shared/src/schemas/olo/triedenyZberPapieraPlastovASklaPreSpravcovskeSpolocnosti.ts
+++ b/forms-shared/src/schemas/olo/triedenyZberPapieraPlastovASklaPreSpravcovskeSpolocnosti.ts
@@ -35,7 +35,7 @@ const getFakturacia = (novyOdberatel: boolean) =>
           title: 'Súhlasím so zaslaním elektronickej faktúry',
         },
         {
-          helptextHeader:
+          helptext:
             'V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.',
           checkboxLabel: 'Súhlasím so zaslaním elektronickej faktúry',
           variant: 'boxed',
@@ -142,7 +142,7 @@ export default schema(
           datePicker(
             'datumZmeny',
             { title: 'Dátum zmeny', required: true },
-            { helptextHeader: 'Uveďte dátum predpokladanej zmeny odberateľa' },
+            { helptext: 'Uveďte dátum predpokladanej zmeny odberateľa' },
           ),
         ],
         [input('dic', { type: 'text', title: 'DIČ', required: true }, {})],
@@ -209,7 +209,7 @@ export default schema(
           input(
             'miestoDodania',
             { type: 'text', title: 'Miesto dodania / výkonu služby', required: true },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
           select(
             'druhOdpadu',
@@ -223,7 +223,7 @@ export default schema(
               ]),
             },
             {
-              helptextHeader: markdownText(
+              helptext: markdownText(
                 'Vyberte len 1 komoditu. Správcovia nehnuteľností v prípade Kuchynského biologicky rozložiteľného odpadu riešia zapojenie a zmeny v systéme zapojenia na Magistráte hlavného mesta. **Zmesový komunálny odpad sa rieši na** [Magistráte hlavného mesta](https://bratislava.sk/mesto-bratislava/dane-a-poplatky/poplatok-za-komunalne-odpady-a-drobne-stavebne-odpady).',
               ),
             },
@@ -327,7 +327,7 @@ export default schema(
           number(
             'pocetNadob',
             { type: 'number', title: 'Počet nádob', required: true },
-            { helptextHeader: 'Uveďte počet nádob' },
+            { helptext: 'Uveďte počet nádob' },
           ),
         ],
       ),

--- a/forms-shared/src/schemas/olo/triedenyZberPapieraPlastovASklaPreSpravcovskeSpolocnosti.ts
+++ b/forms-shared/src/schemas/olo/triedenyZberPapieraPlastovASklaPreSpravcovskeSpolocnosti.ts
@@ -5,7 +5,6 @@ import {
   customComponentsField,
   datePicker,
   input,
-  markdownText,
   number,
   object,
   radioGroup,
@@ -223,9 +222,9 @@ export default schema(
               ]),
             },
             {
-              helptext: markdownText(
+              helptext:
                 'Vyberte len 1 komoditu. Správcovia nehnuteľností v prípade Kuchynského biologicky rozložiteľného odpadu riešia zapojenie a zmeny v systéme zapojenia na Magistráte hlavného mesta. **Zmesový komunálny odpad sa rieši na** [Magistráte hlavného mesta](https://bratislava.sk/mesto-bratislava/dane-a-poplatky/poplatok-za-komunalne-odpady-a-drobne-stavebne-odpady).',
-              ),
+              helptextMarkdown: true,
             },
           ),
           conditionalFields(

--- a/forms-shared/src/schemas/predzahradky.ts
+++ b/forms-shared/src/schemas/predzahradky.ts
@@ -2,7 +2,6 @@ import {
   conditionalFields,
   fileUpload,
   input,
-  markdownText,
   object,
   radioGroup,
   schema,
@@ -102,9 +101,10 @@ export default schema(
           'parcelneCislo',
           { title: 'Číslo parcely', required: true, type: 'text' },
           {
-            helptext: markdownText(
+            helptext:
               'Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13). Pre schválenie žiadosti sa musí jednať o mestský pozemok.',
-            ),
+            helptextMarkdown: true,
+
             size: 'medium',
           },
         ),

--- a/forms-shared/src/schemas/predzahradky.ts
+++ b/forms-shared/src/schemas/predzahradky.ts
@@ -102,7 +102,7 @@ export default schema(
           'parcelneCislo',
           { title: 'Číslo parcely', required: true, type: 'text' },
           {
-            helptextHeader: markdownText(
+            helptext: markdownText(
               'Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13). Pre schválenie žiadosti sa musí jednať o mestský pozemok.',
             ),
             size: 'medium',
@@ -129,7 +129,7 @@ export default schema(
             },
             {
               placeholder: 'Popíšte',
-              helptextHeader: 'Popíšte rozloženie jednotlivých prvkov predzáhradky.',
+              helptext: 'Popíšte rozloženie jednotlivých prvkov predzáhradky.',
             },
           ),
           input(
@@ -143,7 +143,7 @@ export default schema(
           { title: 'Iné', required: true },
           {
             placeholder: 'Popíšte',
-            helptextHeader:
+            helptext:
               'Ak by ste nám chceli ešte niečo v súvislosti s predzáhradkou napísať, tu je na to priestor.',
           },
         ),
@@ -169,8 +169,7 @@ export default schema(
         { title: 'Projekt predzáhradky' },
         {
           type: 'dragAndDrop',
-          helptextHeader:
-            'Napríklad, vo forme jednoduchého nákresu rozloženia jednotlivých prvkov.',
+          helptext: 'Napríklad, vo forme jednoduchého nákresu rozloženia jednotlivých prvkov.',
         },
       ),
       fileUpload('inePrilohy', { title: 'Iné' }, { type: 'dragAndDrop' }),

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/kalkulacky.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/kalkulacky.ts
@@ -4,12 +4,12 @@ import { createCondition } from '../../generator/helpers'
 export const kalkulackaFields = ({
   title,
   checkboxLabel,
-  helptextFooter,
+  helptext,
   inner,
 }: {
   title: string
   checkboxLabel: string
-  helptextFooter: string
+  helptext: string
   inner: (kalkulacka: boolean) => Field
 }) => [
   object(
@@ -30,7 +30,7 @@ export const kalkulackaFields = ({
           variant: 'basic',
           labelSize: 'h3',
           checkboxLabel,
-          helptextFooter,
+          helptext,
         },
       ),
     ],

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/kalkulacky.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/kalkulacky.ts
@@ -4,12 +4,12 @@ import { createCondition } from '../../generator/helpers'
 export const kalkulackaFields = ({
   title,
   checkboxLabel,
-  helptextHeader,
+  helptext,
   inner,
 }: {
   title: string
   checkboxLabel: string
-  helptextHeader: string
+  helptext: string
   inner: (kalkulacka: boolean) => Field
 }) => [
   object(
@@ -30,7 +30,7 @@ export const kalkulackaFields = ({
           variant: 'basic',
           labelSize: 'h3',
           checkboxLabel,
-          helptextHeader,
+          helptext,
         },
       ),
     ],

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/kalkulacky.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/kalkulacky.ts
@@ -4,12 +4,12 @@ import { createCondition } from '../../generator/helpers'
 export const kalkulackaFields = ({
   title,
   checkboxLabel,
-  helptext,
+  helptextFooter,
   inner,
 }: {
   title: string
   checkboxLabel: string
-  helptext: string
+  helptextFooter: string
   inner: (kalkulacka: boolean) => Field
 }) => [
   object(
@@ -30,7 +30,7 @@ export const kalkulackaFields = ({
           variant: 'basic',
           labelSize: 'h3',
           checkboxLabel,
-          helptext,
+          helptextFooter,
         },
       ),
     ],

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/osoby.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/osoby.ts
@@ -15,7 +15,7 @@ const rodneCisloField = input(
   'rodneCislo',
   { type: 'text', title: 'Rodné číslo', required: true },
   {
-    helptext:
+    helptextFooter:
       'Rodné číslo zadávajte s lomítkom. V prípade, že nemáte rodné číslo, uveďte dátum narodenia v tvare DD.MM.YYYY.',
   },
 )
@@ -52,7 +52,7 @@ const ulicaCisloFields = (type: UlicaCisloTyp) =>
         'ulica',
         { type: 'text', title: 'Ulica', required: true },
         {
-          helptext: {
+          helptextFooter: {
             [UlicaCisloTyp.FyzickaOsoba]: 'Zadajte ulicu svojho trvalého pobytu.',
             [UlicaCisloTyp.FyzickaOsobaPodnikatel]:
               'Zadajte ulicu miesta podnikania podľa živnostenského registra.',
@@ -98,7 +98,7 @@ const emailField = (required = true) =>
   input(
     'email',
     { title: 'E-mail', type: 'email', required },
-    { helptext: 'E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.' },
+    { helptextFooter: 'E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.' },
   )
 
 const telefonField = (required = true) =>

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/pravnyVztahSpoluvlastnictvo.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/pravnyVztahSpoluvlastnictvo.ts
@@ -51,7 +51,7 @@ export const pravnyVztahSpoluvlastnictvo = (step?: StepEnum) => [
         { title: 'Zadajte počet spoluvlastníkov', type: 'integer', minimum: 1, required: true },
         {
           size: 'medium',
-          helptext:
+          helptextFooter:
             'Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).',
         },
       ),
@@ -102,7 +102,7 @@ export const pravnyVztahSpoluvlastnictvo = (step?: StepEnum) => [
               },
             },
           ],
-          helptext:
+          helptextFooter:
             'Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.',
         },
       ),

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/stavbyBase.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/stavbyBase.ts
@@ -1,4 +1,4 @@
-import { input, markdownText, number, object, select } from '../../generator/functions'
+import { input, number, object, select } from '../../generator/functions'
 import { createStringItems } from '../../generator/helpers'
 import { pravnyVztahSpoluvlastnictvo } from './pravnyVztahSpoluvlastnictvo'
 import { StepEnum } from './stepEnum'
@@ -71,18 +71,17 @@ export const stavbyBase = (step: StepEnum) => [
         { type: 'text', title: 'Číslo parcely', required: true },
         {
           placeholder: 'Napr. 7986/1',
-          helptext: markdownText(
-            {
-              [StepEnum.DanZPozemkov]:
-                'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}',
-              [StepEnum.DanZoStaviebJedencel]:
-                'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}',
-              [StepEnum.DanZoStaviebViacereUcely]:
-                'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}',
-              [StepEnum.DanZBytovANebytovychPriestorov]:
-                'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}',
-            }[step],
-          ),
+          helptext: {
+            [StepEnum.DanZPozemkov]:
+              'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}',
+            [StepEnum.DanZoStaviebJedencel]:
+              'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}',
+            [StepEnum.DanZoStaviebViacereUcely]:
+              'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}',
+            [StepEnum.DanZBytovANebytovychPriestorov]:
+              'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}',
+          }[step],
+          helptextMarkdown: true,
         },
       ),
     ],

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/stavbyBase.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/stavbyBase.ts
@@ -71,7 +71,7 @@ export const stavbyBase = (step: StepEnum) => [
         { type: 'text', title: 'Číslo parcely', required: true },
         {
           placeholder: 'Napr. 7986/1',
-          helptext: {
+          helptextFooter: {
             [StepEnum.DanZPozemkov]:
               'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}',
             [StepEnum.DanZoStaviebJedencel]:
@@ -81,7 +81,7 @@ export const stavbyBase = (step: StepEnum) => [
             [StepEnum.DanZBytovANebytovychPriestorov]:
               'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}',
           }[step],
-          helptextMarkdown: true,
+          helptextFooterMarkdown: true,
         },
       ),
     ],

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step1.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step1.ts
@@ -1,4 +1,4 @@
-import { markdownText, number, radioGroup, step } from '../../generator/functions'
+import { number, radioGroup, step } from '../../generator/functions'
 import { createCamelCaseItemsV2 } from '../../generator/helpers'
 
 export default step('druhPriznania', { title: 'Druh priznania' }, [
@@ -46,9 +46,8 @@ export default step('druhPriznania', { title: 'Druh priznania' }, [
       maximum: 2099,
     },
     {
-      helptext: markdownText(
-        `Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.`,
-      ),
+      helptext: `Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.`,
+      helptextMarkdown: true,
     },
   ),
 ])

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step1.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step1.ts
@@ -46,8 +46,8 @@ export default step('druhPriznania', { title: 'Druh priznania' }, [
       maximum: 2099,
     },
     {
-      helptext: `Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.`,
-      helptextMarkdown: true,
+      helptextFooter: `Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.`,
+      helptextFooterMarkdown: true,
     },
   ),
 ])

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step2.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step2.ts
@@ -36,9 +36,9 @@ export default step('udajeODanovnikovi', { title: 'Údaje o daňovníkovi' }, [
           { title: 'Nahrajte splnomocnenie', multiple: true },
           {
             type: 'dragAndDrop',
-            helptext:
+            helptextFooter:
               'Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.',
-            helptextMarkdown: true,
+            helptextFooterMarkdown: true,
           },
         ),
         radioGroup(

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step2.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step2.ts
@@ -1,11 +1,4 @@
-import {
-  conditionalFields,
-  fileUpload,
-  markdownText,
-  object,
-  radioGroup,
-  step,
-} from '../../generator/functions'
+import { conditionalFields, fileUpload, object, radioGroup, step } from '../../generator/functions'
 import { createCamelCaseItemsV2, createCondition } from '../../generator/helpers'
 import { danovnik, splnomocnenec } from './osoby'
 
@@ -43,9 +36,9 @@ export default step('udajeODanovnikovi', { title: 'Údaje o daňovníkovi' }, [
           { title: 'Nahrajte splnomocnenie', multiple: true },
           {
             type: 'dragAndDrop',
-            helptext: markdownText(
+            helptext:
               'Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.',
-            ),
+            helptextMarkdown: true,
           },
         ),
         radioGroup(

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step3.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step3.ts
@@ -317,11 +317,11 @@ export default step(
   { title: 'Priznanie k dani z pozemkov', stepperTitle: 'Daň z pozemkov' },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani z pozemkov?',
-    helptextFooter: `K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}`,
-    helptextFooterMarkdown: true,
+    helptext: `K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}`,
+    helptextMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery pozemkov',
-      helptextFooter:
+      helptext:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.',
       checkboxLabel: 'Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu výmery pozemkov',
       inner: innerArray,

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step3.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step3.ts
@@ -321,7 +321,7 @@ export default step(
     ),
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery pozemkov',
-      helptextHeader:
+      helptext:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.',
       checkboxLabel: 'Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu výmery pozemkov',
       inner: innerArray,

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step3.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step3.ts
@@ -5,7 +5,6 @@ import {
   datePicker,
   fileUpload,
   input,
-  markdownText,
   number,
   object,
   radioGroup,
@@ -23,9 +22,9 @@ const celkovaVymeraPozemku = number(
   'celkovaVymeraPozemku',
   { title: 'Celková výmera pozemku', required: true, minimum: 0 },
   {
-    helptext: markdownText(
+    helptext:
       'Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}',
-    ),
+    helptextMarkdown: true,
   },
 )
 
@@ -38,9 +37,9 @@ const podielPriestoruNaSpolocnychCastiachAZariadeniachDomu = input(
   },
   {
     placeholder: 'Napr. 4827/624441',
-    helptext: markdownText(
+    helptext:
       'Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}',
-    ),
+    helptextMarkdown: true,
   },
 )
 
@@ -49,9 +48,9 @@ const spoluvlastnickyPodiel = input(
   { type: 'ba-ratio', title: 'Spoluvlastnícky podiel', required: true },
   {
     placeholder: 'Napr. 1/1 alebo 1/105',
-    helptext: markdownText(
+    helptext:
       'Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}',
-    ),
+    helptextMarkdown: true,
   },
 )
 
@@ -70,7 +69,8 @@ const vymeraPozemkuKalkulacka = customComponentsField(
             '- Celková výmera pozemku\n' +
             '- Podiel priestoru na spoločných častiach a zariadeniach domu\n' +
             '- Spoluvlastnícky podiel',
-          unit: markdownText('m^2^'),
+          unit: 'm^2^',
+          unitMarkdown: true,
         },
       ],
     },
@@ -109,9 +109,9 @@ const innerArray = (kalkulacka: boolean) =>
           variant: 'nested',
           addButtonLabel: 'Pridať ďalší pozemok (na tom istom LV)',
           itemTitle: 'Pozemok č. {index}',
-          description: markdownText(
+          description:
             'Pozemky pod stavbami, v ktorej máte nehnuteľnosť, sa nezdaňujú.\n\n:form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_c16049c4bd.png"}',
-          ),
+          descriptionMarkdown: true,
           cannotAddItemMessage:
             'Dosiahli ste maximálny počet pozemkov (17) na jedno priznanie. Pridajte ďalšie priznanie.',
         },
@@ -167,9 +167,9 @@ const innerArray = (kalkulacka: boolean) =>
                 { type: 'text', title: 'Číslo parcely', required: true },
                 {
                   placeholder: 'Napr. 7986/1',
-                  helptext: markdownText(
+                  helptext:
                     'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}',
-                  ),
+                  helptextMarkdown: true,
                 },
               ),
               input(
@@ -223,9 +223,9 @@ const innerArray = (kalkulacka: boolean) =>
               ],
             },
             {
-              helptext: markdownText(
+              helptext:
                 'V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}',
-              ),
+              helptextMarkdown: true,
             },
           ),
           conditionalFields(createCondition([[['druhPozemku'], { enum: ['D', 'G'] }]]), [
@@ -261,9 +261,9 @@ const innerArray = (kalkulacka: boolean) =>
                 },
                 {
                   type: 'dragAndDrop',
-                  helptext: markdownText(
+                  helptext:
                     'V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.',
-                  ),
+                  helptextMarkdown: true,
                 },
               ),
             ],
@@ -316,9 +316,8 @@ export default step(
   { title: 'Priznanie k dani z pozemkov', stepperTitle: 'Daň z pozemkov' },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani z pozemkov?',
-    helptext: markdownText(
-      `K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}`,
-    ),
+    helptext: `K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}`,
+    helptextMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery pozemkov',
       helptext:

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step3.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step3.ts
@@ -22,9 +22,9 @@ const celkovaVymeraPozemku = number(
   'celkovaVymeraPozemku',
   { title: 'Celková výmera pozemku', required: true, minimum: 0 },
   {
-    helptext:
+    helptextFooter:
       'Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}',
-    helptextMarkdown: true,
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -37,9 +37,9 @@ const podielPriestoruNaSpolocnychCastiachAZariadeniachDomu = input(
   },
   {
     placeholder: 'Napr. 4827/624441',
-    helptext:
+    helptextFooter:
       'Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}',
-    helptextMarkdown: true,
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -48,9 +48,9 @@ const spoluvlastnickyPodiel = input(
   { type: 'ba-ratio', title: 'Spoluvlastnícky podiel', required: true },
   {
     placeholder: 'Napr. 1/1 alebo 1/105',
-    helptext:
+    helptextFooter:
       'Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}',
-    helptextMarkdown: true,
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -82,7 +82,7 @@ const vymeraPozemku = number(
   'vymeraPozemku',
   { title: 'Vaša výmera pozemku', required: true, minimum: 0 },
   {
-    helptext:
+    helptextFooter:
       'Zadajte výsledok výpočtu vašej časti/podielu na výmere pozemku ako číslo na dve desatinné čísla - bez zaokrúhlenia (napr. 0,65)',
   },
 )
@@ -167,16 +167,16 @@ const innerArray = (kalkulacka: boolean) =>
                 { type: 'text', title: 'Číslo parcely', required: true },
                 {
                   placeholder: 'Napr. 7986/1',
-                  helptext:
+                  helptextFooter:
                     'Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}',
-                  helptextMarkdown: true,
+                  helptextFooterMarkdown: true,
                 },
               ),
               input(
                 'sposobVyuzitiaPozemku',
                 { type: 'text', title: 'Spôsob využitia pozemku' },
                 {
-                  helptext:
+                  helptextFooter:
                     'Vyplňte, ak na pozemok bolo vydané povolenie na dobývanie ložiska nevyhradeného nerastu alebo sa na pozemku nachádza zariadenie na výrobu elektriny zo slnečnej energie, transformačná stanica alebo predajný stánok slúžiaci k predaju tovaru a poskytovaniu služieb.',
                 },
               ),
@@ -223,9 +223,9 @@ const innerArray = (kalkulacka: boolean) =>
               ],
             },
             {
-              helptext:
+              helptextFooter:
                 'V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}',
-              helptextMarkdown: true,
+              helptextFooterMarkdown: true,
             },
           ),
           conditionalFields(createCondition([[['druhPozemku'], { enum: ['D', 'G'] }]]), [
@@ -261,9 +261,9 @@ const innerArray = (kalkulacka: boolean) =>
                 },
                 {
                   type: 'dragAndDrop',
-                  helptext:
+                  helptextFooter:
                     'V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.',
-                  helptextMarkdown: true,
+                  helptextFooterMarkdown: true,
                 },
               ),
             ],
@@ -287,7 +287,7 @@ const innerArray = (kalkulacka: boolean) =>
                 'datumVznikuDanovejPovinnosti',
                 { title: 'Dátum vzniku daňovej povinnosti' },
                 {
-                  helptext:
+                  helptextFooter:
                     'Vypĺňate len v prípade, ak ste pozemok zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).',
                 },
               ),
@@ -295,7 +295,7 @@ const innerArray = (kalkulacka: boolean) =>
                 'datumZanikuDanovejPovinnosti',
                 { title: 'Dátum zániku daňovej povinnosti' },
                 {
-                  helptext:
+                  helptextFooter:
                     'Vypĺňate len v prípade, ak ste pozemok predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).',
                 },
               ),
@@ -316,11 +316,11 @@ export default step(
   { title: 'Priznanie k dani z pozemkov', stepperTitle: 'Daň z pozemkov' },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani z pozemkov?',
-    helptext: `K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}`,
-    helptextMarkdown: true,
+    helptextFooter: `K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}`,
+    helptextFooterMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery pozemkov',
-      helptext:
+      helptextFooter:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.',
       checkboxLabel: 'Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu výmery pozemkov',
       inner: innerArray,

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step4.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step4.ts
@@ -255,11 +255,11 @@ export default step(
   },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani zo stavieb slúžiacich na jeden účel?',
-    helptextFooter: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).\n\n:form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}`,
-    helptextFooterMarkdown: true,
+    helptext: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).\n\n:form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}`,
+    helptextMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery zastavanej plochy stavby',
-      helptextFooter:
+      helptext:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.',
       checkboxLabel: 'Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu zastavanej plochy',
       inner: innerArray,

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step4.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step4.ts
@@ -4,7 +4,6 @@ import {
   customComponentsField,
   datePicker,
   input,
-  markdownText,
   number,
   object,
   radioGroup,
@@ -22,9 +21,9 @@ const celkovaZastavanaPlocha = number(
   'celkovaZastavanaPlocha',
   { type: 'integer', title: 'Celková zastavaná plocha', required: true, minimum: 0 },
   {
-    helptext: markdownText(
+    helptext:
       'Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}',
-    ),
+    helptextMarkdown: true,
   },
 )
 
@@ -37,9 +36,9 @@ const spoluvlastnickyPodiel = input(
   },
   {
     placeholder: 'Napr. 1/1',
-    helptext: markdownText(
+    helptext:
       'Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}',
-    ),
+    helptextMarkdown: true,
   },
 )
 
@@ -47,9 +46,9 @@ const zakladDane = number(
   'zakladDane',
   { type: 'integer', title: 'Základ dane', required: true, minimum: 0 },
   {
-    helptext: markdownText(
+    helptext:
       'Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.',
-    ),
+    helptextMarkdown: true,
   },
 )
 
@@ -66,7 +65,8 @@ const zakladDaneKalkulacka = customComponentsField(
             '**Pre výpočet základu dane vyplňte správne všetky polia:**\n' +
             '- Celková zastavaná plocha\n' +
             '- Spoluvlastnícky podiel',
-          unit: markdownText('m^2^'),
+          unit: 'm^2^',
+          unitMarkdown: true,
         },
       ],
     },
@@ -253,9 +253,8 @@ export default step(
   },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani zo stavieb slúžiacich na jeden účel?',
-    helptext: markdownText(
-      `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).\n\n:form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}`,
-    ),
+    helptext: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).\n\n:form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}`,
+    helptextMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery zastavanej plochy stavby',
       helptext:

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step4.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step4.ts
@@ -21,9 +21,9 @@ const celkovaZastavanaPlocha = number(
   'celkovaZastavanaPlocha',
   { type: 'integer', title: 'Celková zastavaná plocha', required: true, minimum: 0 },
   {
-    helptext:
+    helptextFooter:
       'Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}',
-    helptextMarkdown: true,
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -36,9 +36,9 @@ const spoluvlastnickyPodiel = input(
   },
   {
     placeholder: 'Napr. 1/1',
-    helptext:
+    helptextFooter:
       'Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}',
-    helptextMarkdown: true,
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -46,9 +46,9 @@ const zakladDane = number(
   'zakladDane',
   { type: 'integer', title: 'Základ dane', required: true, minimum: 0 },
   {
-    helptext:
+    helptextFooter:
       'Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.',
-    helptextMarkdown: true,
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -138,7 +138,7 @@ const innerArray = (kalkulacka: boolean) =>
           ],
         },
         {
-          helptext: 'Vyberte stavbu, ktorú zdaňujete, podľa účelu využitia.',
+          helptextFooter: 'Vyberte stavbu, ktorú zdaňujete, podľa účelu využitia.',
         },
       ),
       kalkulacka ? celkovaZastavanaPlocha : skipSchema(celkovaZastavanaPlocha),
@@ -154,7 +154,8 @@ const innerArray = (kalkulacka: boolean) =>
           required: true,
         },
         {
-          helptext: 'Napríklad, ak máte dom s dvomi podlažiami a s pivničným priestorom, zadáte 2.',
+          helptextFooter:
+            'Napríklad, ak máte dom s dvomi podlažiami a s pivničným priestorom, zadáte 2.',
         },
       ),
       radioGroup(
@@ -191,7 +192,7 @@ const innerArray = (kalkulacka: boolean) =>
                 minimum: 0,
               },
               {
-                helptext:
+                helptextFooter:
                   'Spočítajte výmeru na všetkých podlažiach. U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.',
               },
             ),
@@ -204,7 +205,7 @@ const innerArray = (kalkulacka: boolean) =>
                 minimum: 0,
               },
               {
-                helptext: 'U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.',
+                helptextFooter: 'U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.',
               },
             ),
           ],
@@ -222,7 +223,7 @@ const innerArray = (kalkulacka: boolean) =>
             'datumVznikuDanovejPovinnosti',
             { title: 'Dátum vzniku daňovej povinnosti' },
             {
-              helptext:
+              helptextFooter:
                 'Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).',
             },
           ),
@@ -230,7 +231,7 @@ const innerArray = (kalkulacka: boolean) =>
             'datumZanikuDanovejPovinnosti',
             { title: 'Dátum zániku daňovej povinnosti' },
             {
-              helptext:
+              helptextFooter:
                 'Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).',
             },
           ),
@@ -253,11 +254,11 @@ export default step(
   },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani zo stavieb slúžiacich na jeden účel?',
-    helptext: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).\n\n:form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}`,
-    helptextMarkdown: true,
+    helptextFooter: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.\n\nV prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).\n\n:form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}`,
+    helptextFooterMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery zastavanej plochy stavby',
-      helptext:
+      helptextFooter:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.',
       checkboxLabel: 'Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu zastavanej plochy',
       inner: innerArray,

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step4.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step4.ts
@@ -258,7 +258,7 @@ export default step(
     ),
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery zastavanej plochy stavby',
-      helptextHeader:
+      helptext:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.',
       checkboxLabel: 'Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu zastavanej plochy',
       inner: innerArray,

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step5.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step5.ts
@@ -4,7 +4,6 @@ import {
   customComponentsField,
   datePicker,
   input,
-  markdownText,
   number,
   object,
   radioGroup,
@@ -22,9 +21,8 @@ const vymeraPodlahovejPlochy = number(
   'vymeraPodlahovejPlochy',
   { type: 'integer', title: 'Výmera podlahovej plochy', required: true, minimum: 0 },
   {
-    helptext: markdownText(
-      'Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).',
-    ),
+    helptext: 'Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).',
+    helptextMarkdown: true,
   },
 )
 
@@ -42,7 +40,8 @@ const vymeraPodlahovejPlochyKalkulacka = customComponentsField(
             '**Pre výpočet výmery podlahovej plochy vyplňte správne všetky polia:**\n' +
             '- Podiel priestoru na spoločných častiach a zariadeniach domu\n' +
             '- Spoluvlastnícky podiel',
-          unit: markdownText('m^2^'),
+          unit: 'm^2^',
+          unitMarkdown: true,
         },
       ],
     },
@@ -59,9 +58,9 @@ const podielPriestoruNaSpolocnychCastiachAZariadeniachDomu = input(
   },
   {
     placeholder: 'Napr. 4827/624441',
-    helptext: markdownText(
+    helptext:
       'Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}',
-    ),
+    helptextMarkdown: true,
   },
 )
 
@@ -70,9 +69,9 @@ const spoluvlastnickyPodiel = input(
   { type: 'ba-ratio', title: 'Spoluvlastnícky podiel', required: true },
   {
     placeholder: 'Napr. 1/1 alebo 1/105',
-    helptext: markdownText(
+    helptext:
       'Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}',
-    ),
+    helptextMarkdown: true,
   },
 )
 
@@ -86,9 +85,9 @@ const sumar = object('sumar', { required: true }, { objectDisplay: 'boxed', titl
       minimum: 0,
     },
     {
-      helptext: markdownText(
+      helptext:
         'Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.',
-      ),
+      helptextMarkdown: true,
     },
   ),
   number(
@@ -100,9 +99,9 @@ const sumar = object('sumar', { required: true }, { objectDisplay: 'boxed', titl
       minimum: 0,
     },
     {
-      helptext: markdownText(
+      helptext:
         'Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.',
-      ),
+      helptextMarkdown: true,
     },
   ),
 ])
@@ -122,7 +121,8 @@ const sumarKalkulacka = customComponentsField(
           missingFieldsMessage:
             '**Pre výpočet celkovej výmery podlahových plôch všetkých podlaží stavby vyplňte správne všetky polia:**\n' +
             '- Podiel priestoru na spoločných častiach a zariadeniach domu a spoluvlastnícky podiel pre každú časť stavby',
-          unit: markdownText('m^2^'),
+          unit: 'm^2^',
+          unitMarkdown: true,
         },
         {
           label: 'Základ dane – celková výmera zastavanej plochy stavby',
@@ -133,7 +133,8 @@ const sumarKalkulacka = customComponentsField(
             '**Pre výpočet základu dane vyplňte správne všetky polia:**\n' +
             '- Celková výmera zastavanej plochy viacúčelovej stavby\n' +
             '- Podiel priestoru na spoločných častiach a zariadeniach domu a spoluvlastnícky podiel pre každú časť stavby',
-          unit: markdownText('m^2^'),
+          unit: 'm^2^',
+          unitMarkdown: true,
         },
       ],
     },
@@ -199,9 +200,9 @@ const innerArray = (kalkulacka: boolean) =>
           minimum: 0,
         },
         {
-          helptext: markdownText(
+          helptext:
             'Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}',
-          ),
+          helptextMarkdown: true,
         },
       ),
       number(
@@ -338,9 +339,8 @@ export default step(
   },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani zo stavieb slúžiacich na viaceré účely?',
-    helptext: markdownText(
-      `Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.\n\nK úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):\n* k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)\n* k jednotlivým stavbám (napr. byt, garážové státie).\n\nV prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}`,
-    ),
+    helptext: `Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.\n\nK úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):\n* k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)\n* k jednotlivým stavbám (napr. byt, garážové státie).\n\nV prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}`,
+    helptextMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery podlahových plôch a základu dane',
       helptext:

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step5.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step5.ts
@@ -21,8 +21,8 @@ const vymeraPodlahovejPlochy = number(
   'vymeraPodlahovejPlochy',
   { type: 'integer', title: 'Výmera podlahovej plochy', required: true, minimum: 0 },
   {
-    helptext: 'Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).',
-    helptextMarkdown: true,
+    helptextFooter: 'Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).',
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -58,9 +58,9 @@ const podielPriestoruNaSpolocnychCastiachAZariadeniachDomu = input(
   },
   {
     placeholder: 'Napr. 4827/624441',
-    helptext:
+    helptextFooter:
       'Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}',
-    helptextMarkdown: true,
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -69,9 +69,9 @@ const spoluvlastnickyPodiel = input(
   { type: 'ba-ratio', title: 'Spoluvlastnícky podiel', required: true },
   {
     placeholder: 'Napr. 1/1 alebo 1/105',
-    helptext:
+    helptextFooter:
       'Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}',
-    helptextMarkdown: true,
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -85,9 +85,9 @@ const sumar = object('sumar', { required: true }, { objectDisplay: 'boxed', titl
       minimum: 0,
     },
     {
-      helptext:
+      helptextFooter:
         'Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.',
-      helptextMarkdown: true,
+      helptextFooterMarkdown: true,
     },
   ),
   number(
@@ -99,9 +99,9 @@ const sumar = object('sumar', { required: true }, { objectDisplay: 'boxed', titl
       minimum: 0,
     },
     {
-      helptext:
+      helptextFooter:
         'Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.',
-      helptextMarkdown: true,
+      helptextFooterMarkdown: true,
     },
   ),
 ])
@@ -162,7 +162,7 @@ const innerArray = (kalkulacka: boolean) =>
         { type: 'text', title: 'Popis stavby', required: true },
         {
           placeholder: 'Napr. polyfunkčná budova',
-          helptext:
+          helptextFooter:
             'Uveďte stručný popis stavby, napr. administratívna budova, polyfunkčná stavba a pod. (vychádzajte z LV).',
         },
       ),
@@ -178,7 +178,7 @@ const innerArray = (kalkulacka: boolean) =>
             'datumVznikuDanovejPovinnosti',
             { title: 'Dátum vzniku daňovej povinnosti' },
             {
-              helptext:
+              helptextFooter:
                 'Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).',
             },
           ),
@@ -186,7 +186,7 @@ const innerArray = (kalkulacka: boolean) =>
             'datumZanikuDanovejPovinnosti',
             { title: 'Dátum zániku daňovej povinnosti' },
             {
-              helptext:
+              helptextFooter:
                 'Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).',
             },
           ),
@@ -200,9 +200,9 @@ const innerArray = (kalkulacka: boolean) =>
           minimum: 0,
         },
         {
-          helptext:
+          helptextFooter:
             'Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}',
-          helptextMarkdown: true,
+          helptextFooterMarkdown: true,
         },
       ),
       number(
@@ -214,7 +214,7 @@ const innerArray = (kalkulacka: boolean) =>
           required: true,
         },
         {
-          helptext:
+          helptextFooter:
             'Napríklad ak máte stavbu s piatimi nadzemnými podlažiami a dvomi podzemnými podlažiami, uvádzate počet 6.',
         },
       ),
@@ -245,7 +245,7 @@ const innerArray = (kalkulacka: boolean) =>
             minimum: 0,
           },
           {
-            helptext: 'U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.',
+            helptextFooter: 'U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.',
           },
         ),
       ]),
@@ -339,11 +339,11 @@ export default step(
   },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani zo stavieb slúžiacich na viaceré účely?',
-    helptext: `Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.\n\nK úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):\n* k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)\n* k jednotlivým stavbám (napr. byt, garážové státie).\n\nV prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}`,
-    helptextMarkdown: true,
+    helptextFooter: `Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.\n\nK úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):\n* k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)\n* k jednotlivým stavbám (napr. byt, garážové státie).\n\nV prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}`,
+    helptextFooterMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery podlahových plôch a základu dane',
-      helptext:
+      helptextFooter:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.',
       checkboxLabel:
         'Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch a základu dane',

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step5.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step5.ts
@@ -341,11 +341,11 @@ export default step(
   },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani zo stavieb slúžiacich na viaceré účely?',
-    helptextFooter: `Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.\n\nK úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):\n* k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)\n* k jednotlivým stavbám (napr. byt, garážové státie).\n\nV prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}`,
-    helptextFooterMarkdown: true,
+    helptext: `Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.\n\nK úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):\n* k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)\n* k jednotlivým stavbám (napr. byt, garážové státie).\n\nV prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}`,
+    helptextMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery podlahových plôch a základu dane',
-      helptextFooter:
+      helptext:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.',
       checkboxLabel:
         'Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch a základu dane',

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step5.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step5.ts
@@ -343,7 +343,7 @@ export default step(
     ),
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery podlahových plôch a základu dane',
-      helptextHeader:
+      helptext:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.',
       checkboxLabel:
         'Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch a základu dane',

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step6.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step6.ts
@@ -375,11 +375,11 @@ export default step(
   },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani z bytov a z nebytových priestorov v bytovom dome?',
-    helptextFooter: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.\n\nV prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}`,
-    helptextFooterMarkdown: true,
+    helptext: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.\n\nV prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}`,
+    helptextMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery podlahových plôch bytov a nebytových priestorov',
-      helptextFooter:
+      helptext:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.',
       checkboxLabel: 'Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch',
       inner: innerArray,

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step6.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step6.ts
@@ -380,7 +380,7 @@ export default step(
     ),
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery podlahových plôch bytov a nebytových priestorov',
-      helptextHeader:
+      helptext:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.',
       checkboxLabel: 'Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch',
       inner: innerArray,

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step6.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step6.ts
@@ -44,8 +44,8 @@ const vymeraPodlahovejPlochyBytu = number(
     minimum: 0,
   },
   {
-    helptext: 'Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).',
-    helptextMarkdown: true,
+    helptextFooter: 'Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).',
+    helptextFooterMarkdown: true,
   },
 )
 
@@ -62,7 +62,7 @@ const celkovaVymeraSpecialCase = (typ: Typ) =>
       minimum: 0,
     },
     {
-      helptext:
+      helptextFooter:
         'Ak má číslo za lomkou vo vašom podiele priestoru na spoločných častiach hodnotu, napríklad, 1 000, 10 000, alebo 100 000, údaj z listu vlastníctva vám nepomôže. Správne údaje o podlahovej ploche nájdete v kúpnej zmluve alebo znaleckom posudku (celková podlahová plocha okrem balkónov, lodžií a terás).',
     },
   )
@@ -103,11 +103,11 @@ const podielPriestoruNaSpolocnychCastiachAZariadeniachDomu = (typ: Typ) =>
     },
     {
       placeholder: typ === Typ.Byt ? 'Napr. 4827/624441' : 'Napr. 124827/624441',
-      helptext:
+      helptextFooter:
         typ === Typ.Byt
           ? 'Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}'
           : 'Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}',
-      helptextMarkdown: true,
+      helptextFooterMarkdown: true,
     },
   )
 
@@ -117,11 +117,11 @@ const spoluvlastnickyPodiel = (typ: Typ) =>
     { type: 'ba-ratio', title: 'Spoluvlastnícky podiel', required: true },
     {
       placeholder: 'Napr. 1/150',
-      helptext:
+      helptextFooter:
         typ === Typ.Byt
           ? 'Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}'
           : 'Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}',
-      helptextMarkdown: true,
+      helptextFooterMarkdown: true,
     },
   )
 
@@ -134,7 +134,7 @@ const vymeraPodlahovychPlochNebytovehoPriestoruVBytovomDome = number(
     minimum: 0,
   },
   {
-    helptext: 'Zadávajte číslo zaokrúhlené nahor na celé číslo (príklad: 48,27 = 49).',
+    helptextFooter: 'Zadávajte číslo zaokrúhlené nahor na celé číslo (príklad: 48,27 = 49).',
   },
 )
 
@@ -182,7 +182,7 @@ const innerArray = (kalkulacka: boolean) =>
             input(
               'popisBytu',
               { type: 'text', title: 'Popis bytu' },
-              { helptext: 'Stručný popis bytu.', placeholder: 'Napr. dvojizbový byt' },
+              { helptextFooter: 'Stručný popis bytu.', placeholder: 'Napr. dvojizbový byt' },
             ),
             kalkulacka
               ? podielPriestoruNaSpolocnychCastiachAZariadeniachDomu(Typ.Byt)
@@ -205,7 +205,7 @@ const innerArray = (kalkulacka: boolean) =>
                 minimum: 0,
               },
               {
-                helptext:
+                helptextFooter:
                   'Vyplňte v prípade, ak používate časť bytu napríklad na podnikateľské účely. Zadajte výmeru.',
               },
             ),
@@ -221,7 +221,7 @@ const innerArray = (kalkulacka: boolean) =>
                   'datumVznikuDanovejPovinnosti',
                   { title: 'Dátum vzniku daňovej povinnosti' },
                   {
-                    helptext:
+                    helptextFooter:
                       'Vypĺňate len v prípade, ak ste byt zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).',
                   },
                 ),
@@ -229,7 +229,7 @@ const innerArray = (kalkulacka: boolean) =>
                   'datumZanikuDanovejPovinnosti',
                   { title: 'Dátum zániku daňovej povinnosti' },
                   {
-                    helptext:
+                    helptextFooter:
                       'Vypĺňate len v prípade, ak ste byt predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).',
                   },
                 ),
@@ -292,7 +292,7 @@ const innerArray = (kalkulacka: boolean) =>
                         required: true,
                       },
                       {
-                        helptext: 'Napr. garážovanie, skladovanie, podnikanie alebo iné.',
+                        helptextFooter: 'Napr. garážovanie, skladovanie, podnikanie alebo iné.',
                       },
                     ),
                     input(
@@ -303,9 +303,9 @@ const innerArray = (kalkulacka: boolean) =>
                         required: true,
                       },
                       {
-                        helptext:
+                        helptextFooter:
                           'Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}',
-                        helptextMarkdown: true,
+                        helptextFooterMarkdown: true,
                       },
                     ),
                   ],
@@ -339,7 +339,7 @@ const innerArray = (kalkulacka: boolean) =>
                       'datumVznikuDanovejPovinnosti',
                       { title: 'Dátum vzniku daňovej povinnosti' },
                       {
-                        helptext:
+                        helptextFooter:
                           'Vypĺňate len v prípade, ak ste nebytový priestor zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).',
                       },
                     ),
@@ -347,7 +347,7 @@ const innerArray = (kalkulacka: boolean) =>
                       'datumZanikuDanovejPovinnosti',
                       { title: 'Dátum zániku daňovej povinnosti' },
                       {
-                        helptext:
+                        helptextFooter:
                           'Vypĺňate len v prípade, ak ste nebytový priestor predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).',
                       },
                     ),
@@ -374,11 +374,11 @@ export default step(
   },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani z bytov a z nebytových priestorov v bytovom dome?',
-    helptext: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.\n\nV prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}`,
-    helptextMarkdown: true,
+    helptextFooter: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.\n\nV prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}`,
+    helptextFooterMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery podlahových plôch bytov a nebytových priestorov',
-      helptext:
+      helptextFooter:
         'Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.',
       checkboxLabel: 'Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch',
       inner: innerArray,

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step6.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/step6.ts
@@ -4,7 +4,6 @@ import {
   customComponentsField,
   datePicker,
   input,
-  markdownText,
   number,
   object,
   radioGroup,
@@ -45,9 +44,8 @@ const vymeraPodlahovejPlochyBytu = number(
     minimum: 0,
   },
   {
-    helptext: markdownText(
-      'Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).',
-    ),
+    helptext: 'Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).',
+    helptextMarkdown: true,
   },
 )
 
@@ -86,7 +84,8 @@ const vymeraKalkulacka = customComponentsField(
             '**Pre výpočet základu dane vyplňte správne všetky polia:**\n' +
             '- Podiel priestoru na spoločných častiach a zariadeniach domu\n' +
             '- Spoluvlastnícky podiel',
-          unit: markdownText('m^2^'),
+          unit: 'm^2^',
+          unitMarkdown: true,
         },
       ],
     },
@@ -104,11 +103,11 @@ const podielPriestoruNaSpolocnychCastiachAZariadeniachDomu = (typ: Typ) =>
     },
     {
       placeholder: typ === Typ.Byt ? 'Napr. 4827/624441' : 'Napr. 124827/624441',
-      helptext: markdownText(
+      helptext:
         typ === Typ.Byt
           ? 'Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}'
           : 'Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}',
-      ),
+      helptextMarkdown: true,
     },
   )
 
@@ -118,11 +117,11 @@ const spoluvlastnickyPodiel = (typ: Typ) =>
     { type: 'ba-ratio', title: 'Spoluvlastnícky podiel', required: true },
     {
       placeholder: 'Napr. 1/150',
-      helptext: markdownText(
+      helptext:
         typ === Typ.Byt
           ? 'Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}'
           : 'Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}',
-      ),
+      helptextMarkdown: true,
     },
   )
 
@@ -304,9 +303,9 @@ const innerArray = (kalkulacka: boolean) =>
                         required: true,
                       },
                       {
-                        helptext: markdownText(
+                        helptext:
                           'Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}',
-                        ),
+                        helptextMarkdown: true,
                       },
                     ),
                   ],
@@ -375,9 +374,8 @@ export default step(
   },
   vyplnitKrokRadio({
     title: 'Chcete podať daňové priznanie k dani z bytov a z nebytových priestorov v bytovom dome?',
-    helptext: markdownText(
-      `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.\n\nV prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}`,
-    ),
+    helptext: `K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.\n\nV prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.\n\n:form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}`,
+    helptextMarkdown: true,
     fields: kalkulackaFields({
       title: 'Kalkulačka výpočtu výmery podlahových plôch bytov a nebytových priestorov',
       helptext:

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/vyplnitKrokRadio.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/vyplnitKrokRadio.ts
@@ -6,13 +6,13 @@ type SecondArg<F> = F extends (arg1: any, arg2: infer A, ...rest: any[]) => any 
 
 export const vyplnitKrokRadio = ({
   title,
-  helptext,
-  helptextMarkdown,
+  helptextFooter,
+  helptextFooterMarkdown,
   fields,
 }: {
   title: string
-  helptext: string
-  helptextMarkdown: boolean
+  helptextFooter: string
+  helptextFooterMarkdown: boolean
   fields: SecondArg<typeof conditionalFields>
 }) => [
   object(
@@ -37,8 +37,8 @@ export const vyplnitKrokRadio = ({
           variant: 'boxed',
           orientations: 'row',
           labelSize: 'h3',
-          helptext,
-          helptextMarkdown,
+          helptextFooter,
+          helptextFooterMarkdown,
         },
       ),
     ],

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/vyplnitKrokRadio.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/vyplnitKrokRadio.ts
@@ -6,13 +6,13 @@ type SecondArg<F> = F extends (arg1: any, arg2: infer A, ...rest: any[]) => any 
 
 export const vyplnitKrokRadio = ({
   title,
-  helptextFooter,
-  helptextFooterMarkdown,
+  helptext,
+  helptextMarkdown,
   fields,
 }: {
   title: string
-  helptextFooter: string
-  helptextFooterMarkdown: boolean
+  helptext: string
+  helptextMarkdown: boolean
   fields: SecondArg<typeof conditionalFields>
 }) => [
   object(
@@ -37,8 +37,8 @@ export const vyplnitKrokRadio = ({
           variant: 'boxed',
           orientations: 'row',
           labelSize: 'h3',
-          helptextFooter,
-          helptextFooterMarkdown,
+          helptext,
+          helptextMarkdown,
         },
       ),
     ],

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/vyplnitKrokRadio.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/vyplnitKrokRadio.ts
@@ -35,7 +35,7 @@ export const vyplnitKrokRadio = ({
           variant: 'boxed',
           orientations: 'row',
           labelSize: 'h3',
-          helptextHeader: helptext,
+          helptext,
         },
       ),
     ],

--- a/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/vyplnitKrokRadio.ts
+++ b/forms-shared/src/schemas/priznanie-k-dani-z-nehnutelnosti/vyplnitKrokRadio.ts
@@ -7,10 +7,12 @@ type SecondArg<F> = F extends (arg1: any, arg2: infer A, ...rest: any[]) => any 
 export const vyplnitKrokRadio = ({
   title,
   helptext,
+  helptextMarkdown,
   fields,
 }: {
   title: string
   helptext: string
+  helptextMarkdown: boolean
   fields: SecondArg<typeof conditionalFields>
 }) => [
   object(
@@ -36,6 +38,7 @@ export const vyplnitKrokRadio = ({
           orientations: 'row',
           labelSize: 'h3',
           helptext,
+          helptextMarkdown,
         },
       ),
     ],

--- a/forms-shared/src/schemas/showcase.ts
+++ b/forms-shared/src/schemas/showcase.ts
@@ -36,7 +36,7 @@ export default schema(
         },
         {
           placeholder: 'Enter text here',
-          helptextHeader: 'Basic text input example',
+          helptext: 'Basic text input example',
         },
       ),
       object(
@@ -100,7 +100,7 @@ export default schema(
             },
             {
               placeholder: '+421',
-              helptextHeader: 'Slovak phone number format',
+              helptext: 'Slovak phone number format',
             },
           ),
           input(
@@ -111,7 +111,7 @@ export default schema(
               required: true,
             },
             {
-              helptextHeader: 'International Bank Account Number',
+              helptext: 'International Bank Account Number',
             },
           ),
           input(
@@ -123,7 +123,7 @@ export default schema(
             },
             {
               placeholder: '1/2',
-              helptextHeader: 'Format: number/number',
+              helptext: 'Format: number/number',
             },
           ),
         ],
@@ -136,7 +136,7 @@ export default schema(
         },
         {
           placeholder: 'Enter longer text here',
-          helptextHeader: 'Multi-line text input',
+          helptext: 'Multi-line text input',
         },
       ),
     ]),
@@ -150,7 +150,7 @@ export default schema(
         },
         {
           placeholder: 'Select an option',
-          helptextHeader: 'Single selection dropdown',
+          helptext: 'Single selection dropdown',
         },
       ),
       select(
@@ -170,7 +170,7 @@ export default schema(
           ]),
         },
         {
-          helptextHeader: 'Select with additional context',
+          helptext: 'Select with additional context',
         },
       ),
       selectMultiple(
@@ -181,7 +181,7 @@ export default schema(
           items: createStringItems(['Choice 1', 'Choice 2', 'Choice 3']),
         },
         {
-          helptextHeader: 'Select multiple options',
+          helptext: 'Select multiple options',
         },
       ),
       radioGroup(
@@ -198,7 +198,7 @@ export default schema(
         {
           variant: 'boxed',
           orientations: 'row',
-          helptextHeader: 'Yes/No selection',
+          helptext: 'Yes/No selection',
         },
       ),
       radioGroup(
@@ -221,7 +221,7 @@ export default schema(
         {
           variant: 'boxed',
           orientations: 'column',
-          helptextHeader: 'Radio selection with descriptions',
+          helptext: 'Radio selection with descriptions',
         },
       ),
     ]),
@@ -235,7 +235,7 @@ export default schema(
           maximum: 100,
         },
         {
-          helptextHeader: 'Number with min/max validation',
+          helptext: 'Number with min/max validation',
         },
       ),
       object(
@@ -294,7 +294,7 @@ export default schema(
         },
         {
           type: 'button',
-          helptextHeader: 'Click button to upload files',
+          helptext: 'Click button to upload files',
         },
       ),
       fileUpload(
@@ -308,7 +308,7 @@ export default schema(
           type: 'dragAndDrop',
           accept: '.pdf,.jpg,.png',
           sizeLimit: 5000000,
-          helptextHeader: 'Drag files here or click to upload',
+          helptext: 'Drag files here or click to upload',
         },
       ),
     ]),
@@ -321,7 +321,7 @@ export default schema(
           required: true,
         },
         {
-          helptextHeader: 'Select a date',
+          helptext: 'Select a date',
         },
       ),
       timePicker(
@@ -331,7 +331,7 @@ export default schema(
           required: true,
         },
         {
-          helptextHeader: 'Select a time',
+          helptext: 'Select a time',
         },
       ),
     ]),
@@ -346,7 +346,7 @@ export default schema(
         {
           checkboxLabel: 'I agree to the terms',
           variant: 'boxed',
-          helptextHeader: 'Must be checked to proceed',
+          helptext: 'Must be checked to proceed',
         },
       ),
       checkboxGroup(
@@ -361,7 +361,7 @@ export default schema(
         },
         {
           variant: 'boxed',
-          helptextHeader: 'Select multiple options',
+          helptext: 'Select multiple options',
         },
       ),
     ]),
@@ -452,7 +452,7 @@ export default schema(
         {
           variant: 'boxed',
           orientations: 'row',
-          helptextHeader: 'Additional fields and step will appear when selecting Yes',
+          helptext: 'Additional fields and step will appear when selecting Yes',
         },
       ),
       conditionalFields(createCondition([[['showExtra'], { const: true }]]), [
@@ -464,7 +464,7 @@ export default schema(
             required: true,
           },
           {
-            helptextHeader: 'This field only appears conditionally',
+            helptext: 'This field only appears conditionally',
           },
         ),
       ]),
@@ -482,7 +482,7 @@ export default schema(
             required: true,
           },
           {
-            helptextHeader: 'This entire step appears conditionally',
+            helptext: 'This entire step appears conditionally',
           },
         ),
       ],

--- a/forms-shared/src/schemas/tsb/objednavkaVytycenie.ts
+++ b/forms-shared/src/schemas/tsb/objednavkaVytycenie.ts
@@ -79,7 +79,7 @@ export default schema(
           input(
             'adresaTrvalehoPobytu',
             { title: 'Adresa trvalého pobytu', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
         ],
       ),
@@ -96,7 +96,7 @@ export default schema(
           input(
             'adresaPodnikania',
             { title: 'Miesto podnikania', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
         ],
       ),
@@ -113,7 +113,7 @@ export default schema(
           input(
             'adresaSidla',
             { title: 'Adresa sídla', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
         ],
       ),
@@ -133,7 +133,7 @@ export default schema(
       input(
         'telefonneCislo',
         { title: 'Telefónne číslo', required: true, type: 'ba-phone-number' },
-        { helptextHeader: 'Vyplňte vo formáte +421' },
+        { helptext: 'Vyplňte vo formáte +421' },
       ),
       conditionalFields(createCondition([[['objednavatelTyp'], { const: 'Právnická osoba' }]]), [
         object(
@@ -141,21 +141,17 @@ export default schema(
           { required: true },
           { objectDisplay: 'boxed', title: 'Kontaktná osoba' },
           [
-            input(
-              'meno',
-              { title: 'Meno', required: true, type: 'text' },
-              { helptextHeader: 'Meno' },
-            ),
+            input('meno', { title: 'Meno', required: true, type: 'text' }, { helptext: 'Meno' }),
             input(
               'priezvisko',
               { title: 'Priezvisko', required: true, type: 'text' },
-              { helptextHeader: 'Priezvisko' },
+              { helptext: 'Priezvisko' },
             ),
             input('email', { title: 'E-mail', required: true, type: 'email' }, {}),
             input(
               'telefonneCislo',
               { title: 'Telefónne číslo', required: true, type: 'ba-phone-number' },
-              { helptextHeader: 'Vyplňte vo formáte +421' },
+              { helptext: 'Vyplňte vo formáte +421' },
             ),
           ],
         ),
@@ -172,7 +168,7 @@ export default schema(
             'email',
             { title: 'E-mail', required: true, type: 'email' },
             {
-              helptextHeader: 'Faktúra vám bude zaslaná prostredníctvom tohto emailu',
+              helptext: 'Faktúra vám bude zaslaná prostredníctvom tohto emailu',
             },
           ),
         ],
@@ -186,14 +182,14 @@ export default schema(
             'dovodVytycenia',
             { title: 'Dôvod vytýčenia', required: true, type: 'text' },
             {
-              helptextHeader:
+              helptext:
                 'Napríklad: vytýčenie káblovej poruchy, za účelom rozkopávky, vybudovanie inžinierskych sietí...',
             },
           ),
           input(
             'pozadovaneMiestoPlnenia',
             { title: 'Požadované miesto plnenia', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
           radioGroup(
             'viacKatastralneUzemia',
@@ -241,7 +237,7 @@ export default schema(
                 ]),
               },
               {
-                helptextHeader:
+                helptext:
                   'Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.',
               },
             ),
@@ -276,7 +272,7 @@ export default schema(
                 ]),
               },
               {
-                helptextHeader:
+                helptext:
                   'Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.',
               },
             ),
@@ -284,12 +280,12 @@ export default schema(
           input(
             'druhStavby',
             { title: 'Druh stavby', required: false, type: 'text' },
-            { helptextHeader: 'Napríklad: telekomunikačná líniová stavba' },
+            { helptext: 'Napríklad: telekomunikačná líniová stavba' },
           ),
           datePicker(
             'pozadovanyTerminPlnenia',
             { title: 'Požadovaný termín plnenia', required: true },
-            { helptextHeader: 'Štandardný termín na vybavenie objednávky je 30 dní' },
+            { helptext: 'Štandardný termín na vybavenie objednávky je 30 dní' },
           ),
         ],
       ),
@@ -304,7 +300,7 @@ export default schema(
         },
         {
           type: 'dragAndDrop',
-          helptextHeader:
+          helptext:
             'Požiadať o informatívny zákres vydaný Technickými sieťami Bratislava, a.s. môžete formou spoplatnenej služby Objednávka informatívneho zákresu sietí',
           accept: '.pdf,.jpg,.jpeg,.png',
         },

--- a/forms-shared/src/schemas/tsb/objednavkaZakresuSieti.ts
+++ b/forms-shared/src/schemas/tsb/objednavkaZakresuSieti.ts
@@ -76,7 +76,7 @@ export default schema(
           input(
             'adresaTrvalehoPobytu',
             { title: 'Adresa trvalého pobytu', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
         ],
       ),
@@ -93,7 +93,7 @@ export default schema(
           input(
             'adresaPodnikania',
             { title: 'Miesto podnikania', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
         ],
       ),
@@ -110,7 +110,7 @@ export default schema(
           input(
             'adresaSidla',
             { title: 'Adresa sídla', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
         ],
       ),
@@ -130,7 +130,7 @@ export default schema(
       input(
         'telefonneCislo',
         { title: 'Telefónne číslo', required: true, type: 'ba-phone-number' },
-        { helptextHeader: 'Vyplňte vo formáte +421' },
+        { helptext: 'Vyplňte vo formáte +421' },
       ),
       conditionalFields(createCondition([[['objednavatelTyp'], { const: 'Právnická osoba' }]]), [
         object(
@@ -138,21 +138,17 @@ export default schema(
           { required: true },
           { objectDisplay: 'boxed', title: 'Kontaktná osoba' },
           [
-            input(
-              'meno',
-              { title: 'Meno', required: true, type: 'text' },
-              { helptextHeader: 'Meno' },
-            ),
+            input('meno', { title: 'Meno', required: true, type: 'text' }, { helptext: 'Meno' }),
             input(
               'priezvisko',
               { title: 'Priezvisko', required: true, type: 'text' },
-              { helptextHeader: 'Priezvisko' },
+              { helptext: 'Priezvisko' },
             ),
             input('email', { title: 'E-mail', required: true, type: 'email' }, {}),
             input(
               'telefonneCislo',
               { title: 'Telefónne číslo', required: true, type: 'ba-phone-number' },
-              { helptextHeader: 'Vyplňte vo formáte +421' },
+              { helptext: 'Vyplňte vo formáte +421' },
             ),
           ],
         ),
@@ -167,14 +163,14 @@ export default schema(
           input(
             'fakturacnaAdresa',
             { title: 'Fakturačná adresa', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
           input('mesto', { title: 'Mesto', required: true, type: 'text' }, {}),
           input('psc', { title: 'PSČ', required: true, type: 'text' }, {}),
           input(
             'email',
             { title: 'E-mail', required: true, type: 'email' },
-            { helptextHeader: 'Faktúra vám bude zaslaná prostredníctvom tohto emailu' },
+            { helptext: 'Faktúra vám bude zaslaná prostredníctvom tohto emailu' },
           ),
         ],
       ),
@@ -186,7 +182,7 @@ export default schema(
           input(
             'adresaObjednavky',
             { title: 'Adresa objednávky', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
           radioGroup(
             'viacKatastralneUzemia',
@@ -234,7 +230,7 @@ export default schema(
                 ]),
               },
               {
-                helptextHeader:
+                helptext:
                   'Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.',
               },
             ),
@@ -269,7 +265,7 @@ export default schema(
                 ]),
               },
               {
-                helptextHeader:
+                helptext:
                   'Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.',
               },
             ),
@@ -286,7 +282,7 @@ export default schema(
         },
         {
           type: 'dragAndDrop',
-          helptextHeader: `Využiť môžete katastrálnu mapu ZBGIS, kde nájdete požadované záujmové územie.
+          helptext: `Využiť môžete katastrálnu mapu ZBGIS, kde nájdete požadované záujmové územie.
 
 Ako vytvoriť snímku?
 Prejdite do katastrálnej mapy ZBGIS. Otvorením menu v ľavom hornom rohu nájdete funkciu Meranie, ktorá Vám umožní zaznačiť Vaše záujmové územie na katastrálnej mape (zaznačenie Vám následne vypočíta výmeru plochy). Snímku vycentrujte a využite možnosť ZBGIS Tlačiť do PDF. Dokument uložte a následne nahrajte do Nahrať súbory.`,

--- a/forms-shared/src/schemas/tsb/umiestnenieZariadenia.ts
+++ b/forms-shared/src/schemas/tsb/umiestnenieZariadenia.ts
@@ -71,7 +71,7 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
         input(
           'adresaTrvalehoPobytu',
           { title: 'Adresa trvalého pobytu', required: true, type: 'text' },
-          { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+          { helptext: 'Vyplňte vo formáte ulica a číslo' },
         ),
       ],
     ),
@@ -88,7 +88,7 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
         input(
           'adresaPodnikania',
           { title: 'Miesto podnikania', required: true, type: 'text' },
-          { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+          { helptext: 'Vyplňte vo formáte ulica a číslo' },
         ),
       ],
     ),
@@ -105,7 +105,7 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
         input(
           'adresaSidla',
           { title: 'Adresa sídla', required: true, type: 'text' },
-          { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+          { helptext: 'Vyplňte vo formáte ulica a číslo' },
         ),
       ],
     ),
@@ -125,7 +125,7 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
     input(
       'telefonneCislo',
       { title: 'Telefónne číslo', required: true, type: 'ba-phone-number' },
-      { helptextHeader: 'Vyplňte vo formáte +421' },
+      { helptext: 'Vyplňte vo formáte +421' },
     ),
     conditionalFields(createCondition([[['objednavatelTyp'], { const: 'Právnická osoba' }]]), [
       object(
@@ -133,21 +133,17 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
         { required: true },
         { objectDisplay: 'boxed', title: 'Kontaktná osoba' },
         [
-          input(
-            'meno',
-            { title: 'Meno', required: true, type: 'text' },
-            { helptextHeader: 'Meno' },
-          ),
+          input('meno', { title: 'Meno', required: true, type: 'text' }, { helptext: 'Meno' }),
           input(
             'priezvisko',
             { title: 'Priezvisko', required: true, type: 'text' },
-            { helptextHeader: 'Priezvisko' },
+            { helptext: 'Priezvisko' },
           ),
           input('email', { title: 'E-mail', required: true, type: 'email' }, {}),
           input(
             'telefonneCislo',
             { title: 'Telefónne číslo', required: true, type: 'ba-phone-number' },
-            { helptextHeader: 'Vyplňte vo formáte +421' },
+            { helptext: 'Vyplňte vo formáte +421' },
           ),
         ],
       ),
@@ -164,7 +160,7 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
       },
       {
         type: 'dragAndDrop',
-        helptextHeader:
+        helptext:
           'V prípade, že požadovaný súbor na vyplnenie ešte nemáte, stiahnuť si ho viete na tomto odkaze. Dbajte na to, aby ste v súbore spomenuli všetky zariadenia, ktoré si želáte umiestniť. Bez vyplnenia a nahratia tohto súboru nebude možné vašu žiadosť spracovať.',
       },
     ),
@@ -218,7 +214,7 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
     input(
       'telefonneCislo',
       { title: 'Telefónne číslo', required: true, type: 'ba-phone-number' },
-      { helptextHeader: 'Vyplňte vo formáte +421' },
+      { helptext: 'Vyplňte vo formáte +421' },
     ),
     datePicker(
       'planovanyDatumMontaze',
@@ -227,7 +223,7 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
         required: true,
       },
       {
-        helptextHeader:
+        helptext:
           'O zahájení prác je potrebné písomne informovať minimálne 1 pracovný deň vopred prostredníctvom e-mailu na info@tsb.sk.',
       },
     ),
@@ -238,7 +234,7 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
         required: true,
       },
       {
-        helptextHeader:
+        helptext:
           'Žiadateľ je povinný na základe písomnej výzvy zabezpečiť demontáž svojho zariadenia na vlastné náklady, a to v lehote najneskôr do 15 kalendárnych dní od doručenia takejto výzvy prostredníctvom kontaktného e-mailu.',
       },
     ),
@@ -253,7 +249,7 @@ export default schema({ title: 'TEST - Umiestnenie zariadenia' }, {}, [
       },
       {
         type: 'dragAndDrop',
-        helptextHeader:
+        helptext:
           'Nahrajte jednu prílohu obsahujúcu fotografie alebo vizualizácie všetkých zariadení.',
       },
     ),

--- a/forms-shared/src/schemas/tsb/ziadostOStanoviskoPD.ts
+++ b/forms-shared/src/schemas/tsb/ziadostOStanoviskoPD.ts
@@ -77,7 +77,7 @@ export default schema(
           input(
             'adresaTrvalehoPobytu',
             { title: 'Adresa trvalého pobytu', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
         ],
       ),
@@ -94,7 +94,7 @@ export default schema(
           input(
             'adresaPodnikania',
             { title: 'Miesto podnikania', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
         ],
       ),
@@ -111,7 +111,7 @@ export default schema(
           input(
             'adresaSidla',
             { title: 'Adresa sídla', required: true, type: 'text' },
-            { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+            { helptext: 'Vyplňte vo formáte ulica a číslo' },
           ),
         ],
       ),
@@ -131,7 +131,7 @@ export default schema(
       input(
         'telefonneCislo',
         { title: 'Telefónne číslo', required: true, type: 'ba-phone-number' },
-        { helptextHeader: 'Vyplňte vo formáte +421' },
+        { helptext: 'Vyplňte vo formáte +421' },
       ),
       conditionalFields(createCondition([[['objednavatelTyp'], { const: 'Právnická osoba' }]]), [
         object(
@@ -139,21 +139,17 @@ export default schema(
           { required: true },
           { objectDisplay: 'boxed', title: 'Kontaktná osoba' },
           [
-            input(
-              'meno',
-              { title: 'Meno', required: true, type: 'text' },
-              { helptextHeader: 'Meno' },
-            ),
+            input('meno', { title: 'Meno', required: true, type: 'text' }, { helptext: 'Meno' }),
             input(
               'priezvisko',
               { title: 'Priezvisko', required: true, type: 'text' },
-              { helptextHeader: 'Priezvisko' },
+              { helptext: 'Priezvisko' },
             ),
             input('email', { title: 'E-mail', required: true, type: 'email' }, {}),
             input(
               'telefonneCislo',
               { title: 'Telefónne číslo', required: true, type: 'ba-phone-number' },
-              { helptextHeader: 'Vyplňte vo formáte +421' },
+              { helptext: 'Vyplňte vo formáte +421' },
             ),
           ],
         ),
@@ -164,13 +160,13 @@ export default schema(
         'nazovStavby',
         { type: 'text', title: 'Názov stavby', required: true },
         {
-          helptextHeader: 'Napríklad: Polyfunkčný objekt ABC',
+          helptext: 'Napríklad: Polyfunkčný objekt ABC',
         },
       ),
       input(
         'adresaStavby',
         { type: 'text', title: 'Adresa stavby', required: true },
-        { helptextHeader: 'Vyplňte vo formáte ulica a číslo' },
+        { helptext: 'Vyplňte vo formáte ulica a číslo' },
       ),
       selectMultiple(
         'katastralneUzemie',
@@ -201,8 +197,7 @@ export default schema(
           ]),
         },
         {
-          helptextHeader:
-            'Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.',
+          helptext: 'Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.',
         },
       ),
       datePicker(
@@ -218,7 +213,7 @@ export default schema(
       input(
         'typProjektovejDokumentacie',
         { type: 'text', title: 'Typ projektovej dokumentácie', required: true },
-        { helptextHeader: 'Napríklad: Ohlásenie stavby' },
+        { helptext: 'Napríklad: Ohlásenie stavby' },
       ),
       radioGroup(
         'stupenProjektovejDokumentacie',
@@ -245,7 +240,7 @@ export default schema(
         },
         {
           type: 'dragAndDrop',
-          helptextHeader: 'Technická správa s popisom navrhovaného technického riešenia.',
+          helptext: 'Technická správa s popisom navrhovaného technického riešenia.',
         },
       ),
       fileUpload(
@@ -257,7 +252,7 @@ export default schema(
         },
         {
           type: 'dragAndDrop',
-          helptextHeader:
+          helptext:
             'Využiť môžete katastrálnu mapu ZBGIS, kde nájdete požadované záujmové územie. V katastrálnej mape zvoľte funkciu Meranie v ľavom menu a vyznačte záujmové územie. Meranie uložte cez možnosť Tlačiť do PDF.',
         },
       ),
@@ -281,7 +276,7 @@ export default schema(
         },
         {
           type: 'dragAndDrop',
-          helptextHeader: 'Výpočet je nutné doložiť v prípade stavby verejného osvetlenia.',
+          helptext: 'Výpočet je nutné doložiť v prípade stavby verejného osvetlenia.',
         },
       ),
     ]),

--- a/forms-shared/src/schemas/ziadostONajomBytu.ts
+++ b/forms-shared/src/schemas/ziadostONajomBytu.ts
@@ -7,7 +7,6 @@ import {
   datePicker,
   FieldType,
   input,
-  markdownText,
   number,
   object,
   radioGroup,
@@ -72,12 +71,9 @@ const getVlastnikNehnutelnostiFields = (stepType: StepType) => {
         orientations: 'row',
         helptext:
           stepType === StepType.Ziadatel
-            ? markdownText(
-                'Ak ste vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.',
-              )
-            : markdownText(
-                'Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.',
-              ),
+            ? 'Ak ste vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.'
+            : 'Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.',
+        helptextMarkdown: true,
       },
     ),
     conditionalFields(createCondition([[['vlastnikNehnutelnosti'], { const: true }]]), [
@@ -516,19 +512,16 @@ const getPrijemSection = (stepType: StepType) => {
         variant: 'boxed',
         orientations: 'row',
         helptext: {
-          [StepType.Ziadatel]: markdownText(
+          [StepType.Ziadatel]:
             'Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Váš zamestnávateľ vám na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť váš priemerný mesačný čistý príjem za minulý kalendárny rok.',
-          ),
-          [StepType.ManzelManzelka]: markdownText(
+          [StepType.ManzelManzelka]:
             'Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu manželovi/manželke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.',
-          ),
-          [StepType.DruhDruzka]: markdownText(
+          [StepType.DruhDruzka]:
             'Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu druhovi/družke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.',
-          ),
-          [StepType.InyClen]: markdownText(
+          [StepType.InyClen]:
             'Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ člena/členky domácnosti na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.',
-          ),
         }[stepType],
+        helptextMarkdown: true,
       },
     ),
     conditionalFields(createCondition([[['zamestnanie'], { const: true }]]), [
@@ -556,19 +549,16 @@ const getPrijemSection = (stepType: StepType) => {
         variant: 'boxed',
         orientations: 'row',
         helptext: {
-          [StepType.Ziadatel]: markdownText(
+          [StepType.Ziadatel]:
             'V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu Vášho čistého príjmu podľa potvrdenia, ktoré vám vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemáte podané daňové priznanie, resp. nepoznáte sumu vášho príjmu, vyplňte prosím váš čistý príjem za posledný známy rok.',
-          ),
-          [StepType.ManzelManzelka]: markdownText(
+          [StepType.ManzelManzelka]:
             'V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu manžela/manželky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.',
-          ),
-          [StepType.DruhDruzka]: markdownText(
+          [StepType.DruhDruzka]:
             'V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu druha/družky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.',
-          ),
-          [StepType.InyClen]: markdownText(
+          [StepType.InyClen]:
             'V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu člena/členky domácnosti podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.',
-          ),
         }[stepType],
+        helptextMarkdown: true,
       },
     ),
     conditionalFields(createCondition([[['samostatnaZarobkovaCinnost'], { const: true }]]), [
@@ -765,22 +755,18 @@ const getZdravotnyStavSection = (stepType: StepType) => {
       objectDisplay: 'boxed',
       title: 'Zdravotný stav',
       description: {
-        [StepType.Ziadatel]: markdownText(
+        [StepType.Ziadatel]:
           'Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené vašim (všeobecným) lekárom - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).',
-        ),
-        [StepType.ManzelManzelka]: markdownText(
+        [StepType.ManzelManzelka]:
           'Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom manžela/manželky - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).',
-        ),
-        [StepType.DruhDruzka]: markdownText(
+        [StepType.DruhDruzka]:
           'Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom druha/družky - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).',
-        ),
-        [StepType.Dieta]: markdownText(
+        [StepType.Dieta]:
           'Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom dieťaťa - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).',
-        ),
-        [StepType.InyClen]: markdownText(
+        [StepType.InyClen]:
           'Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom člena/členky domácnosti - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).',
-        ),
       }[stepType],
+      descriptionMarkdown: true,
     },
     [
       radioGroup(
@@ -984,9 +970,8 @@ const getZdravotnyStavSection = (stepType: StepType) => {
             {
               variant: 'boxed',
               orientations: 'row',
-              helptext: markdownText(
-                `Podmienkou pridelenia bezbariérového bytu je, že žiadateľ alebo člen domácnosti musí mať lekárom potvrdené, že má diagnostikované zdravotné postihnutie, v zmysle [prílohy č. 2 zákona 443/2010 Z. z.](https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2010/443/20180101#prilohy) - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_bezbarierovy_byt_Priloha2_94fc7ae8e6.pdf).`,
-              ),
+              helptext: `Podmienkou pridelenia bezbariérového bytu je, že žiadateľ alebo člen domácnosti musí mať lekárom potvrdené, že má diagnostikované zdravotné postihnutie, v zmysle [prílohy č. 2 zákona 443/2010 Z. z.](https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2010/443/20180101#prilohy) - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_bezbarierovy_byt_Priloha2_94fc7ae8e6.pdf).`,
+              helptextMarkdown: true,
             },
           )
         : null,

--- a/forms-shared/src/schemas/ziadostONajomBytu.ts
+++ b/forms-shared/src/schemas/ziadostONajomBytu.ts
@@ -70,7 +70,7 @@ const getVlastnikNehnutelnostiFields = (stepType: StepType) => {
       {
         variant: 'boxed',
         orientations: 'row',
-        helptextHeader:
+        helptext:
           stepType === StepType.Ziadatel
             ? markdownText(
                 'Ak ste vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.',
@@ -239,7 +239,7 @@ const getOsobneUdajeSection = (stepType: StepType) => {
             'rodnePriezvisko',
             { title: 'Rodné priezvisko', type: 'text' },
             {
-              helptextHeader:
+              helptext:
                 stepType === StepType.Ziadatel
                   ? 'Vyplňte iba v prípade, ak je vaše priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.'
                   : 'Vyplňte iba v prípade, ak je priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.',
@@ -337,8 +337,7 @@ const getOsobneUdajeSection = (stepType: StepType) => {
               'email',
               { title: 'Email', type: 'email' },
               {
-                helptextHeader:
-                  'Ak nemáte email, uveďte kontaktné údaje na inú osobu resp. organizáciu.',
+                helptext: 'Ak nemáte email, uveďte kontaktné údaje na inú osobu resp. organizáciu.',
               },
             ),
             conditionalFields(createCondition([[['email'], { type: 'string' }]]), [
@@ -368,7 +367,7 @@ const getOsobneUdajeSection = (stepType: StepType) => {
             {
               size: 'medium',
               placeholder: '+421',
-              helptextHeader:
+              helptext:
                 'Ak nemáte telefonický kontakt, uveďte kontaktné údaje na inú osobu resp. organizáciu. Vyplňte vo formáte s predvoľbou +421.',
             },
           )
@@ -516,7 +515,7 @@ const getPrijemSection = (stepType: StepType) => {
       {
         variant: 'boxed',
         orientations: 'row',
-        helptextHeader: {
+        helptext: {
           [StepType.Ziadatel]: markdownText(
             'Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Váš zamestnávateľ vám na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť váš priemerný mesačný čistý príjem za minulý kalendárny rok.',
           ),
@@ -556,7 +555,7 @@ const getPrijemSection = (stepType: StepType) => {
       {
         variant: 'boxed',
         orientations: 'row',
-        helptextHeader: {
+        helptext: {
           [StepType.Ziadatel]: markdownText(
             'V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu Vášho čistého príjmu podľa potvrdenia, ktoré vám vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemáte podané daňové priznanie, resp. nepoznáte sumu vášho príjmu, vyplňte prosím váš čistý príjem za posledný známy rok.',
           ),
@@ -596,7 +595,7 @@ const getPrijemSection = (stepType: StepType) => {
       {
         variant: 'boxed',
         orientations: 'row',
-        helptextHeader:
+        helptext:
           stepType === StepType.Ziadatel
             ? 'Označte áno, ak ste poberali v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.'
             : 'Označte áno, ak poberal/poberala v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.',
@@ -672,7 +671,7 @@ const getPrijemSection = (stepType: StepType) => {
       {
         variant: 'boxed',
         orientations: 'row',
-        helptextHeader:
+        helptext:
           'Materskú, tehotenský príspevok, rodičovský príspevok, prídavky na deti, dávka v hmotnej núdzi, ochranný príspevok, opatrovateľský príspevok, kompenzačný príspevok alebo iné príspevky z Úradu práce.',
       },
     ),
@@ -985,7 +984,7 @@ const getZdravotnyStavSection = (stepType: StepType) => {
             {
               variant: 'boxed',
               orientations: 'row',
-              helptextHeader: markdownText(
+              helptext: markdownText(
                 `Podmienkou pridelenia bezbariérového bytu je, že žiadateľ alebo člen domácnosti musí mať lekárom potvrdené, že má diagnostikované zdravotné postihnutie, v zmysle [prílohy č. 2 zákona 443/2010 Z. z.](https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2010/443/20180101#prilohy) - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_bezbarierovy_byt_Priloha2_94fc7ae8e6.pdf).`,
               ),
             },
@@ -1075,7 +1074,7 @@ const getSucasneByvanieSection = (stepType: StepType) => {
       {
         variant: 'boxed',
         orientations: 'row',
-        helptextHeader: {
+        helptext: {
           [StepType.Ziadatel]: undefined,
           [StepType.ManzelManzelka]:
             'Ak označíte odpoveď  "Áno", zobrazia sa vám konkrétne možnosti bývania. Ak sa manžela/manželky žiadna z nich nebude týkať, označte odpoveď "Nie".',
@@ -1235,7 +1234,7 @@ const getRizikoveFaktorySection = (stepType: StepType) => {
             required: true,
           },
           {
-            helptextHeader: 'Môžete označiť viac možností.',
+            helptext: 'Môžete označiť viac možností.',
             variant: 'boxed',
           },
         ),
@@ -1255,7 +1254,7 @@ const getRizikoveFaktorySection = (stepType: StepType) => {
         },
         {
           variant: 'boxed',
-          helptextHeader:
+          helptext:
             'Vyšší vek jedného z členov domácnosti je považovaný za rizikový faktor. Otázka sa vzťahuje iba na členov domácnosti, s ktorými by ste chceli bývať v mestskom nájomnom byte.',
           belowComponents: [
             {
@@ -1412,7 +1411,7 @@ export default schema(
         'dovodyPodaniaZiadosti',
         { title: 'Prečo si podávate žiadosť?' },
         {
-          helptextHeader:
+          helptext:
             'Priestor pre vyjadrenie akýchkoľvek informácií, ktoré si myslíte, že by sme mali vedieť, ale neboli súčasťou otázok.',
         },
       ),

--- a/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
+++ b/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
@@ -660,7 +660,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       "parcelneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "markdown_gKgflRNwdS:Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13).",
+          "helptext": "markdown_gKgflRNwdS:Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13).",
           "inputType": "text",
           "size": "medium",
         },
@@ -726,7 +726,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
               "value": "Vyšehradská",
             },
           ],
-          "helptextHeader": "markdown_gKgflRNwdS:Pre zaistenie kvalitného verejného priestoru sme na niektorých mestských pozemkoch zaviedli zopár [podmienok](https://bratislava.sk/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/komunitne-zahrady) pre vznik komunitnej záhrady.",
+          "helptext": "markdown_gKgflRNwdS:Pre zaistenie kvalitného verejného priestoru sme na niektorých mestských pozemkoch zaviedli zopár [podmienok](https://bratislava.sk/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/komunitne-zahrady) pre vznik komunitnej záhrady.",
         },
         "ui:widget": "Select",
       },
@@ -761,7 +761,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
     "prilohyInyPozemok": {
       "dizajn": {
         "ui:options": {
-          "helptextHeader": "markdown_gKgflRNwdS:Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.
+          "helptext": "markdown_gKgflRNwdS:Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.
 
  Napríklad, záhony či pestovacie boxy, výsadbu akejkoľvek trvalkovej zelene, kríkov a stromov spolu s druhovým špecifikovaním tejto zelene, kompost, mobiliár, priestor na uskladnenie náradia a zariadenia záhrady, priestor pre využívanie grilu, spôsob zabezpečenia vody a jej distribúcie.",
           "type": "dragAndDrop",
@@ -770,7 +770,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       },
       "fotografie": {
         "ui:options": {
-          "helptextHeader": "Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
+          "helptext": "Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUpload",
@@ -792,7 +792,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       ],
       "umiestnenie": {
         "ui:options": {
-          "helptextHeader": "markdown_gKgflRNwdS:Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
+          "helptext": "markdown_gKgflRNwdS:Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUpload",
@@ -801,7 +801,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
     "prilohyPredschvalenyPozemok": {
       "dizajn": {
         "ui:options": {
-          "helptextHeader": "markdown_gKgflRNwdS:Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.
+          "helptext": "markdown_gKgflRNwdS:Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.
 
  Napríklad, záhony či pestovacie boxy, výsadbu akejkoľvek trvalkovej zelene, kríkov a stromov spolu s druhovým špecifikovaním tejto zelene, kompost, mobiliár, priestor na uskladnenie náradia a zariadenia záhrady, priestor pre využívanie grilu, spôsob zabezpečenia vody a jej distribúcie.",
           "type": "dragAndDrop",
@@ -831,7 +831,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       ],
       "umiestnenie": {
         "ui:options": {
-          "helptextHeader": "markdown_gKgflRNwdS:Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
+          "helptext": "markdown_gKgflRNwdS:Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUpload",
@@ -843,7 +843,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       "dovodyZalozenia": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "markdown_gKgflRNwdS:Vysvetlite, prečo považujete za vhodné zabrať daný verejný priestor a vytvoriť na ňom záhradu s menej verejným režimom (predpokladáme, že záhrady sú oplotené a poloverejné). Argumentmi môže byť doterajšie nevyužívanie alebo nevhodné využívanie priestoru, napríklad, nelegálne parkovisko na zeleni, zeleň bez udržiavaných sadových úprav, neprístupný/nevyužívaný priestor.",
+          "helptext": "markdown_gKgflRNwdS:Vysvetlite, prečo považujete za vhodné zabrať daný verejný priestor a vytvoriť na ňom záhradu s menej verejným režimom (predpokladáme, že záhrady sú oplotené a poloverejné). Argumentmi môže byť doterajšie nevyužívanie alebo nevhodné využívanie priestoru, napríklad, nelegálne parkovisko na zeleni, zeleň bez udržiavaných sadových úprav, neprístupný/nevyužívaný priestor.",
           "placeholder": "Popíšte",
         },
         "ui:widget": "TextArea",
@@ -851,7 +851,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       "financovanie": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Aké budete mať členské poplatky? Využijete na tvorbu záhrady granty? Aké zdroje už máte a aké plánujete získať? V prípade, že už máte (predbežný) rozpočet, nahrajte ho do poľa nižšie.",
+          "helptext": "Aké budete mať členské poplatky? Využijete na tvorbu záhrady granty? Aké zdroje už máte a aké plánujete získať? V prípade, že už máte (predbežný) rozpočet, nahrajte ho do poľa nižšie.",
           "placeholder": "Popíšte",
         },
         "ui:widget": "TextArea",
@@ -859,7 +859,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       "inkluzivnost": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Ako zabezpečíte otvorenosť projektu, kto bude mať priamy či nepriamy úžitok z projektu, ako vyberiete, kto bude záhradkár? Ako sa vysporiadate so situáciou, ak budete mať väčší záujem o záhradkárčenie, než budete mať kapacitu nasýtiť?",
+          "helptext": "Ako zabezpečíte otvorenosť projektu, kto bude mať priamy či nepriamy úžitok z projektu, ako vyberiete, kto bude záhradkár? Ako sa vysporiadate so situáciou, ak budete mať väčší záujem o záhradkárčenie, než budete mať kapacitu nasýtiť?",
           "placeholder": "Popíšte",
         },
         "ui:widget": "TextArea",
@@ -874,7 +874,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       "prevadzka": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Kto a akým spôsobom bude zabezpečovať prevádzku záhrady z hľadiska údržby zelene (napríklad kosenie) a starostlivosti o poriadok? Ako bude zabezpečený odpad? Ideálne je, napríklad, zaviazať sa ku zero-waste režimu a každý, kto vytvorí odpad bude zodpovedný za jeho likvidáciu.",
+          "helptext": "Kto a akým spôsobom bude zabezpečovať prevádzku záhrady z hľadiska údržby zelene (napríklad kosenie) a starostlivosti o poriadok? Ako bude zabezpečený odpad? Ideálne je, napríklad, zaviazať sa ku zero-waste režimu a každý, kto vytvorí odpad bude zodpovedný za jeho likvidáciu.",
           "placeholder": "Popíšte",
         },
         "ui:widget": "TextArea",
@@ -882,7 +882,7 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       "suhlasKomunity": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Dôležitý aspekt legitimity je zapojenie okolitej komunity – organizačný tím by mal získať súhlas miestnych obyvateľov a obyvateliek, ktorí priestor v súčasnosti využívajú.",
+          "helptext": "Dôležitý aspekt legitimity je zapojenie okolitej komunity – organizačný tím by mal získať súhlas miestnych obyvateľov a obyvateliek, ktorí priestor v súčasnosti využívajú.",
           "placeholder": "Popíšte",
         },
         "ui:widget": "TextArea",
@@ -1407,7 +1407,7 @@ exports[`Form definitions olo-docistenie-stanovista-zbernych-nadob schemas match
       "doplnujuceInfo": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Špecifikujte individuálne požiadavky.",
+          "helptext": "Špecifikujte individuálne požiadavky.",
         },
         "ui:widget": "TextArea",
       },
@@ -1435,21 +1435,21 @@ exports[`Form definitions olo-docistenie-stanovista-zbernych-nadob schemas match
               "value": "Biologicky rozložiteľný odpad",
             },
           ],
-          "helptextHeader": "Poplatok je účtovaný za množstvo naložených a vysypaných nádob",
+          "helptext": "Poplatok je účtovaný za množstvo naložených a vysypaných nádob",
         },
         "ui:widget": "Select",
       },
       "miestoDodania": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
       },
       "preferovanyDatum": {
         "ui:options": {
-          "helptextHeader": "Vami zvolený dátum má iba informačný charakter. Objednávku je potrebné podať minimálne 2 pracovné dni pred zvoleným termínom. V prípade, ak vami zvolený termín nebude voľný, budeme vás kontaktovať.",
+          "helptext": "Vami zvolený dátum má iba informačný charakter. Objednávku je potrebné podať minimálne 2 pracovné dni pred zvoleným termínom. V prípade, ak vami zvolený termín nebude voľný, budeme vás kontaktovať.",
           "size": "medium",
         },
         "ui:widget": "DatePicker",
@@ -1601,7 +1601,7 @@ exports[`Form definitions olo-docistenie-stanovista-zbernych-nadob schemas match
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej fakúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -1647,7 +1647,7 @@ exports[`Form definitions olo-docistenie-stanovista-zbernych-nadob schemas match
       "konatel": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko konateľa",
+          "helptext": "Uveďte meno a priezvisko konateľa",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -1729,7 +1729,7 @@ exports[`Form definitions olo-docistenie-stanovista-zbernych-nadob schemas match
       "zastupeny": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
+          "helptext": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -3453,7 +3453,7 @@ exports[`Form definitions olo-energeticke-zhodnotenie-odpadu-v-zevo schemas matc
               "value": false,
             },
           ],
-          "helptextHeader": "Definícia zo Zákona č. 79/2015 Z. z. o odpadoch v znení neskorších predpisov",
+          "helptext": "Definícia zo Zákona č. 79/2015 Z. z. o odpadoch v znení neskorších predpisov",
           "orientations": "row",
           "variant": "boxed",
         },
@@ -3494,7 +3494,7 @@ exports[`Form definitions olo-energeticke-zhodnotenie-odpadu-v-zevo schemas matc
     "informacieODovoze": {
       "fotoOdpadu": {
         "ui:options": {
-          "helptextHeader": "Nahrajte fotografie odpadu, ktorý priveziete na zhodnotenie (povolené typy súborov jpg, gif, png, max. veľkosť 1 súboru 10 MB, maximálne 5 súborov.)",
+          "helptext": "Nahrajte fotografie odpadu, ktorý priveziete na zhodnotenie (povolené typy súborov jpg, gif, png, max. veľkosť 1 súboru 10 MB, maximálne 5 súborov.)",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUploadMultiple",
@@ -3650,7 +3650,7 @@ exports[`Form definitions olo-energeticke-zhodnotenie-odpadu-v-zevo schemas matc
               "value": false,
             },
           ],
-          "helptextHeader": "Definícia zo Zákona č. 79/2015 Z. z. o odpadoch v znení neskorších predpisov",
+          "helptext": "Definícia zo Zákona č. 79/2015 Z. z. o odpadoch v znení neskorších predpisov",
           "orientations": "row",
           "variant": "boxed",
         },
@@ -4575,7 +4575,7 @@ exports[`Form definitions olo-energeticke-zhodnotenie-odpadu-v-zevo schemas matc
       "cisloPovoleniaNaVstup": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vo formáte: 123/45 alebo 1234/45/2026 (číslo Objednávky alebo Zmluvy)",
+          "helptext": "Vo formáte: 123/45 alebo 1234/45/2026 (číslo Objednávky alebo Zmluvy)",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -4598,7 +4598,7 @@ exports[`Form definitions olo-energeticke-zhodnotenie-odpadu-v-zevo schemas matc
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej faktúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -4662,7 +4662,7 @@ exports[`Form definitions olo-energeticke-zhodnotenie-odpadu-v-zevo schemas matc
       "konatel": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko konateľa",
+          "helptext": "Uveďte meno a priezvisko konateľa",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -4919,7 +4919,7 @@ exports[`Form definitions olo-energeticke-zhodnotenie-odpadu-v-zevo schemas matc
       "zastupeny": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
+          "helptext": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -5336,7 +5336,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
     "sluzba": {
       "fotoDarovanychVeci": {
         "ui:options": {
-          "helptextHeader": "Nahrajte fotografiu vecí, ktoré chcete darovať (jpg, jpeg, png, max. 5MB)",
+          "helptext": "Nahrajte fotografiu vecí, ktoré chcete darovať (jpg, jpeg, png, max. 5MB)",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUploadMultiple",
@@ -5344,7 +5344,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
       "miestoDodania": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -5352,7 +5352,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
       "popisDarovanychVeci": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Okrem čalúneného nábytku a elektrospotrebičov",
+          "helptext": "Okrem čalúneného nábytku a elektrospotrebičov",
         },
         "ui:widget": "TextArea",
       },
@@ -5510,7 +5510,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej faktúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -5556,7 +5556,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
       "konatel": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko konateľa",
+          "helptext": "Uveďte meno a priezvisko konateľa",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -5638,7 +5638,7 @@ exports[`Form definitions olo-kolo-taxi schemas match snapshot 1`] = `
       "zastupeny": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
+          "helptext": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -6344,7 +6344,7 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
       "doplnujuceInfo": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Špecifikujte individuálne požiadavky.",
+          "helptext": "Špecifikujte individuálne požiadavky.",
         },
         "ui:widget": "TextArea",
       },
@@ -6384,7 +6384,7 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
           "miestoDodania": {
             "ui:label": false,
             "ui:options": {
-              "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+              "helptext": "Vyplňte vo formáte ulica a číslo",
               "inputType": "text",
             },
             "ui:widget": "Input",
@@ -6412,7 +6412,7 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
                   "value": "120 l zberná nádoba",
                 },
               ],
-              "helptextHeader": "markdown_gKgflRNwdS:Služba sa poskytuje iba pre bytové doby a firmy. Pre rodinné domy sú určené nádoby na [zberné hniezda](https://www.olo.sk/zberne-hniezda/).",
+              "helptext": "markdown_gKgflRNwdS:Služba sa poskytuje iba pre bytové doby a firmy. Pre rodinné domy sú určené nádoby na [zberné hniezda](https://www.olo.sk/zberne-hniezda/).",
             },
             "ui:widget": "Select",
           },
@@ -6432,7 +6432,7 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
                   "value": "240 l zberná nádoba",
                 },
               ],
-              "helptextHeader": "23 l zberná nádoba sa poskytuje iba pre odvoz z rodinných domov.",
+              "helptext": "23 l zberná nádoba sa poskytuje iba pre odvoz z rodinných domov.",
             },
             "ui:widget": "Select",
           },
@@ -6569,7 +6569,7 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
       },
       "preferovanyDatum": {
         "ui:options": {
-          "helptextHeader": "Vami zvolený dátum má iba informačný charakter. Objednávku je potrebné podať minimálne 2 pracovné dni pred zvoleným termínom. V prípade, ak vami zvolený termín nebude voľný, budeme vás kontaktovať.",
+          "helptext": "Vami zvolený dátum má iba informačný charakter. Objednávku je potrebné podať minimálne 2 pracovné dni pred zvoleným termínom. V prípade, ak vami zvolený termín nebude voľný, budeme vás kontaktovať.",
         },
         "ui:widget": "DatePicker",
       },
@@ -6719,7 +6719,7 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej faktúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -6765,7 +6765,7 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
       "konatel": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko konateľa",
+          "helptext": "Uveďte meno a priezvisko konateľa",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -6847,7 +6847,7 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
       "zastupeny": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
+          "helptext": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -7157,7 +7157,7 @@ exports[`Form definitions olo-odvoz-objemneho-odpadu-valnikom schemas match snap
       "miestoDodania": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -7272,7 +7272,7 @@ exports[`Form definitions olo-odvoz-objemneho-odpadu-valnikom schemas match snap
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej faktúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -7318,7 +7318,7 @@ exports[`Form definitions olo-odvoz-objemneho-odpadu-valnikom schemas match snap
       "konatel": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko konateľa",
+          "helptext": "Uveďte meno a priezvisko konateľa",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -7374,7 +7374,7 @@ exports[`Form definitions olo-odvoz-objemneho-odpadu-valnikom schemas match snap
       "zastupeny": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
+          "helptext": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -7864,14 +7864,14 @@ exports[`Form definitions olo-odvoz-odpadu-velkokapacitnym-alebo-lisovacim-konta
     "sluzba": {
       "casOdvozu": {
         "ui:options": {
-          "helptextHeader": "V pracovné dni od 7.00 - 12.30",
+          "helptext": "V pracovné dni od 7.00 - 12.30",
           "size": "medium",
         },
         "ui:widget": "TimePicker",
       },
       "casPristavenia": {
         "ui:options": {
-          "helptextHeader": "V pracovné dni od 7.00 - 12.30",
+          "helptext": "V pracovné dni od 7.00 - 12.30",
           "size": "medium",
         },
         "ui:widget": "TimePicker",
@@ -7911,7 +7911,7 @@ exports[`Form definitions olo-odvoz-odpadu-velkokapacitnym-alebo-lisovacim-konta
       "miestoDodania": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -8104,7 +8104,7 @@ exports[`Form definitions olo-odvoz-odpadu-velkokapacitnym-alebo-lisovacim-konta
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej fakúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -8150,7 +8150,7 @@ exports[`Form definitions olo-odvoz-odpadu-velkokapacitnym-alebo-lisovacim-konta
       "konatel": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko konateľa",
+          "helptext": "Uveďte meno a priezvisko konateľa",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -8232,7 +8232,7 @@ exports[`Form definitions olo-odvoz-odpadu-velkokapacitnym-alebo-lisovacim-konta
       "zastupeny": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
+          "helptext": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -8456,7 +8456,7 @@ exports[`Form definitions olo-olo-taxi schemas match snapshot 1`] = `
       "miestoDodania": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
           "placeholder": "Zadajte presnú adresu",
         },
@@ -8465,7 +8465,7 @@ exports[`Form definitions olo-olo-taxi schemas match snapshot 1`] = `
       "mnozstvoADruhOdpadu": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Špecifikujte druh odpadu, uveďte počet kusov alebo množstvo v m³.",
+          "helptext": "Špecifikujte druh odpadu, uveďte počet kusov alebo množstvo v m³.",
         },
         "ui:widget": "TextArea",
       },
@@ -8494,7 +8494,7 @@ exports[`Form definitions olo-olo-taxi schemas match snapshot 1`] = `
       },
       "preferovanyDatumOdvozu": {
         "ui:options": {
-          "helptextHeader": "Vami zvolený dátum má iba informačný charakter. Objednávku je potrebné podať minimálne 2 pracovné dni pred zvoleným termínom. V prípade, ak vami zvolený termín nebude voľný, budeme vás kontaktovať.",
+          "helptext": "Vami zvolený dátum má iba informačný charakter. Objednávku je potrebné podať minimálne 2 pracovné dni pred zvoleným termínom. V prípade, ak vami zvolený termín nebude voľný, budeme vás kontaktovať.",
         },
         "ui:widget": "DatePicker",
       },
@@ -8825,7 +8825,7 @@ exports[`Form definitions olo-podnety-a-pochvaly-obcanov schemas match snapshot 
       "adresaMiestaOdvozu": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -8866,7 +8866,7 @@ exports[`Form definitions olo-podnety-a-pochvaly-obcanov schemas match snapshot 
               "value": "Sklo",
             },
           ],
-          "helptextHeader": "Vyberte aspoň jednu možnosť",
+          "helptext": "Vyberte aspoň jednu možnosť",
           "variant": "boxed",
         },
         "ui:widget": "CheckboxGroup",
@@ -8930,7 +8930,7 @@ exports[`Form definitions olo-podnety-a-pochvaly-obcanov schemas match snapshot 
       "sprava": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Napíšte svoje podnety",
+          "helptext": "Napíšte svoje podnety",
         },
         "ui:widget": "TextArea",
       },
@@ -9756,7 +9756,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
                   "value": "Kuchynský biologicky rozložiteľný odpad (Pravidelný odvoz vytriedených zložiek komunálneho odpadu kat. číslo 20)",
                 },
               ],
-              "helptextHeader": "Vyberte len 1 komoditu",
+              "helptext": "Vyberte len 1 komoditu",
             },
             "ui:widget": "Select",
           },
@@ -9787,7 +9787,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
                   "value": "2 x do týždňa",
                 },
               ],
-              "helptextHeader": "Kuchynský biologicky rozložiteľný odpad sa v Bratislave zbiera celoročne. Interval odvozov sa mení sezónne, a to dvakrát ročne. Od začiatku marca do konca novembra je zber realizovaný 2x za 7 dní. Od začiatku decembra do konca februára bude zber 1x do týždňa.",
+              "helptext": "Kuchynský biologicky rozložiteľný odpad sa v Bratislave zbiera celoročne. Interval odvozov sa mení sezónne, a to dvakrát ročne. Od začiatku marca do konca novembra je zber realizovaný 2x za 7 dní. Od začiatku decembra do konca februára bude zber 1x do týždňa.",
             },
             "ui:widget": "Select",
           },
@@ -9831,7 +9831,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
           "miestoDodania": {
             "ui:label": false,
             "ui:options": {
-              "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+              "helptext": "Vyplňte vo formáte ulica a číslo",
               "inputType": "text",
             },
             "ui:widget": "Input",
@@ -9852,7 +9852,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
                   "value": "240 l zberná nádoba",
                 },
               ],
-              "helptextHeader": "23 l zberná nádoba je možná vybrať iba pre právnické osoby, ktoré majú sídlo v rodinných domoch",
+              "helptext": "23 l zberná nádoba je možná vybrať iba pre právnické osoby, ktoré majú sídlo v rodinných domoch",
             },
             "ui:widget": "Select",
           },
@@ -9936,7 +9936,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
           "pocetNadob": {
             "ui:label": false,
             "ui:options": {
-              "helptextHeader": "Uveďte počet nádob",
+              "helptext": "Uveďte počet nádob",
             },
             "ui:widget": "Number",
           },
@@ -10057,7 +10057,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
       },
       "datumZmeny": {
         "ui:options": {
-          "helptextHeader": "Uveďte dátum predpokladanej zmeny odberateľa",
+          "helptext": "Uveďte dátum predpokladanej zmeny odberateľa",
         },
         "ui:widget": "DatePicker",
       },
@@ -10086,7 +10086,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej faktúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -10119,7 +10119,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej faktúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -10172,7 +10172,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
       "konatel": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko konateľa",
+          "helptext": "Uveďte meno a priezvisko konateľa",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -10289,7 +10289,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-pravnicke
       "zastupeny": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
+          "helptext": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -11075,7 +11075,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
                   "value": "Sklo (Pravidelný odvoz vytriedených zložiek komunálneho odpadu kat. číslo 20)",
                 },
               ],
-              "helptextHeader": "markdown_gKgflRNwdS:Vyberte len 1 komoditu. Správcovia nehnuteľností v prípade Kuchynského biologicky rozložiteľného odpadu riešia zapojenie a zmeny v systéme zapojenia na Magistráte hlavného mesta. **Zmesový komunálny odpad sa rieši na** [Magistráte hlavného mesta](https://bratislava.sk/mesto-bratislava/dane-a-poplatky/poplatok-za-komunalne-odpady-a-drobne-stavebne-odpady).",
+              "helptext": "markdown_gKgflRNwdS:Vyberte len 1 komoditu. Správcovia nehnuteľností v prípade Kuchynského biologicky rozložiteľného odpadu riešia zapojenie a zmeny v systéme zapojenia na Magistráte hlavného mesta. **Zmesový komunálny odpad sa rieši na** [Magistráte hlavného mesta](https://bratislava.sk/mesto-bratislava/dane-a-poplatky/poplatok-za-komunalne-odpady-a-drobne-stavebne-odpady).",
             },
             "ui:widget": "Select",
           },
@@ -11119,7 +11119,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
           "miestoDodania": {
             "ui:label": false,
             "ui:options": {
-              "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+              "helptext": "Vyplňte vo formáte ulica a číslo",
               "inputType": "text",
             },
             "ui:widget": "Input",
@@ -11177,7 +11177,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
           "pocetNadob": {
             "ui:label": false,
             "ui:options": {
-              "helptextHeader": "Uveďte počet nádob",
+              "helptext": "Uveďte počet nádob",
             },
             "ui:widget": "Number",
           },
@@ -11294,7 +11294,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
       },
       "datumZmeny": {
         "ui:options": {
-          "helptextHeader": "Uveďte dátum predpokladanej zmeny odberateľa",
+          "helptext": "Uveďte dátum predpokladanej zmeny odberateľa",
         },
         "ui:widget": "DatePicker",
       },
@@ -11323,7 +11323,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej faktúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -11356,7 +11356,7 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej faktúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -13519,7 +13519,7 @@ exports[`Form definitions olo-uzatvorenie-zmluvy-o-nakladani-s-odpadom schemas m
       "cisloPovoleniaNaVstup": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vo formáte: 123/45 alebo 1234/45/2026 (číslo Objednávky alebo Zmluvy)",
+          "helptext": "Vo formáte: 123/45 alebo 1234/45/2026 (číslo Objednávky alebo Zmluvy)",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -13542,7 +13542,7 @@ exports[`Form definitions olo-uzatvorenie-zmluvy-o-nakladani-s-odpadom schemas m
         "elektronickaFaktura": {
           "ui:options": {
             "checkboxLabel": "Súhlasím so zaslaním elektronickej faktúry",
-            "helptextHeader": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
+            "helptext": "V prípade vyjadrenia nesúhlasu bude zákazníkovi za zasielanie faktúry poštou účtovaný poplatok 10 € bez DPH. Osobitné ustanovenia o zasielaní faktúry v elektronickej podobe v zmysle bodu 5.9 VOP.",
             "variant": "boxed",
           },
           "ui:widget": "Checkbox",
@@ -13606,7 +13606,7 @@ exports[`Form definitions olo-uzatvorenie-zmluvy-o-nakladani-s-odpadom schemas m
       "konatel": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko konateľa",
+          "helptext": "Uveďte meno a priezvisko konateľa",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -13689,7 +13689,7 @@ exports[`Form definitions olo-uzatvorenie-zmluvy-o-nakladani-s-odpadom schemas m
       "zastupeny": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
+          "helptext": "Uveďte meno a priezvisko osoby zastupujúcej na základe splnomocnenia",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -14003,7 +14003,7 @@ exports[`Form definitions predzahradky schemas match snapshot 1`] = `
       "ine": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Ak by ste nám chceli ešte niečo v súvislosti s predzáhradkou napísať, tu je na to priestor.",
+          "helptext": "Ak by ste nám chceli ešte niečo v súvislosti s predzáhradkou napísať, tu je na to priestor.",
           "placeholder": "Popíšte",
         },
         "ui:widget": "TextArea",
@@ -14087,7 +14087,7 @@ exports[`Form definitions predzahradky schemas match snapshot 1`] = `
       "parcelneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "markdown_gKgflRNwdS:Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13). Pre schválenie žiadosti sa musí jednať o mestský pozemok.",
+          "helptext": "markdown_gKgflRNwdS:Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13). Pre schválenie žiadosti sa musí jednať o mestský pozemok.",
           "inputType": "text",
           "size": "medium",
         },
@@ -14096,7 +14096,7 @@ exports[`Form definitions predzahradky schemas match snapshot 1`] = `
       "rozlozenieExistujuca": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Popíšte rozloženie jednotlivých prvkov predzáhradky.",
+          "helptext": "Popíšte rozloženie jednotlivých prvkov predzáhradky.",
           "placeholder": "Popíšte",
         },
         "ui:widget": "TextArea",
@@ -14160,7 +14160,7 @@ exports[`Form definitions predzahradky schemas match snapshot 1`] = `
       },
       "projekt": {
         "ui:options": {
-          "helptextHeader": "Napríklad, vo forme jednoduchého nákresu rozloženia jednotlivých prvkov.",
+          "helptext": "Napríklad, vo forme jednoduchého nákresu rozloženia jednotlivých prvkov.",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUpload",
@@ -20914,7 +20914,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch",
-            "helptextHeader": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -21501,7 +21501,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
+            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
 
 V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.
 
@@ -21519,7 +21519,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu výmery pozemkov",
-            "helptextHeader": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -21974,7 +21974,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
 
@@ -21992,7 +21992,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu zastavanej plochy",
-            "helptextHeader": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -22462,7 +22462,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).
 
@@ -22480,7 +22480,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch a základu dane",
-            "helptextHeader": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -23032,7 +23032,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
+            "helptext": "markdown_gKgflRNwdS:Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
 
 K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 * k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)
@@ -34662,7 +34662,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch",
-            "helptextHeader": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -35249,7 +35249,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
+            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
 
 V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.
 
@@ -35267,7 +35267,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu výmery pozemkov",
-            "helptextHeader": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -35722,7 +35722,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
 
@@ -35740,7 +35740,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu zastavanej plochy",
-            "helptextHeader": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -36210,7 +36210,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).
 
@@ -36228,7 +36228,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch a základu dane",
-            "helptextHeader": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -36780,7 +36780,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
+            "helptext": "markdown_gKgflRNwdS:Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
 
 K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 * k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)
@@ -43699,7 +43699,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
       "adresaPodnikania": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -43707,7 +43707,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
       "adresaSidla": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -43715,7 +43715,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
       "adresaTrvalehoPobytu": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -43759,7 +43759,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
         "meno": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Meno",
+            "helptext": "Meno",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -43767,7 +43767,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
         "priezvisko": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Priezvisko",
+            "helptext": "Priezvisko",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -43775,7 +43775,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
         "telefonneCislo": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte vo formáte +421",
+            "helptext": "Vyplňte vo formáte +421",
             "inputType": "tel",
           },
           "ui:widget": "Input",
@@ -43870,7 +43870,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
       "telefonneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte +421",
+          "helptext": "Vyplňte vo formáte +421",
           "inputType": "tel",
         },
         "ui:widget": "Input",
@@ -43898,7 +43898,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
       "informativnyZakresSieti": {
         "ui:options": {
           "accept": ".pdf,.jpg,.jpeg,.png",
-          "helptextHeader": "Požiadať o informatívny zákres vydaný Technickými sieťami Bratislava, a.s. môžete formou spoplatnenej služby Objednávka informatívneho zákresu sietí",
+          "helptext": "Požiadať o informatívny zákres vydaný Technickými sieťami Bratislava, a.s. môžete formou spoplatnenej služby Objednávka informatívneho zákresu sietí",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUploadMultiple",
@@ -43956,7 +43956,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
         "email": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Faktúra vám bude zaslaná prostredníctvom tohto emailu",
+            "helptext": "Faktúra vám bude zaslaná prostredníctvom tohto emailu",
             "inputType": "email",
           },
           "ui:widget": "Input",
@@ -43974,7 +43974,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
         "dovodVytycenia": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Napríklad: vytýčenie káblovej poruchy, za účelom rozkopávky, vybudovanie inžinierskych sietí...",
+            "helptext": "Napríklad: vytýčenie káblovej poruchy, za účelom rozkopávky, vybudovanie inžinierskych sietí...",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -43982,7 +43982,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
         "druhStavby": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Napríklad: telekomunikačná líniová stavba",
+            "helptext": "Napríklad: telekomunikačná líniová stavba",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -44071,7 +44071,7 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
                 "value": "Záhorská Bystrica",
               },
             ],
-            "helptextHeader": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
+            "helptext": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
           },
           "ui:widget": "SelectMultiple",
         },
@@ -44159,21 +44159,21 @@ exports[`Form definitions tsb-objednavka-vytycenia schemas match snapshot 1`] = 
                 "value": "Záhorská Bystrica",
               },
             ],
-            "helptextHeader": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
+            "helptext": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
           },
           "ui:widget": "Select",
         },
         "pozadovaneMiestoPlnenia": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+            "helptext": "Vyplňte vo formáte ulica a číslo",
             "inputType": "text",
           },
           "ui:widget": "Input",
         },
         "pozadovanyTerminPlnenia": {
           "ui:options": {
-            "helptextHeader": "Štandardný termín na vybavenie objednávky je 30 dní",
+            "helptext": "Štandardný termín na vybavenie objednávky je 30 dní",
           },
           "ui:widget": "DatePicker",
         },
@@ -44722,7 +44722,7 @@ exports[`Form definitions tsb-objednavka-zakresu-sieti schemas match snapshot 1`
       "adresaPodnikania": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -44730,7 +44730,7 @@ exports[`Form definitions tsb-objednavka-zakresu-sieti schemas match snapshot 1`
       "adresaSidla": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -44738,7 +44738,7 @@ exports[`Form definitions tsb-objednavka-zakresu-sieti schemas match snapshot 1`
       "adresaTrvalehoPobytu": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -44782,7 +44782,7 @@ exports[`Form definitions tsb-objednavka-zakresu-sieti schemas match snapshot 1`
         "meno": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Meno",
+            "helptext": "Meno",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -44790,7 +44790,7 @@ exports[`Form definitions tsb-objednavka-zakresu-sieti schemas match snapshot 1`
         "priezvisko": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Priezvisko",
+            "helptext": "Priezvisko",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -44798,7 +44798,7 @@ exports[`Form definitions tsb-objednavka-zakresu-sieti schemas match snapshot 1`
         "telefonneCislo": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte vo formáte +421",
+            "helptext": "Vyplňte vo formáte +421",
             "inputType": "tel",
           },
           "ui:widget": "Input",
@@ -44893,7 +44893,7 @@ exports[`Form definitions tsb-objednavka-zakresu-sieti schemas match snapshot 1`
       "telefonneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte +421",
+          "helptext": "Vyplňte vo formáte +421",
           "inputType": "tel",
         },
         "ui:widget": "Input",
@@ -44920,7 +44920,7 @@ exports[`Form definitions tsb-objednavka-zakresu-sieti schemas match snapshot 1`
     "prilohy": {
       "snimkaKatastralnejMapy": {
         "ui:options": {
-          "helptextHeader": "Využiť môžete katastrálnu mapu ZBGIS, kde nájdete požadované záujmové územie.
+          "helptext": "Využiť môžete katastrálnu mapu ZBGIS, kde nájdete požadované záujmové územie.
 
 Ako vytvoriť snímku?
 Prejdite do katastrálnej mapy ZBGIS. Otvorením menu v ľavom hornom rohu nájdete funkciu Meranie, ktorá Vám umožní zaznačiť Vaše záujmové územie na katastrálnej mape (zaznačenie Vám následne vypočíta výmeru plochy). Snímku vycentrujte a využite možnosť ZBGIS Tlačiť do PDF. Dokument uložte a následne nahrajte do Nahrať súbory.",
@@ -44940,7 +44940,7 @@ Prejdite do katastrálnej mapy ZBGIS. Otvorením menu v ľavom hornom rohu nájd
         "email": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Faktúra vám bude zaslaná prostredníctvom tohto emailu",
+            "helptext": "Faktúra vám bude zaslaná prostredníctvom tohto emailu",
             "inputType": "email",
           },
           "ui:widget": "Input",
@@ -44948,7 +44948,7 @@ Prejdite do katastrálnej mapy ZBGIS. Otvorením menu v ľavom hornom rohu nájd
         "fakturacnaAdresa": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+            "helptext": "Vyplňte vo formáte ulica a číslo",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -44982,7 +44982,7 @@ Prejdite do katastrálnej mapy ZBGIS. Otvorením menu v ľavom hornom rohu nájd
         "adresaObjednavky": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+            "helptext": "Vyplňte vo formáte ulica a číslo",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -45071,7 +45071,7 @@ Prejdite do katastrálnej mapy ZBGIS. Otvorením menu v ľavom hornom rohu nájd
                 "value": "Záhorská Bystrica",
               },
             ],
-            "helptextHeader": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
+            "helptext": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
           },
           "ui:widget": "SelectMultiple",
         },
@@ -45159,7 +45159,7 @@ Prejdite do katastrálnej mapy ZBGIS. Otvorením menu v ľavom hornom rohu nájd
                 "value": "Záhorská Bystrica",
               },
             ],
-            "helptextHeader": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
+            "helptext": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
           },
           "ui:widget": "SelectMultiple",
         },
@@ -45753,20 +45753,20 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
       },
       "planovanyDatumDemontaze": {
         "ui:options": {
-          "helptextHeader": "Žiadateľ je povinný na základe písomnej výzvy zabezpečiť demontáž svojho zariadenia na vlastné náklady, a to v lehote najneskôr do 15 kalendárnych dní od doručenia takejto výzvy prostredníctvom kontaktného e-mailu.",
+          "helptext": "Žiadateľ je povinný na základe písomnej výzvy zabezpečiť demontáž svojho zariadenia na vlastné náklady, a to v lehote najneskôr do 15 kalendárnych dní od doručenia takejto výzvy prostredníctvom kontaktného e-mailu.",
         },
         "ui:widget": "DatePicker",
       },
       "planovanyDatumMontaze": {
         "ui:options": {
-          "helptextHeader": "O zahájení prác je potrebné písomne informovať minimálne 1 pracovný deň vopred prostredníctvom e-mailu na info@tsb.sk.",
+          "helptext": "O zahájení prác je potrebné písomne informovať minimálne 1 pracovný deň vopred prostredníctvom e-mailu na info@tsb.sk.",
         },
         "ui:widget": "DatePicker",
       },
       "telefonneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte +421",
+          "helptext": "Vyplňte vo formáte +421",
           "inputType": "tel",
         },
         "ui:widget": "Input",
@@ -45787,7 +45787,7 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
       ],
       "umiestnenieStoziare": {
         "ui:options": {
-          "helptextHeader": "V prípade, že požadovaný súbor na vyplnenie ešte nemáte, stiahnuť si ho viete na tomto odkaze. Dbajte na to, aby ste v súbore spomenuli všetky zariadenia, ktoré si želáte umiestniť. Bez vyplnenia a nahratia tohto súboru nebude možné vašu žiadosť spracovať.",
+          "helptext": "V prípade, že požadovaný súbor na vyplnenie ešte nemáte, stiahnuť si ho viete na tomto odkaze. Dbajte na to, aby ste v súbore spomenuli všetky zariadenia, ktoré si želáte umiestniť. Bez vyplnenia a nahratia tohto súboru nebude možné vašu žiadosť spracovať.",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUploadMultiple",
@@ -45813,7 +45813,7 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
     "prilohy": {
       "fotografiaVizualizacia": {
         "ui:options": {
-          "helptextHeader": "Nahrajte jednu prílohu obsahujúcu fotografie alebo vizualizácie všetkých zariadení.",
+          "helptext": "Nahrajte jednu prílohu obsahujúcu fotografie alebo vizualizácie všetkých zariadení.",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUploadMultiple",
@@ -45831,7 +45831,7 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
       "adresaPodnikania": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -45839,7 +45839,7 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
       "adresaSidla": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -45847,7 +45847,7 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
       "adresaTrvalehoPobytu": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -45891,7 +45891,7 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
         "meno": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Meno",
+            "helptext": "Meno",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -45899,7 +45899,7 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
         "priezvisko": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Priezvisko",
+            "helptext": "Priezvisko",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -45907,7 +45907,7 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
         "telefonneCislo": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte vo formáte +421",
+            "helptext": "Vyplňte vo formáte +421",
             "inputType": "tel",
           },
           "ui:widget": "Input",
@@ -46002,7 +46002,7 @@ exports[`Form definitions tsb-umiestnenie-zariadenia schemas match snapshot 1`] 
       "telefonneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte +421",
+          "helptext": "Vyplňte vo formáte +421",
           "inputType": "tel",
         },
         "ui:widget": "Input",
@@ -46488,14 +46488,14 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
       },
       "svetelnoTechnickyVypocetFile": {
         "ui:options": {
-          "helptextHeader": "Výpočet je nutné doložiť v prípade stavby verejného osvetlenia.",
+          "helptext": "Výpočet je nutné doložiť v prípade stavby verejného osvetlenia.",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUploadMultiple",
       },
       "technickaSpravaFile": {
         "ui:options": {
-          "helptextHeader": "Technická správa s popisom navrhovaného technického riešenia.",
+          "helptext": "Technická správa s popisom navrhovaného technického riešenia.",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUploadMultiple",
@@ -46511,7 +46511,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
       ],
       "vyznaceneZaujmoveUzemieFile": {
         "ui:options": {
-          "helptextHeader": "Využiť môžete katastrálnu mapu ZBGIS, kde nájdete požadované záujmové územie. V katastrálnej mape zvoľte funkciu Meranie v ľavom menu a vyznačte záujmové územie. Meranie uložte cez možnosť Tlačiť do PDF.",
+          "helptext": "Využiť môžete katastrálnu mapu ZBGIS, kde nájdete požadované záujmové územie. V katastrálnej mape zvoľte funkciu Meranie v ľavom menu a vyznačte záujmové územie. Meranie uložte cez možnosť Tlačiť do PDF.",
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUploadMultiple",
@@ -46521,7 +46521,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
       "adresaStavby": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -46610,14 +46610,14 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
               "value": "Záhorská Bystrica",
             },
           ],
-          "helptextHeader": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
+          "helptext": "Vyberte zo zoznamu katastrálnych území. Zobraziť ukážku katastrálnych území.",
         },
         "ui:widget": "SelectMultiple",
       },
       "nazovStavby": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Napríklad: Polyfunkčný objekt ABC",
+          "helptext": "Napríklad: Polyfunkčný objekt ABC",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -46654,7 +46654,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
       "typProjektovejDokumentacie": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Napríklad: Ohlásenie stavby",
+          "helptext": "Napríklad: Ohlásenie stavby",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -46678,7 +46678,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
       "adresaPodnikania": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -46686,7 +46686,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
       "adresaSidla": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -46694,7 +46694,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
       "adresaTrvalehoPobytu": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte ulica a číslo",
+          "helptext": "Vyplňte vo formáte ulica a číslo",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -46738,7 +46738,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
         "meno": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Meno",
+            "helptext": "Meno",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -46746,7 +46746,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
         "priezvisko": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Priezvisko",
+            "helptext": "Priezvisko",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -46754,7 +46754,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
         "telefonneCislo": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte vo formáte +421",
+            "helptext": "Vyplňte vo formáte +421",
             "inputType": "tel",
           },
           "ui:widget": "Input",
@@ -46849,7 +46849,7 @@ exports[`Form definitions tsb-ziadost-o-stanovisko-pd schemas match snapshot 1`]
       "telefonneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Vyplňte vo formáte +421",
+          "helptext": "Vyplňte vo formáte +421",
           "inputType": "tel",
         },
         "ui:widget": "Input",
@@ -52174,7 +52174,7 @@ exports[`Form definitions ziadost-o-najom-bytu schemas match snapshot 1`] = `
                     "value": false,
                   },
                 ],
-                "helptextHeader": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+                "helptext": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -52309,7 +52309,7 @@ exports[`Form definitions ziadost-o-najom-bytu schemas match snapshot 1`] = `
                     "value": false,
                   },
                 ],
-                "helptextHeader": "Ak označíte odpoveď  "Áno", zobrazia sa vám konkrétne možnosti bývania. Ak sa nezaopatreného dieťaťa žiadna z nich nebude týkať, označte odpoveď "Nie".",
+                "helptext": "Ak označíte odpoveď  "Áno", zobrazia sa vám konkrétne možnosti bývania. Ak sa nezaopatreného dieťaťa žiadna z nich nebude týkať, označte odpoveď "Nie".",
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -52813,7 +52813,7 @@ exports[`Form definitions ziadost-o-najom-bytu schemas match snapshot 1`] = `
                   "value": false,
                 },
               ],
-              "helptextHeader": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+              "helptext": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
               "orientations": "row",
               "variant": "boxed",
             },
@@ -52919,7 +52919,7 @@ exports[`Form definitions ziadost-o-najom-bytu schemas match snapshot 1`] = `
         "rodnePriezvisko": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte iba v prípade, ak je priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.",
+            "helptext": "Vyplňte iba v prípade, ak je priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -53034,7 +53034,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "Označte áno, ak poberal/poberala v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.",
+            "helptext": "Označte áno, ak poberal/poberala v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -53060,7 +53060,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "Materskú, tehotenský príspevok, rodičovský príspevok, prídavky na deti, dávka v hmotnej núdzi, ochranný príspevok, opatrovateľský príspevok, kompenzačný príspevok alebo iné príspevky z Úradu práce.",
+            "helptext": "Materskú, tehotenský príspevok, rodičovský príspevok, prídavky na deti, dávka v hmotnej núdzi, ochranný príspevok, opatrovateľský príspevok, kompenzačný príspevok alebo iné príspevky z Úradu práce.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -53086,7 +53086,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu druha/družky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
+            "helptext": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu druha/družky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -53158,7 +53158,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu druhovi/družke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
+            "helptext": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu druhovi/družke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -53186,7 +53186,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "Ak označíte odpoveď  "Áno", zobrazia sa vám konkrétne možnosti bývania. Ak sa druha/družky žiadna z nich nebude týkať, označte odpoveď "Nie".",
+            "helptext": "Ak označíte odpoveď  "Áno", zobrazia sa vám konkrétne možnosti bývania. Ak sa druha/družky žiadna z nich nebude týkať, označte odpoveď "Nie".",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -53615,7 +53615,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
       "dovodyPodaniaZiadosti": {
         "ui:label": false,
         "ui:options": {
-          "helptextHeader": "Priestor pre vyjadrenie akýchkoľvek informácií, ktoré si myslíte, že by sme mali vedieť, ale neboli súčasťou otázok.",
+          "helptext": "Priestor pre vyjadrenie akýchkoľvek informácií, ktoré si myslíte, že by sme mali vedieť, ale neboli súčasťou otázok.",
         },
         "ui:widget": "TextArea",
       },
@@ -53810,7 +53810,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
             "rodnePriezvisko": {
               "ui:label": false,
               "ui:options": {
-                "helptextHeader": "Vyplňte iba v prípade, ak je priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.",
+                "helptext": "Vyplňte iba v prípade, ak je priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.",
                 "inputType": "text",
               },
               "ui:widget": "Input",
@@ -53858,7 +53858,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                     "value": false,
                   },
                 ],
-                "helptextHeader": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+                "helptext": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -53960,7 +53960,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                     "value": false,
                   },
                 ],
-                "helptextHeader": "Označte áno, ak poberal/poberala v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.",
+                "helptext": "Označte áno, ak poberal/poberala v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.",
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -53986,7 +53986,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                     "value": false,
                   },
                 ],
-                "helptextHeader": "Materskú, tehotenský príspevok, rodičovský príspevok, prídavky na deti, dávka v hmotnej núdzi, ochranný príspevok, opatrovateľský príspevok, kompenzačný príspevok alebo iné príspevky z Úradu práce.",
+                "helptext": "Materskú, tehotenský príspevok, rodičovský príspevok, prídavky na deti, dávka v hmotnej núdzi, ochranný príspevok, opatrovateľský príspevok, kompenzačný príspevok alebo iné príspevky z Úradu práce.",
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -54012,7 +54012,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                     "value": false,
                   },
                 ],
-                "helptextHeader": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu člena/členky domácnosti podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
+                "helptext": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu člena/členky domácnosti podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -54084,7 +54084,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                     "value": false,
                   },
                 ],
-                "helptextHeader": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ člena/členky domácnosti na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
+                "helptext": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ člena/členky domácnosti na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -54112,7 +54112,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                     "value": false,
                   },
                 ],
-                "helptextHeader": "Ak pri otázke Nachádza sa v bytovej núdzi označíte odpoveď  "Áno", zobrazia sa vám konkrétne možnosti bývania. Ak sa člena/členky domácnosti žiadna z nich nebude týkať, označte odpoveď "Nie".",
+                "helptext": "Ak pri otázke Nachádza sa v bytovej núdzi označíte odpoveď  "Áno", zobrazia sa vám konkrétne možnosti bývania. Ak sa člena/členky domácnosti žiadna z nich nebude týkať, označte odpoveď "Nie".",
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -54616,7 +54616,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                   "value": false,
                 },
               ],
-              "helptextHeader": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+              "helptext": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
               "orientations": "row",
               "variant": "boxed",
             },
@@ -54681,7 +54681,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
         "rodnePriezvisko": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte iba v prípade, ak je priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.",
+            "helptext": "Vyplňte iba v prípade, ak je priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -54794,7 +54794,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "Označte áno, ak poberal/poberala v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.",
+            "helptext": "Označte áno, ak poberal/poberala v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -54820,7 +54820,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "Materskú, tehotenský príspevok, rodičovský príspevok, prídavky na deti, dávka v hmotnej núdzi, ochranný príspevok, opatrovateľský príspevok, kompenzačný príspevok alebo iné príspevky z Úradu práce.",
+            "helptext": "Materskú, tehotenský príspevok, rodičovský príspevok, prídavky na deti, dávka v hmotnej núdzi, ochranný príspevok, opatrovateľský príspevok, kompenzačný príspevok alebo iné príspevky z Úradu práce.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -54846,7 +54846,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu manžela/manželky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
+            "helptext": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu manžela/manželky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -54918,7 +54918,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu manželovi/manželke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
+            "helptext": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu manželovi/manželke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -54946,7 +54946,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "Ak označíte odpoveď  "Áno", zobrazia sa vám konkrétne možnosti bývania. Ak sa manžela/manželky žiadna z nich nebude týkať, označte odpoveď "Nie".",
+            "helptext": "Ak označíte odpoveď  "Áno", zobrazia sa vám konkrétne možnosti bývania. Ak sa manžela/manželky žiadna z nich nebude týkať, označte odpoveď "Nie".",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -55635,7 +55635,7 @@ ziadatelPrijem + manzelManzelkaPrijem + druhDruzkaPrijem + detiPrijmy + inyCleno
                   "value": false,
                 },
               ],
-              "helptextHeader": "markdown_gKgflRNwdS:Ak ste vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+              "helptext": "markdown_gKgflRNwdS:Ak ste vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
               "orientations": "row",
               "variant": "boxed",
             },
@@ -55690,7 +55690,7 @@ ziadatelPrijem + manzelManzelkaPrijem + druhDruzkaPrijem + detiPrijmy + inyCleno
         "email": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Ak nemáte email, uveďte kontaktné údaje na inú osobu resp. organizáciu.",
+            "helptext": "Ak nemáte email, uveďte kontaktné údaje na inú osobu resp. organizáciu.",
             "inputType": "email",
           },
           "ui:widget": "Input",
@@ -55766,7 +55766,7 @@ ziadatelPrijem + manzelManzelkaPrijem + druhDruzkaPrijem + detiPrijmy + inyCleno
         "rodnePriezvisko": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Vyplňte iba v prípade, ak je vaše priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.",
+            "helptext": "Vyplňte iba v prípade, ak je vaše priezvisko iné ako to, ktoré ste uviedli v predchádzajúcej odpovedi.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -55791,7 +55791,7 @@ ziadatelPrijem + manzelManzelkaPrijem + druhDruzkaPrijem + detiPrijmy + inyCleno
         "telefonneCislo": {
           "ui:label": false,
           "ui:options": {
-            "helptextHeader": "Ak nemáte telefonický kontakt, uveďte kontaktné údaje na inú osobu resp. organizáciu. Vyplňte vo formáte s predvoľbou +421.",
+            "helptext": "Ak nemáte telefonický kontakt, uveďte kontaktné údaje na inú osobu resp. organizáciu. Vyplňte vo formáte s predvoľbou +421.",
             "inputType": "tel",
             "placeholder": "+421",
             "size": "medium",
@@ -55894,7 +55894,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "Označte áno, ak ste poberali v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.",
+            "helptext": "Označte áno, ak ste poberali v minulom kalendárnom roku niektorý z dôchodkov, resp. dôchodkových dávok v rámci systému sociálneho zabezpečenia, napr. invalidný dôchodok, starobný / predčasný starobný dôchodok, vdovský / vdovecký dôchodok, sirotský dôchodok, výsluhový dôchodok.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -55920,7 +55920,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "Materskú, tehotenský príspevok, rodičovský príspevok, prídavky na deti, dávka v hmotnej núdzi, ochranný príspevok, opatrovateľský príspevok, kompenzačný príspevok alebo iné príspevky z Úradu práce.",
+            "helptext": "Materskú, tehotenský príspevok, rodičovský príspevok, prídavky na deti, dávka v hmotnej núdzi, ochranný príspevok, opatrovateľský príspevok, kompenzačný príspevok alebo iné príspevky z Úradu práce.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -55946,7 +55946,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu Vášho čistého príjmu podľa potvrdenia, ktoré vám vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemáte podané daňové priznanie, resp. nepoznáte sumu vášho príjmu, vyplňte prosím váš čistý príjem za posledný známy rok.",
+            "helptext": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu Vášho čistého príjmu podľa potvrdenia, ktoré vám vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemáte podané daňové priznanie, resp. nepoznáte sumu vášho príjmu, vyplňte prosím váš čistý príjem za posledný známy rok.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -56018,7 +56018,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Váš zamestnávateľ vám na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť váš priemerný mesačný čistý príjem za minulý kalendárny rok.",
+            "helptext": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Váš zamestnávateľ vám na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť váš priemerný mesačný čistý príjem za minulý kalendárny rok.",
             "orientations": "row",
             "variant": "boxed",
           },
@@ -56089,7 +56089,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": "81aViac",
               },
             ],
-            "helptextHeader": "Vyšší vek jedného z členov domácnosti je považovaný za rizikový faktor. Otázka sa vzťahuje iba na členov domácnosti, s ktorými by ste chceli bývať v mestskom nájomnom byte.",
+            "helptext": "Vyšší vek jedného z členov domácnosti je považovaný za rizikový faktor. Otázka sa vzťahuje iba na členov domácnosti, s ktorými by ste chceli bývať v mestskom nájomnom byte.",
             "variant": "boxed",
           },
           "ui:widget": "RadioGroup",
@@ -56122,7 +56122,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": "opustenieSpecialnehoZariadenia",
               },
             ],
-            "helptextHeader": "Môžete označiť viac možností.",
+            "helptext": "Môžete označiť viac možností.",
             "variant": "boxed",
           },
           "ui:widget": "CheckboxGroup",
@@ -56252,7 +56252,7 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptextHeader": "markdown_gKgflRNwdS:Podmienkou pridelenia bezbariérového bytu je, že žiadateľ alebo člen domácnosti musí mať lekárom potvrdené, že má diagnostikované zdravotné postihnutie, v zmysle [prílohy č. 2 zákona 443/2010 Z. z.](https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2010/443/20180101#prilohy) - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_bezbarierovy_byt_Priloha2_94fc7ae8e6.pdf).",
+            "helptext": "markdown_gKgflRNwdS:Podmienkou pridelenia bezbariérového bytu je, že žiadateľ alebo člen domácnosti musí mať lekárom potvrdené, že má diagnostikované zdravotné postihnutie, v zmysle [prílohy č. 2 zákona 443/2010 Z. z.](https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2010/443/20180101#prilohy) - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_bezbarierovy_byt_Priloha2_94fc7ae8e6.pdf).",
             "orientations": "row",
             "variant": "boxed",
           },

--- a/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
+++ b/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
@@ -20924,7 +20924,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch",
-            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -21520,12 +21520,12 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "value": false,
               },
             ],
-            "helptextFooter": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
+            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
 
 V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}",
-            "helptextFooterMarkdown": true,
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -21539,7 +21539,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu výmery pozemkov",
-            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -22002,12 +22002,12 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "value": false,
               },
             ],
-            "helptextFooter": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}",
-            "helptextFooterMarkdown": true,
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -22021,7 +22021,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu zastavanej plochy",
-            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -22496,12 +22496,12 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                 "value": false,
               },
             ],
-            "helptextFooter": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).
 
 :form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}",
-            "helptextFooterMarkdown": true,
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -22515,7 +22515,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch a základu dane",
-            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -23077,7 +23077,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "value": false,
               },
             ],
-            "helptextFooter": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
+            "helptext": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
 
 K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 * k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)
@@ -23086,7 +23086,7 @@ K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}",
-            "helptextFooterMarkdown": true,
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -34710,7 +34710,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch",
-            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -35306,12 +35306,12 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "value": false,
               },
             ],
-            "helptextFooter": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
+            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
 
 V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}",
-            "helptextFooterMarkdown": true,
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -35325,7 +35325,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu výmery pozemkov",
-            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -35788,12 +35788,12 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "value": false,
               },
             ],
-            "helptextFooter": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}",
-            "helptextFooterMarkdown": true,
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -35807,7 +35807,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu zastavanej plochy",
-            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -36282,12 +36282,12 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                 "value": false,
               },
             ],
-            "helptextFooter": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).
 
 :form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}",
-            "helptextFooterMarkdown": true,
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -36301,7 +36301,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch a základu dane",
-            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
+            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -36863,7 +36863,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "value": false,
               },
             ],
-            "helptextFooter": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
+            "helptext": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
 
 K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 * k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)
@@ -36872,7 +36872,7 @@ K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}",
-            "helptextFooterMarkdown": true,
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",

--- a/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
+++ b/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
@@ -660,7 +660,8 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       "parcelneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "markdown_gKgflRNwdS:Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13).",
+          "helptext": "Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13).",
+          "helptextMarkdown": true,
           "inputType": "text",
           "size": "medium",
         },
@@ -726,7 +727,8 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
               "value": "Vyšehradská",
             },
           ],
-          "helptext": "markdown_gKgflRNwdS:Pre zaistenie kvalitného verejného priestoru sme na niektorých mestských pozemkoch zaviedli zopár [podmienok](https://bratislava.sk/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/komunitne-zahrady) pre vznik komunitnej záhrady.",
+          "helptext": "Pre zaistenie kvalitného verejného priestoru sme na niektorých mestských pozemkoch zaviedli zopár [podmienok](https://bratislava.sk/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/komunitne-zahrady) pre vznik komunitnej záhrady.",
+          "helptextMarkdown": true,
         },
         "ui:widget": "Select",
       },
@@ -761,9 +763,10 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
     "prilohyInyPozemok": {
       "dizajn": {
         "ui:options": {
-          "helptext": "markdown_gKgflRNwdS:Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.
+          "helptext": "Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.
 
  Napríklad, záhony či pestovacie boxy, výsadbu akejkoľvek trvalkovej zelene, kríkov a stromov spolu s druhovým špecifikovaním tejto zelene, kompost, mobiliár, priestor na uskladnenie náradia a zariadenia záhrady, priestor pre využívanie grilu, spôsob zabezpečenia vody a jej distribúcie.",
+          "helptextMarkdown": true,
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUpload",
@@ -792,7 +795,8 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       ],
       "umiestnenie": {
         "ui:options": {
-          "helptext": "markdown_gKgflRNwdS:Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
+          "helptext": "Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
+          "helptextMarkdown": true,
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUpload",
@@ -801,9 +805,10 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
     "prilohyPredschvalenyPozemok": {
       "dizajn": {
         "ui:options": {
-          "helptext": "markdown_gKgflRNwdS:Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.
+          "helptext": "Situácia záhrady spracovaná v adekvátnej mierke, ktorá ilustruje plánované využitie a umiestnenie jednotlivých prvkov na záhrade.
 
  Napríklad, záhony či pestovacie boxy, výsadbu akejkoľvek trvalkovej zelene, kríkov a stromov spolu s druhovým špecifikovaním tejto zelene, kompost, mobiliár, priestor na uskladnenie náradia a zariadenia záhrady, priestor pre využívanie grilu, spôsob zabezpečenia vody a jej distribúcie.",
+          "helptextMarkdown": true,
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUpload",
@@ -831,7 +836,8 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       ],
       "umiestnenie": {
         "ui:options": {
-          "helptext": "markdown_gKgflRNwdS:Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
+          "helptext": "Využiť môžete [katastrálnu mapu ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13), kde nájdete pozemok. Na snímke obrazovky vyznačte presné umiestnenie záhrady (ohraničenie). Zakreslenie presného umiestnenia záhrady na pozemku urýchli celý proces - mesto bude vedieť o ktorú časť pozemku máte konkrétne záujem.",
+          "helptextMarkdown": true,
           "type": "dragAndDrop",
         },
         "ui:widget": "FileUpload",
@@ -843,7 +849,8 @@ exports[`Form definitions komunitne-zahrady schemas match snapshot 1`] = `
       "dovodyZalozenia": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "markdown_gKgflRNwdS:Vysvetlite, prečo považujete za vhodné zabrať daný verejný priestor a vytvoriť na ňom záhradu s menej verejným režimom (predpokladáme, že záhrady sú oplotené a poloverejné). Argumentmi môže byť doterajšie nevyužívanie alebo nevhodné využívanie priestoru, napríklad, nelegálne parkovisko na zeleni, zeleň bez udržiavaných sadových úprav, neprístupný/nevyužívaný priestor.",
+          "helptext": "Vysvetlite, prečo považujete za vhodné zabrať daný verejný priestor a vytvoriť na ňom záhradu s menej verejným režimom (predpokladáme, že záhrady sú oplotené a poloverejné). Argumentmi môže byť doterajšie nevyužívanie alebo nevhodné využívanie priestoru, napríklad, nelegálne parkovisko na zeleni, zeleň bez udržiavaných sadových úprav, neprístupný/nevyužívaný priestor.",
+          "helptextMarkdown": true,
           "placeholder": "Popíšte",
         },
         "ui:widget": "TextArea",
@@ -6412,7 +6419,8 @@ exports[`Form definitions olo-mimoriadny-odvoz-a-zhodnotenie-odpadu schemas matc
                   "value": "120 l zberná nádoba",
                 },
               ],
-              "helptext": "markdown_gKgflRNwdS:Služba sa poskytuje iba pre bytové doby a firmy. Pre rodinné domy sú určené nádoby na [zberné hniezda](https://www.olo.sk/zberne-hniezda/).",
+              "helptext": "Služba sa poskytuje iba pre bytové doby a firmy. Pre rodinné domy sú určené nádoby na [zberné hniezda](https://www.olo.sk/zberne-hniezda/).",
+              "helptextMarkdown": true,
             },
             "ui:widget": "Select",
           },
@@ -11075,7 +11083,8 @@ exports[`Form definitions olo-triedeny-zber-papiera-plastov-a-skla-pre-spravcovs
                   "value": "Sklo (Pravidelný odvoz vytriedených zložiek komunálneho odpadu kat. číslo 20)",
                 },
               ],
-              "helptext": "markdown_gKgflRNwdS:Vyberte len 1 komoditu. Správcovia nehnuteľností v prípade Kuchynského biologicky rozložiteľného odpadu riešia zapojenie a zmeny v systéme zapojenia na Magistráte hlavného mesta. **Zmesový komunálny odpad sa rieši na** [Magistráte hlavného mesta](https://bratislava.sk/mesto-bratislava/dane-a-poplatky/poplatok-za-komunalne-odpady-a-drobne-stavebne-odpady).",
+              "helptext": "Vyberte len 1 komoditu. Správcovia nehnuteľností v prípade Kuchynského biologicky rozložiteľného odpadu riešia zapojenie a zmeny v systéme zapojenia na Magistráte hlavného mesta. **Zmesový komunálny odpad sa rieši na** [Magistráte hlavného mesta](https://bratislava.sk/mesto-bratislava/dane-a-poplatky/poplatok-za-komunalne-odpady-a-drobne-stavebne-odpady).",
+              "helptextMarkdown": true,
             },
             "ui:widget": "Select",
           },
@@ -14087,7 +14096,8 @@ exports[`Form definitions predzahradky schemas match snapshot 1`] = `
       "parcelneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "markdown_gKgflRNwdS:Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13). Pre schválenie žiadosti sa musí jednať o mestský pozemok.",
+          "helptext": "Číslo parcely a bližšie informácie k pozemku a jeho vlastníkom nájdete na [katastrálnej mape ZBGIS](https://zbgis.skgeodesy.sk/mkzbgis/sk/kataster?pos=48.155530,17.129713,13). Pre schválenie žiadosti sa musí jednať o mestský pozemok.",
+          "helptextMarkdown": true,
           "inputType": "text",
           "size": "medium",
         },
@@ -21017,7 +21027,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                           "missingFieldsMessage": "**Pre výpočet základu dane vyplňte správne všetky polia:**
 - Podiel priestoru na spoločných častiach a zariadeniach domu
 - Spoluvlastnícky podiel",
-                          "unit": "markdown_gKgflRNwdS:m^2^",
+                          "unit": "m^2^",
+                          "unitMarkdown": true,
                         },
                       ],
                       "variant": "black",
@@ -21053,7 +21064,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}",
+                "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 4827/624441",
               },
@@ -21089,7 +21101,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "spoluvlastnickyPodiel": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}",
+                "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 1/150",
               },
@@ -21113,7 +21126,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "vymeraPodlahovejPlochyBytu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                "helptext": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                "helptextMarkdown": true,
               },
               "ui:widget": "Number",
             },
@@ -21150,7 +21164,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                               "missingFieldsMessage": "**Pre výpočet základu dane vyplňte správne všetky polia:**
 - Podiel priestoru na spoločných častiach a zariadeniach domu
 - Spoluvlastnícky podiel",
-                              "unit": "markdown_gKgflRNwdS:m^2^",
+                              "unit": "m^2^",
+                              "unitMarkdown": true,
                             },
                           ],
                           "variant": "black",
@@ -21186,7 +21201,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}",
+                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 124827/624441",
                   },
@@ -21196,7 +21212,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                   "cisloNebytovehoPriestoruVBytovomDome": {
                     "ui:label": false,
                     "ui:options": {
-                      "helptext": "markdown_gKgflRNwdS:Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}",
+                      "helptext": "Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}",
+                      "helptextMarkdown": true,
                       "inputType": "text",
                     },
                     "ui:widget": "Input",
@@ -21221,7 +21238,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "spoluvlastnickyPodiel": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}",
+                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 1/150",
                   },
@@ -21305,7 +21323,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}",
+                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -21501,11 +21520,12 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
+            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
 
 V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}",
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -21564,7 +21584,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "celkovaVymeraPozemku": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}",
+                  "helptext": "Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}",
+                  "helptextMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
@@ -21590,7 +21611,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
 - Celková výmera pozemku
 - Podiel priestoru na spoločných častiach a zariadeniach domu
 - Spoluvlastnícky podiel",
-                            "unit": "markdown_gKgflRNwdS:m^2^",
+                            "unit": "m^2^",
+                            "unitMarkdown": true,
                           },
                         ],
                         "variant": "black",
@@ -21659,7 +21681,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                       "value": "H",
                     },
                   ],
-                  "helptext": "markdown_gKgflRNwdS:V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}",
+                  "helptext": "V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}",
+                  "helptextMarkdown": true,
                 },
                 "ui:widget": "Select",
               },
@@ -21771,7 +21794,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "cisloParcely": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}",
+                    "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 7986/1",
                   },
@@ -21797,7 +21821,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}",
+                  "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}",
+                  "helptextMarkdown": true,
                   "inputType": "text",
                   "placeholder": "Napr. 4827/624441",
                 },
@@ -21806,7 +21831,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "spoluvlastnickyPodiel": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}",
+                  "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}",
+                  "helptextMarkdown": true,
                   "inputType": "text",
                   "placeholder": "Napr. 1/1 alebo 1/105",
                 },
@@ -21836,7 +21862,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               },
               "znaleckyPosudok": {
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.",
+                  "helptext": "V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.",
+                  "helptextMarkdown": true,
                   "type": "dragAndDrop",
                 },
                 "ui:widget": "FileUploadMultiple",
@@ -21845,9 +21872,10 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
             "ui:options": {
               "addButtonLabel": "Pridať ďalší pozemok (na tom istom LV)",
               "cannotAddItemMessage": "Dosiahli ste maximálny počet pozemkov (17) na jedno priznanie. Pridajte ďalšie priznanie.",
-              "description": "markdown_gKgflRNwdS:Pozemky pod stavbami, v ktorej máte nehnuteľnosť, sa nezdaňujú.
+              "description": "Pozemky pod stavbami, v ktorej máte nehnuteľnosť, sa nezdaňujú.
 
 :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_c16049c4bd.png"}",
+              "descriptionMarkdown": true,
               "itemTitle": "Pozemok č. {index}",
               "variant": "nested",
             },
@@ -21974,11 +22002,12 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}",
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -22051,7 +22080,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "celkovaZastavanaPlocha": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "markdown_gKgflRNwdS:Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}",
+              "helptext": "Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}",
+              "helptextMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -22076,7 +22106,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                         "missingFieldsMessage": "**Pre výpočet základu dane vyplňte správne všetky polia:**
 - Celková zastavaná plocha
 - Spoluvlastnícky podiel",
-                        "unit": "markdown_gKgflRNwdS:m^2^",
+                        "unit": "m^2^",
+                        "unitMarkdown": true,
                       },
                     ],
                     "variant": "black",
@@ -22243,7 +22274,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}",
+                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -22368,7 +22400,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "spoluvlastnickyPodiel": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "markdown_gKgflRNwdS:Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}",
+              "helptext": "Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}",
+              "helptextMarkdown": true,
               "inputType": "text",
               "placeholder": "Napr. 1/1",
             },
@@ -22420,7 +22453,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "zakladDane": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "markdown_gKgflRNwdS:Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.",
+              "helptext": "Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.",
+              "helptextMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -22462,11 +22496,12 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).
 
 :form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}",
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -22515,7 +22550,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "celkovaVymera": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "markdown_gKgflRNwdS:Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}",
+              "helptext": "Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}",
+              "helptextMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -22580,7 +22616,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                           "label": "Celková výmera podlahových plôch všetkých podlaží stavby",
                           "missingFieldsMessage": "**Pre výpočet celkovej výmery podlahových plôch všetkých podlaží stavby vyplňte správne všetky polia:**
 - Podiel priestoru na spoločných častiach a zariadeniach domu a spoluvlastnícky podiel pre každú časť stavby",
-                          "unit": "markdown_gKgflRNwdS:m^2^",
+                          "unit": "m^2^",
+                          "unitMarkdown": true,
                         },
                         {
                           "dataContextLevelsUp": 1,
@@ -22589,7 +22626,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                           "missingFieldsMessage": "**Pre výpočet základu dane vyplňte správne všetky polia:**
 - Celková výmera zastavanej plochy viacúčelovej stavby
 - Podiel priestoru na spoločných častiach a zariadeniach domu a spoluvlastnícky podiel pre každú časť stavby",
-                          "unit": "markdown_gKgflRNwdS:m^2^",
+                          "unit": "m^2^",
+                          "unitMarkdown": true,
                         },
                       ],
                       "label": "Sumár",
@@ -22615,7 +22653,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                               "missingFieldsMessage": "**Pre výpočet výmery podlahovej plochy vyplňte správne všetky polia:**
 - Podiel priestoru na spoločných častiach a zariadeniach domu
 - Spoluvlastnícky podiel",
-                              "unit": "markdown_gKgflRNwdS:m^2^",
+                              "unit": "m^2^",
+                              "unitMarkdown": true,
                             },
                           ],
                           "variant": "black",
@@ -22629,7 +22668,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}",
+                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 4827/624441",
                   },
@@ -22638,7 +22678,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "spoluvlastnickyPodiel": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}",
+                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 1/1 alebo 1/105",
                   },
@@ -22698,7 +22739,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "vymeraPodlahovejPlochy": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                    "helptext": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                    "helptextMarkdown": true,
                   },
                   "ui:widget": "Number",
                 },
@@ -22721,14 +22763,16 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
               "vymeraPodlahovychPloch": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                  "helptext": "Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                  "helptextMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
               "zakladDane": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.",
+                  "helptext": "Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.",
+                  "helptextMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
@@ -22824,7 +22868,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}",
+                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -23032,7 +23077,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
+            "helptext": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
 
 K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 * k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)
@@ -23041,6 +23086,7 @@ K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}",
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -23087,7 +23133,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
       "rok": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "markdown_gKgflRNwdS:Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.",
+          "helptext": "Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.",
+          "helptextMarkdown": true,
         },
         "ui:widget": "Number",
       },
@@ -24357,7 +24404,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         },
         "splnomocnenie": {
           "ui:options": {
-            "helptext": "markdown_gKgflRNwdS:Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.",
+            "helptext": "Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.",
+            "helptextMarkdown": true,
             "type": "dragAndDrop",
           },
           "ui:widget": "FileUploadMultiple",
@@ -34765,7 +34813,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                           "missingFieldsMessage": "**Pre výpočet základu dane vyplňte správne všetky polia:**
 - Podiel priestoru na spoločných častiach a zariadeniach domu
 - Spoluvlastnícky podiel",
-                          "unit": "markdown_gKgflRNwdS:m^2^",
+                          "unit": "m^2^",
+                          "unitMarkdown": true,
                         },
                       ],
                       "variant": "black",
@@ -34801,7 +34850,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}",
+                "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 4827/624441",
               },
@@ -34837,7 +34887,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "spoluvlastnickyPodiel": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}",
+                "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 1/150",
               },
@@ -34861,7 +34912,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "vymeraPodlahovejPlochyBytu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                "helptext": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                "helptextMarkdown": true,
               },
               "ui:widget": "Number",
             },
@@ -34898,7 +34950,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                               "missingFieldsMessage": "**Pre výpočet základu dane vyplňte správne všetky polia:**
 - Podiel priestoru na spoločných častiach a zariadeniach domu
 - Spoluvlastnícky podiel",
-                              "unit": "markdown_gKgflRNwdS:m^2^",
+                              "unit": "m^2^",
+                              "unitMarkdown": true,
                             },
                           ],
                           "variant": "black",
@@ -34934,7 +34987,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}",
+                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 124827/624441",
                   },
@@ -34944,7 +34998,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                   "cisloNebytovehoPriestoruVBytovomDome": {
                     "ui:label": false,
                     "ui:options": {
-                      "helptext": "markdown_gKgflRNwdS:Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}",
+                      "helptext": "Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}",
+                      "helptextMarkdown": true,
                       "inputType": "text",
                     },
                     "ui:widget": "Input",
@@ -34969,7 +35024,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "spoluvlastnickyPodiel": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}",
+                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 1/150",
                   },
@@ -35053,7 +35109,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}",
+                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -35249,11 +35306,12 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
+            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
 
 V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}",
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -35312,7 +35370,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "celkovaVymeraPozemku": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}",
+                  "helptext": "Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}",
+                  "helptextMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
@@ -35338,7 +35397,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
 - Celková výmera pozemku
 - Podiel priestoru na spoločných častiach a zariadeniach domu
 - Spoluvlastnícky podiel",
-                            "unit": "markdown_gKgflRNwdS:m^2^",
+                            "unit": "m^2^",
+                            "unitMarkdown": true,
                           },
                         ],
                         "variant": "black",
@@ -35407,7 +35467,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                       "value": "H",
                     },
                   ],
-                  "helptext": "markdown_gKgflRNwdS:V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}",
+                  "helptext": "V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}",
+                  "helptextMarkdown": true,
                 },
                 "ui:widget": "Select",
               },
@@ -35519,7 +35580,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "cisloParcely": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}",
+                    "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 7986/1",
                   },
@@ -35545,7 +35607,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}",
+                  "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}",
+                  "helptextMarkdown": true,
                   "inputType": "text",
                   "placeholder": "Napr. 4827/624441",
                 },
@@ -35554,7 +35617,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "spoluvlastnickyPodiel": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}",
+                  "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}",
+                  "helptextMarkdown": true,
                   "inputType": "text",
                   "placeholder": "Napr. 1/1 alebo 1/105",
                 },
@@ -35584,7 +35648,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               },
               "znaleckyPosudok": {
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.",
+                  "helptext": "V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.",
+                  "helptextMarkdown": true,
                   "type": "dragAndDrop",
                 },
                 "ui:widget": "FileUploadMultiple",
@@ -35593,9 +35658,10 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
             "ui:options": {
               "addButtonLabel": "Pridať ďalší pozemok (na tom istom LV)",
               "cannotAddItemMessage": "Dosiahli ste maximálny počet pozemkov (17) na jedno priznanie. Pridajte ďalšie priznanie.",
-              "description": "markdown_gKgflRNwdS:Pozemky pod stavbami, v ktorej máte nehnuteľnosť, sa nezdaňujú.
+              "description": "Pozemky pod stavbami, v ktorej máte nehnuteľnosť, sa nezdaňujú.
 
 :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_c16049c4bd.png"}",
+              "descriptionMarkdown": true,
               "itemTitle": "Pozemok č. {index}",
               "variant": "nested",
             },
@@ -35722,11 +35788,12 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}",
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -35799,7 +35866,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "celkovaZastavanaPlocha": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "markdown_gKgflRNwdS:Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}",
+              "helptext": "Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}",
+              "helptextMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -35824,7 +35892,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                         "missingFieldsMessage": "**Pre výpočet základu dane vyplňte správne všetky polia:**
 - Celková zastavaná plocha
 - Spoluvlastnícky podiel",
-                        "unit": "markdown_gKgflRNwdS:m^2^",
+                        "unit": "m^2^",
+                        "unitMarkdown": true,
                       },
                     ],
                     "variant": "black",
@@ -35991,7 +36060,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}",
+                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -36116,7 +36186,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "spoluvlastnickyPodiel": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "markdown_gKgflRNwdS:Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}",
+              "helptext": "Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}",
+              "helptextMarkdown": true,
               "inputType": "text",
               "placeholder": "Napr. 1/1",
             },
@@ -36168,7 +36239,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "zakladDane": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "markdown_gKgflRNwdS:Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.",
+              "helptext": "Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.",
+              "helptextMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -36210,11 +36282,12 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).
 
 :form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}",
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -36263,7 +36336,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "celkovaVymera": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "markdown_gKgflRNwdS:Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}",
+              "helptext": "Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}",
+              "helptextMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -36328,7 +36402,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                           "label": "Celková výmera podlahových plôch všetkých podlaží stavby",
                           "missingFieldsMessage": "**Pre výpočet celkovej výmery podlahových plôch všetkých podlaží stavby vyplňte správne všetky polia:**
 - Podiel priestoru na spoločných častiach a zariadeniach domu a spoluvlastnícky podiel pre každú časť stavby",
-                          "unit": "markdown_gKgflRNwdS:m^2^",
+                          "unit": "m^2^",
+                          "unitMarkdown": true,
                         },
                         {
                           "dataContextLevelsUp": 1,
@@ -36337,7 +36412,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                           "missingFieldsMessage": "**Pre výpočet základu dane vyplňte správne všetky polia:**
 - Celková výmera zastavanej plochy viacúčelovej stavby
 - Podiel priestoru na spoločných častiach a zariadeniach domu a spoluvlastnícky podiel pre každú časť stavby",
-                          "unit": "markdown_gKgflRNwdS:m^2^",
+                          "unit": "m^2^",
+                          "unitMarkdown": true,
                         },
                       ],
                       "label": "Sumár",
@@ -36363,7 +36439,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                               "missingFieldsMessage": "**Pre výpočet výmery podlahovej plochy vyplňte správne všetky polia:**
 - Podiel priestoru na spoločných častiach a zariadeniach domu
 - Spoluvlastnícky podiel",
-                              "unit": "markdown_gKgflRNwdS:m^2^",
+                              "unit": "m^2^",
+                              "unitMarkdown": true,
                             },
                           ],
                           "variant": "black",
@@ -36377,7 +36454,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}",
+                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 4827/624441",
                   },
@@ -36386,7 +36464,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "spoluvlastnickyPodiel": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}",
+                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}",
+                    "helptextMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 1/1 alebo 1/105",
                   },
@@ -36446,7 +36525,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "vymeraPodlahovejPlochy": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "markdown_gKgflRNwdS:Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                    "helptext": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                    "helptextMarkdown": true,
                   },
                   "ui:widget": "Number",
                 },
@@ -36469,14 +36549,16 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
               "vymeraPodlahovychPloch": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                  "helptext": "Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                  "helptextMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
               "zakladDane": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "markdown_gKgflRNwdS:Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.",
+                  "helptext": "Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.",
+                  "helptextMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
@@ -36572,7 +36654,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "markdown_gKgflRNwdS:Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}",
+                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}",
+                "helptextMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -36780,7 +36863,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
+            "helptext": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
 
 K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 * k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)
@@ -36789,6 +36872,7 @@ K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}",
+            "helptextMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -36835,7 +36919,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
       "rok": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "markdown_gKgflRNwdS:Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.",
+          "helptext": "Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.",
+          "helptextMarkdown": true,
         },
         "ui:widget": "Number",
       },
@@ -38105,7 +38190,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         },
         "splnomocnenie": {
           "ui:options": {
-            "helptext": "markdown_gKgflRNwdS:Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.",
+            "helptext": "Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.",
+            "helptextMarkdown": true,
             "type": "dragAndDrop",
           },
           "ui:widget": "FileUploadMultiple",
@@ -52174,7 +52260,8 @@ exports[`Form definitions ziadost-o-najom-bytu schemas match snapshot 1`] = `
                     "value": false,
                   },
                 ],
-                "helptext": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+                "helptext": "Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+                "helptextMarkdown": true,
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -52718,7 +52805,8 @@ exports[`Form definitions ziadost-o-najom-bytu schemas match snapshot 1`] = `
               "ui:widget": "RadioGroup",
             },
             "ui:options": {
-              "description": "markdown_gKgflRNwdS:Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom dieťaťa - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+              "description": "Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom dieťaťa - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+              "descriptionMarkdown": true,
               "objectDisplay": "boxed",
               "title": "Zdravotný stav",
             },
@@ -52813,7 +52901,8 @@ exports[`Form definitions ziadost-o-najom-bytu schemas match snapshot 1`] = `
                   "value": false,
                 },
               ],
-              "helptext": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+              "helptext": "Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+              "helptextMarkdown": true,
               "orientations": "row",
               "variant": "boxed",
             },
@@ -53086,7 +53175,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu druha/družky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
+            "helptext": "V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu druha/družky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
+            "helptextMarkdown": true,
             "orientations": "row",
             "variant": "boxed",
           },
@@ -53158,7 +53248,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu druhovi/družke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
+            "helptext": "Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu druhovi/družke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
+            "helptextMarkdown": true,
             "orientations": "row",
             "variant": "boxed",
           },
@@ -53598,7 +53689,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
           "ui:widget": "RadioGroup",
         },
         "ui:options": {
-          "description": "markdown_gKgflRNwdS:Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom druha/družky - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+          "description": "Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom druha/družky - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+          "descriptionMarkdown": true,
           "objectDisplay": "boxed",
           "title": "Zdravotný stav",
         },
@@ -53858,7 +53950,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                     "value": false,
                   },
                 ],
-                "helptext": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+                "helptext": "Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+                "helptextMarkdown": true,
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -54012,7 +54105,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                     "value": false,
                   },
                 ],
-                "helptext": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu člena/členky domácnosti podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
+                "helptext": "V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu člena/členky domácnosti podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
+                "helptextMarkdown": true,
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -54084,7 +54178,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                     "value": false,
                   },
                 ],
-                "helptext": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ člena/členky domácnosti na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
+                "helptext": "Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ člena/členky domácnosti na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
+                "helptextMarkdown": true,
                 "orientations": "row",
                 "variant": "boxed",
               },
@@ -54521,7 +54616,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
               "ui:widget": "RadioGroup",
             },
             "ui:options": {
-              "description": "markdown_gKgflRNwdS:Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom člena/členky domácnosti - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+              "description": "Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom člena/členky domácnosti - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+              "descriptionMarkdown": true,
               "objectDisplay": "boxed",
               "title": "Zdravotný stav",
             },
@@ -54616,7 +54712,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                   "value": false,
                 },
               ],
-              "helptext": "markdown_gKgflRNwdS:Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+              "helptext": "Ak je vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+              "helptextMarkdown": true,
               "orientations": "row",
               "variant": "boxed",
             },
@@ -54846,7 +54943,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu manžela/manželky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
+            "helptext": "V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu čistého príjmu manžela/manželky podľa potvrdenia, ktoré mu/jej vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemá podané daňové priznanie, resp. nepozná sumu jeho/jej príjmu, vyplňte prosím čistý príjem za posledný známy rok.",
+            "helptextMarkdown": true,
             "orientations": "row",
             "variant": "boxed",
           },
@@ -54918,7 +55016,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu manželovi/manželke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
+            "helptext": "Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Zamestnávateľ vášmu manželovi/manželke na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť priemerný mesačný čistý príjem za minulý kalendárny rok.",
+            "helptextMarkdown": true,
             "orientations": "row",
             "variant": "boxed",
           },
@@ -55358,7 +55457,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
           "ui:widget": "RadioGroup",
         },
         "ui:options": {
-          "description": "markdown_gKgflRNwdS:Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom manžela/manželky - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+          "description": "Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené (všeobecným) lekárom manžela/manželky - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+          "descriptionMarkdown": true,
           "objectDisplay": "boxed",
           "title": "Zdravotný stav",
         },
@@ -55635,7 +55735,8 @@ ziadatelPrijem + manzelManzelkaPrijem + druhDruzkaPrijem + detiPrijmy + inyCleno
                   "value": false,
                 },
               ],
-              "helptext": "markdown_gKgflRNwdS:Ak ste vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+              "helptext": "Ak ste vlastníkom/vlastníčkou alebo spoluvlastníkom/spoluvlastníčkou nehnuteľnosti, ale nemôžete v nej bývať, napr. kvôli stavebným, hygienickým nedostatkom alebo právnym prekážkam brániacim riadnemu užívaniu nehnuteľnosti, označte "Áno" a uveďte túto skutočnosť pod otázkou *Napíšte dôvody, pre ktoré nemôžete využívať túto nehnuteľnosť na bývanie*.",
+              "helptextMarkdown": true,
               "orientations": "row",
               "variant": "boxed",
             },
@@ -55946,7 +56047,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu Vášho čistého príjmu podľa potvrdenia, ktoré vám vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemáte podané daňové priznanie, resp. nepoznáte sumu vášho príjmu, vyplňte prosím váš čistý príjem za posledný známy rok.",
+            "helptext": "V prípade príjmu z podnikania, resp. zo samostatnej zárobkovej činnosti (vrátane živnosti) je potrebné uviesť čistý príjem SZČO po odpočítaní výdavkov, odvodov poistného na [sociálne poistenie](https://sk.wikipedia.org/wiki/Soci%C3%A1lne_poistenie) a [zdravotné poistenie](https://sk.wikipedia.org/wiki/Zdravotn%C3%A9_poistenie) a zaplatenej dane z príjmu. V tomto prípade prosím uveďte sumu Vášho čistého príjmu podľa potvrdenia, ktoré vám vydá daňový úrad. Ak v čase podávania tejto žiadosti ešte nemáte podané daňové priznanie, resp. nepoznáte sumu vášho príjmu, vyplňte prosím váš čistý príjem za posledný známy rok.",
+            "helptextMarkdown": true,
             "orientations": "row",
             "variant": "boxed",
           },
@@ -56018,7 +56120,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Váš zamestnávateľ vám na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť váš priemerný mesačný čistý príjem za minulý kalendárny rok.",
+            "helptext": "Pri príjme zo zamestnania ide o čistú mzdu, t. j. príjem očistený od dane z príjmu a odvodov na zdravotné a sociálne poistenie, príp. dôchodkového sporenia. Váš zamestnávateľ vám na základe žiadosti vystaví [potvrdenie o výške príjmu](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_o_vyske_prijmu_Priloha3_0eceac9a76.pdf). Je potrebné uviesť váš priemerný mesačný čistý príjem za minulý kalendárny rok.",
+            "helptextMarkdown": true,
             "orientations": "row",
             "variant": "boxed",
           },
@@ -56252,7 +56355,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
                 "value": false,
               },
             ],
-            "helptext": "markdown_gKgflRNwdS:Podmienkou pridelenia bezbariérového bytu je, že žiadateľ alebo člen domácnosti musí mať lekárom potvrdené, že má diagnostikované zdravotné postihnutie, v zmysle [prílohy č. 2 zákona 443/2010 Z. z.](https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2010/443/20180101#prilohy) - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_bezbarierovy_byt_Priloha2_94fc7ae8e6.pdf).",
+            "helptext": "Podmienkou pridelenia bezbariérového bytu je, že žiadateľ alebo člen domácnosti musí mať lekárom potvrdené, že má diagnostikované zdravotné postihnutie, v zmysle [prílohy č. 2 zákona 443/2010 Z. z.](https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2010/443/20180101#prilohy) - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_bezbarierovy_byt_Priloha2_94fc7ae8e6.pdf).",
+            "helptextMarkdown": true,
             "orientations": "row",
             "variant": "boxed",
           },
@@ -56553,7 +56657,8 @@ zamestnaniePrijemSum + samostatnaZarobkovaCinnostPrijemSum + dochodokSum + vyziv
           "ui:widget": "RadioGroup",
         },
         "ui:options": {
-          "description": "markdown_gKgflRNwdS:Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené vašim (všeobecným) lekárom - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+          "description": "Diagnózy vypĺňajte až po tom, ako ich budete mať odkonzultované a následne potvrdené vašim (všeobecným) lekárom - [vzor tlačiva pre lekára](https://cdn-api.bratislava.sk/strapi-homepage/upload/Potvrdenie_od_lekara_zoznam_diagnoz_Priloha1_3cb11640e7.pdf).",
+          "descriptionMarkdown": true,
           "objectDisplay": "boxed",
           "title": "Zdravotný stav",
         },

--- a/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
+++ b/forms-shared/tests/definitions/__snapshots__/formDefinitions.ts.snap
@@ -19765,7 +19765,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
       "email": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
+          "helptextFooter": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
           "inputType": "email",
         },
         "ui:widget": "Input",
@@ -19828,7 +19828,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
       "rodneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "Rodné číslo zadávajte s lomítkom. V prípade, že nemáte rodné číslo, uveďte dátum narodenia v tvare DD.MM.YYYY.",
+          "helptextFooter": "Rodné číslo zadávajte s lomítkom. V prípade, že nemáte rodné číslo, uveďte dátum narodenia v tvare DD.MM.YYYY.",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -20912,7 +20912,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
         "ulica": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "Zadajte ulicu trvalého pobytu manžela/manželky.",
+            "helptextFooter": "Zadajte ulicu trvalého pobytu manžela/manželky.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -20924,7 +20924,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch",
-            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
+            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -20968,7 +20968,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
           "pocetSpoluvlastnikov": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
+              "helptextFooter": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
               "size": "medium",
             },
             "ui:widget": "Number",
@@ -21001,7 +21001,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "celkovaVymeraSpecialCase": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Ak má číslo za lomkou vo vašom podiele priestoru na spoločných častiach hodnotu, napríklad, 1 000, 10 000, alebo 100 000, údaj z listu vlastníctva vám nepomôže. Správne údaje o podlahovej ploche nájdete v kúpnej zmluve alebo znaleckom posudku (celková podlahová plocha okrem balkónov, lodžií a terás).",
+                "helptextFooter": "Ak má číslo za lomkou vo vašom podiele priestoru na spoločných častiach hodnotu, napríklad, 1 000, 10 000, alebo 100 000, údaj z listu vlastníctva vám nepomôže. Správne údaje o podlahovej ploche nájdete v kúpnej zmluve alebo znaleckom posudku (celková podlahová plocha okrem balkónov, lodžií a terás).",
               },
               "ui:widget": "Number",
             },
@@ -21042,13 +21042,13 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "datumy": {
               "datumVznikuDanovejPovinnosti": {
                 "ui:options": {
-                  "helptext": "Vypĺňate len v prípade, ak ste byt zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                  "helptextFooter": "Vypĺňate len v prípade, ak ste byt zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
                 },
                 "ui:widget": "DatePicker",
               },
               "datumZanikuDanovejPovinnosti": {
                 "ui:options": {
-                  "helptext": "Vypĺňate len v prípade, ak ste byt predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                  "helptextFooter": "Vypĺňate len v prípade, ak ste byt predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
                 },
                 "ui:widget": "DatePicker",
               },
@@ -21064,8 +21064,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 4827/624441",
               },
@@ -21074,7 +21074,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "popisBytu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Stručný popis bytu.",
+                "helptextFooter": "Stručný popis bytu.",
                 "inputType": "text",
                 "placeholder": "Napr. dvojizbový byt",
               },
@@ -21101,8 +21101,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "spoluvlastnickyPodiel": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 1/150",
               },
@@ -21126,15 +21126,15 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "vymeraPodlahovejPlochyBytu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                "helptextFooterMarkdown": true,
               },
               "ui:widget": "Number",
             },
             "vymeraPodlahovejPlochyNaIneUcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Vyplňte v prípade, ak používate časť bytu napríklad na podnikateľské účely. Zadajte výmeru.",
+                "helptextFooter": "Vyplňte v prípade, ak používate časť bytu napríklad na podnikateľské účely. Zadajte výmeru.",
               },
               "ui:widget": "Number",
             },
@@ -21145,7 +21145,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "celkovaVymeraSpecialCase": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Ak má číslo za lomkou vo vašom podiele priestoru na spoločných častiach hodnotu, napríklad, 1 000, 10 000, alebo 100 000, údaj z listu vlastníctva vám nepomôže. Správne údaje o podlahovej ploche nájdete v kúpnej zmluve alebo znaleckom posudku (celková podlahová plocha okrem balkónov, lodžií a terás).",
+                    "helptextFooter": "Ak má číslo za lomkou vo vašom podiele priestoru na spoločných častiach hodnotu, napríklad, 1 000, 10 000, alebo 100 000, údaj z listu vlastníctva vám nepomôže. Správne údaje o podlahovej ploche nájdete v kúpnej zmluve alebo znaleckom posudku (celková podlahová plocha okrem balkónov, lodžií a terás).",
                   },
                   "ui:widget": "Number",
                 },
@@ -21179,13 +21179,13 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "datumy": {
                   "datumVznikuDanovejPovinnosti": {
                     "ui:options": {
-                      "helptext": "Vypĺňate len v prípade, ak ste nebytový priestor zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                      "helptextFooter": "Vypĺňate len v prípade, ak ste nebytový priestor zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
                     },
                     "ui:widget": "DatePicker",
                   },
                   "datumZanikuDanovejPovinnosti": {
                     "ui:options": {
-                      "helptext": "Vypĺňate len v prípade, ak ste nebytový priestor predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                      "helptextFooter": "Vypĺňate len v prípade, ak ste nebytový priestor predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
                     },
                     "ui:widget": "DatePicker",
                   },
@@ -21201,8 +21201,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 124827/624441",
                   },
@@ -21212,8 +21212,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                   "cisloNebytovehoPriestoruVBytovomDome": {
                     "ui:label": false,
                     "ui:options": {
-                      "helptext": "Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}",
-                      "helptextMarkdown": true,
+                      "helptextFooter": "Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}",
+                      "helptextFooterMarkdown": true,
                       "inputType": "text",
                     },
                     "ui:widget": "Input",
@@ -21221,7 +21221,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                   "ucelVyuzitiaNebytovehoPriestoruVBytovomDome": {
                     "ui:label": false,
                     "ui:options": {
-                      "helptext": "Napr. garážovanie, skladovanie, podnikanie alebo iné.",
+                      "helptextFooter": "Napr. garážovanie, skladovanie, podnikanie alebo iné.",
                       "inputType": "text",
                     },
                     "ui:widget": "Input",
@@ -21238,8 +21238,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "spoluvlastnickyPodiel": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 1/150",
                   },
@@ -21258,7 +21258,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "vymeraPodlahovychPlochNebytovehoPriestoruVBytovomDome": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte číslo zaokrúhlené nahor na celé číslo (príklad: 48,27 = 49).",
+                    "helptextFooter": "Zadávajte číslo zaokrúhlené nahor na celé číslo (príklad: 48,27 = 49).",
                   },
                   "ui:widget": "Number",
                 },
@@ -21323,8 +21323,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -21441,7 +21441,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                   "type": "additionalLinks",
                 },
               ],
-              "helptext": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
+              "helptextFooter": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
               "type": "dragAndDrop",
             },
             "ui:widget": "FileUploadMultiple",
@@ -21520,12 +21520,12 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti schemas match snapsho
                 "value": false,
               },
             ],
-            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
+            "helptextFooter": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
 
 V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}",
-            "helptextMarkdown": true,
+            "helptextFooterMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -21539,7 +21539,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu výmery pozemkov",
-            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
+            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -21574,7 +21574,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
           "pocetSpoluvlastnikov": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
+              "helptextFooter": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
               "size": "medium",
             },
             "ui:widget": "Number",
@@ -21584,8 +21584,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "celkovaVymeraPozemku": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}",
+                  "helptextFooterMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
@@ -21626,13 +21626,13 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "datumy": {
                 "datumVznikuDanovejPovinnosti": {
                   "ui:options": {
-                    "helptext": "Vypĺňate len v prípade, ak ste pozemok zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                    "helptextFooter": "Vypĺňate len v prípade, ak ste pozemok zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
                   },
                   "ui:widget": "DatePicker",
                 },
                 "datumZanikuDanovejPovinnosti": {
                   "ui:options": {
-                    "helptext": "Vypĺňate len v prípade, ak ste pozemok predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                    "helptextFooter": "Vypĺňate len v prípade, ak ste pozemok predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
                   },
                   "ui:widget": "DatePicker",
                 },
@@ -21681,8 +21681,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                       "value": "H",
                     },
                   ],
-                  "helptext": "V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}",
+                  "helptextFooterMarkdown": true,
                 },
                 "ui:widget": "Select",
               },
@@ -21794,8 +21794,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "cisloParcely": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 7986/1",
                   },
@@ -21804,7 +21804,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "sposobVyuzitiaPozemku": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Vyplňte, ak na pozemok bolo vydané povolenie na dobývanie ložiska nevyhradeného nerastu alebo sa na pozemku nachádza zariadenie na výrobu elektriny zo slnečnej energie, transformačná stanica alebo predajný stánok slúžiaci k predaju tovaru a poskytovaniu služieb.",
+                    "helptextFooter": "Vyplňte, ak na pozemok bolo vydané povolenie na dobývanie ložiska nevyhradeného nerastu alebo sa na pozemku nachádza zariadenie na výrobu elektriny zo slnečnej energie, transformačná stanica alebo predajný stánok slúžiaci k predaju tovaru a poskytovaniu služieb.",
                     "inputType": "text",
                   },
                   "ui:widget": "Input",
@@ -21821,8 +21821,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}",
+                  "helptextFooterMarkdown": true,
                   "inputType": "text",
                   "placeholder": "Napr. 4827/624441",
                 },
@@ -21831,8 +21831,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "spoluvlastnickyPodiel": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}",
+                  "helptextFooterMarkdown": true,
                   "inputType": "text",
                   "placeholder": "Napr. 1/1 alebo 1/105",
                 },
@@ -21856,14 +21856,14 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "vymeraPozemku": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Zadajte výsledok výpočtu vašej časti/podielu na výmere pozemku ako číslo na dve desatinné čísla - bez zaokrúhlenia (napr. 0,65)",
+                  "helptextFooter": "Zadajte výsledok výpočtu vašej časti/podielu na výmere pozemku ako číslo na dve desatinné čísla - bez zaokrúhlenia (napr. 0,65)",
                 },
                 "ui:widget": "Number",
               },
               "znaleckyPosudok": {
                 "ui:options": {
-                  "helptext": "V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.",
+                  "helptextFooterMarkdown": true,
                   "type": "dragAndDrop",
                 },
                 "ui:widget": "FileUploadMultiple",
@@ -21927,7 +21927,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                   "type": "additionalLinks",
                 },
               ],
-              "helptext": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
+              "helptextFooter": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
               "type": "dragAndDrop",
             },
             "ui:widget": "FileUploadMultiple",
@@ -22002,12 +22002,12 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "value": false,
               },
             ],
-            "helptext": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptextFooter": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}",
-            "helptextMarkdown": true,
+            "helptextFooterMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -22021,7 +22021,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu zastavanej plochy",
-            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
+            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -22057,7 +22057,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
             "celkovaVymeraPodlahovychPlochVsetkychPodlaziStavby": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Spočítajte výmeru na všetkých podlažiach. U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                "helptextFooter": "Spočítajte výmeru na všetkých podlažiach. U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
               },
               "ui:widget": "Number",
             },
@@ -22072,7 +22072,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
             "vymeraPodlahovychPlochCastiStavbyOslobodenejOdDaneZoStavieb": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                "helptextFooter": "U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
               },
               "ui:widget": "Number",
             },
@@ -22080,8 +22080,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "celkovaZastavanaPlocha": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}",
-              "helptextMarkdown": true,
+              "helptextFooter": "Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}",
+              "helptextFooterMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -22121,13 +22121,13 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "datumy": {
             "datumVznikuDanovejPovinnosti": {
               "ui:options": {
-                "helptext": "Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                "helptextFooter": "Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
               },
               "ui:widget": "DatePicker",
             },
             "datumZanikuDanovejPovinnosti": {
               "ui:options": {
-                "helptext": "Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                "helptextFooter": "Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
               },
               "ui:widget": "DatePicker",
             },
@@ -22160,14 +22160,14 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "pocetNadzemnychAPodzemnychPodlaziStavbyOkremPrvehoNadzemnehoPodlazia": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Napríklad, ak máte dom s dvomi podlažiami a s pivničným priestorom, zadáte 2.",
+              "helptextFooter": "Napríklad, ak máte dom s dvomi podlažiami a s pivničným priestorom, zadáte 2.",
             },
             "ui:widget": "Number",
           },
           "pocetSpoluvlastnikov": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
+              "helptextFooter": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
               "size": "medium",
             },
             "ui:widget": "Number",
@@ -22244,7 +22244,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                   "value": "i",
                 },
               ],
-              "helptext": "Vyberte stavbu, ktorú zdaňujete, podľa účelu využitia.",
+              "helptextFooter": "Vyberte stavbu, ktorú zdaňujete, podľa účelu využitia.",
             },
             "ui:widget": "Select",
           },
@@ -22274,8 +22274,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -22392,7 +22392,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                   "type": "additionalLinks",
                 },
               ],
-              "helptext": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
+              "helptextFooter": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
               "type": "dragAndDrop",
             },
             "ui:widget": "FileUploadMultiple",
@@ -22400,8 +22400,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "spoluvlastnickyPodiel": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}",
-              "helptextMarkdown": true,
+              "helptextFooter": "Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}",
+              "helptextFooterMarkdown": true,
               "inputType": "text",
               "placeholder": "Napr. 1/1",
             },
@@ -22453,8 +22453,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "zakladDane": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.",
-              "helptextMarkdown": true,
+              "helptextFooter": "Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.",
+              "helptextFooterMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -22496,12 +22496,12 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                 "value": false,
               },
             ],
-            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptextFooter": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).
 
 :form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}",
-            "helptextMarkdown": true,
+            "helptextFooterMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -22515,7 +22515,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch a základu dane",
-            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
+            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -22550,8 +22550,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "celkovaVymera": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}",
-              "helptextMarkdown": true,
+              "helptextFooter": "Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}",
+              "helptextFooterMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -22567,13 +22567,13 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "datumy": {
             "datumVznikuDanovejPovinnosti": {
               "ui:options": {
-                "helptext": "Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                "helptextFooter": "Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
               },
               "ui:widget": "DatePicker",
             },
             "datumZanikuDanovejPovinnosti": {
               "ui:options": {
-                "helptext": "Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                "helptextFooter": "Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
               },
               "ui:widget": "DatePicker",
             },
@@ -22668,8 +22668,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 4827/624441",
                   },
@@ -22678,8 +22678,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "spoluvlastnickyPodiel": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 1/1 alebo 1/105",
                   },
@@ -22739,8 +22739,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "vymeraPodlahovejPlochy": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                    "helptextFooterMarkdown": true,
                   },
                   "ui:widget": "Number",
                 },
@@ -22763,16 +22763,16 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
               "vymeraPodlahovychPloch": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                  "helptextFooterMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
               "zakladDane": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.",
+                  "helptextFooterMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
@@ -22789,14 +22789,14 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "pocetNadzemnychAPodzemnychPodlaziStavbyOkremPrvehoNadzemnehoPodlazia": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Napríklad ak máte stavbu s piatimi nadzemnými podlažiami a dvomi podzemnými podlažiami, uvádzate počet 6.",
+              "helptextFooter": "Napríklad ak máte stavbu s piatimi nadzemnými podlažiami a dvomi podzemnými podlažiami, uvádzate počet 6.",
             },
             "ui:widget": "Number",
           },
           "pocetSpoluvlastnikov": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
+              "helptextFooter": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
               "size": "medium",
             },
             "ui:widget": "Number",
@@ -22804,7 +22804,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "popisStavby": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte stručný popis stavby, napr. administratívna budova, polyfunkčná stavba a pod. (vychádzajte z LV).",
+              "helptextFooter": "Uveďte stručný popis stavby, napr. administratívna budova, polyfunkčná stavba a pod. (vychádzajte z LV).",
               "inputType": "text",
               "placeholder": "Napr. polyfunkčná budova",
             },
@@ -22868,8 +22868,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -22986,7 +22986,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                   "type": "additionalLinks",
                 },
               ],
-              "helptext": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
+              "helptextFooter": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
               "type": "dragAndDrop",
             },
             "ui:widget": "FileUploadMultiple",
@@ -23035,7 +23035,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "vymeraPodlahovychPlochCastiStavbyOslobodenejOdDaneZoStavieb": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+              "helptextFooter": "U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
             },
             "ui:widget": "Number",
           },
@@ -23077,7 +23077,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "value": false,
               },
             ],
-            "helptext": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
+            "helptextFooter": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
 
 K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 * k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)
@@ -23086,7 +23086,7 @@ K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}",
-            "helptextMarkdown": true,
+            "helptextFooterMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -23133,8 +23133,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
       "rok": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.",
-          "helptextMarkdown": true,
+          "helptextFooter": "Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.",
+          "helptextFooterMarkdown": true,
         },
         "ui:widget": "Number",
       },
@@ -23150,7 +23150,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
       "email": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
+          "helptextFooter": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
           "inputType": "email",
         },
         "ui:widget": "Input",
@@ -24317,7 +24317,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "email": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
+            "helptextFooter": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
             "inputType": "email",
           },
           "ui:widget": "Input",
@@ -24404,8 +24404,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         },
         "splnomocnenie": {
           "ui:options": {
-            "helptext": "Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.",
-            "helptextMarkdown": true,
+            "helptextFooter": "Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.",
+            "helptextFooterMarkdown": true,
             "type": "dragAndDrop",
           },
           "ui:widget": "FileUploadMultiple",
@@ -25475,7 +25475,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
           "ulica": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Zadajte ulicu svojho trvalého pobytu.",
+              "helptextFooter": "Zadajte ulicu svojho trvalého pobytu.",
               "inputType": "text",
             },
             "ui:widget": "Input",
@@ -25500,7 +25500,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
           "ulica": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Zadajte ulicu sídla.",
+              "helptextFooter": "Zadajte ulicu sídla.",
               "inputType": "text",
             },
             "ui:widget": "Input",
@@ -25678,7 +25678,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
       "rodneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "Rodné číslo zadávajte s lomítkom. V prípade, že nemáte rodné číslo, uveďte dátum narodenia v tvare DD.MM.YYYY.",
+          "helptextFooter": "Rodné číslo zadávajte s lomítkom. V prípade, že nemáte rodné číslo, uveďte dátum narodenia v tvare DD.MM.YYYY.",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -26716,7 +26716,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "email": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
+            "helptextFooter": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
             "inputType": "email",
           },
           "ui:widget": "Input",
@@ -27857,7 +27857,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
           "ulica": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Zadajte ulicu svojho trvalého pobytu.",
+              "helptextFooter": "Zadajte ulicu svojho trvalého pobytu.",
               "inputType": "text",
             },
             "ui:widget": "Input",
@@ -27907,7 +27907,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "ulica": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "Zadajte ulicu svojho trvalého pobytu.",
+            "helptextFooter": "Zadajte ulicu svojho trvalého pobytu.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -27932,7 +27932,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "ulica": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "Zadajte ulicu miesta podnikania podľa živnostenského registra.",
+            "helptextFooter": "Zadajte ulicu miesta podnikania podľa živnostenského registra.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -27957,7 +27957,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "ulica": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "Zadajte ulicu sídla.",
+            "helptextFooter": "Zadajte ulicu sídla.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -33551,7 +33551,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
       "email": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
+          "helptextFooter": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
           "inputType": "email",
         },
         "ui:widget": "Input",
@@ -33614,7 +33614,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
       "rodneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "Rodné číslo zadávajte s lomítkom. V prípade, že nemáte rodné číslo, uveďte dátum narodenia v tvare DD.MM.YYYY.",
+          "helptextFooter": "Rodné číslo zadávajte s lomítkom. V prípade, že nemáte rodné číslo, uveďte dátum narodenia v tvare DD.MM.YYYY.",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -34698,7 +34698,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
         "ulica": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "Zadajte ulicu trvalého pobytu manžela/manželky.",
+            "helptextFooter": "Zadajte ulicu trvalého pobytu manžela/manželky.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -34710,7 +34710,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch",
-            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
+            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a výmery podlahových plôch vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -34754,7 +34754,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
           "pocetSpoluvlastnikov": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
+              "helptextFooter": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
               "size": "medium",
             },
             "ui:widget": "Number",
@@ -34787,7 +34787,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "celkovaVymeraSpecialCase": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Ak má číslo za lomkou vo vašom podiele priestoru na spoločných častiach hodnotu, napríklad, 1 000, 10 000, alebo 100 000, údaj z listu vlastníctva vám nepomôže. Správne údaje o podlahovej ploche nájdete v kúpnej zmluve alebo znaleckom posudku (celková podlahová plocha okrem balkónov, lodžií a terás).",
+                "helptextFooter": "Ak má číslo za lomkou vo vašom podiele priestoru na spoločných častiach hodnotu, napríklad, 1 000, 10 000, alebo 100 000, údaj z listu vlastníctva vám nepomôže. Správne údaje o podlahovej ploche nájdete v kúpnej zmluve alebo znaleckom posudku (celková podlahová plocha okrem balkónov, lodžií a terás).",
               },
               "ui:widget": "Number",
             },
@@ -34828,13 +34828,13 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "datumy": {
               "datumVznikuDanovejPovinnosti": {
                 "ui:options": {
-                  "helptext": "Vypĺňate len v prípade, ak ste byt zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                  "helptextFooter": "Vypĺňate len v prípade, ak ste byt zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
                 },
                 "ui:widget": "DatePicker",
               },
               "datumZanikuDanovejPovinnosti": {
                 "ui:options": {
-                  "helptext": "Vypĺňate len v prípade, ak ste byt predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                  "helptextFooter": "Vypĺňate len v prípade, ak ste byt predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
                 },
                 "ui:widget": "DatePicker",
               },
@@ -34850,8 +34850,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_podiel_priestoru_265f9a3965.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 4827/624441",
               },
@@ -34860,7 +34860,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "popisBytu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Stručný popis bytu.",
+                "helptextFooter": "Stručný popis bytu.",
                 "inputType": "text",
                 "placeholder": "Napr. dvojizbový byt",
               },
@@ -34887,8 +34887,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "spoluvlastnickyPodiel": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_spoluvlastnicky_podiel_cf4b72f71b.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 1/150",
               },
@@ -34912,15 +34912,15 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "vymeraPodlahovejPlochyBytu": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                "helptextFooterMarkdown": true,
               },
               "ui:widget": "Number",
             },
             "vymeraPodlahovejPlochyNaIneUcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Vyplňte v prípade, ak používate časť bytu napríklad na podnikateľské účely. Zadajte výmeru.",
+                "helptextFooter": "Vyplňte v prípade, ak používate časť bytu napríklad na podnikateľské účely. Zadajte výmeru.",
               },
               "ui:widget": "Number",
             },
@@ -34931,7 +34931,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "celkovaVymeraSpecialCase": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Ak má číslo za lomkou vo vašom podiele priestoru na spoločných častiach hodnotu, napríklad, 1 000, 10 000, alebo 100 000, údaj z listu vlastníctva vám nepomôže. Správne údaje o podlahovej ploche nájdete v kúpnej zmluve alebo znaleckom posudku (celková podlahová plocha okrem balkónov, lodžií a terás).",
+                    "helptextFooter": "Ak má číslo za lomkou vo vašom podiele priestoru na spoločných častiach hodnotu, napríklad, 1 000, 10 000, alebo 100 000, údaj z listu vlastníctva vám nepomôže. Správne údaje o podlahovej ploche nájdete v kúpnej zmluve alebo znaleckom posudku (celková podlahová plocha okrem balkónov, lodžií a terás).",
                   },
                   "ui:widget": "Number",
                 },
@@ -34965,13 +34965,13 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "datumy": {
                   "datumVznikuDanovejPovinnosti": {
                     "ui:options": {
-                      "helptext": "Vypĺňate len v prípade, ak ste nebytový priestor zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                      "helptextFooter": "Vypĺňate len v prípade, ak ste nebytový priestor zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
                     },
                     "ui:widget": "DatePicker",
                   },
                   "datumZanikuDanovejPovinnosti": {
                     "ui:options": {
-                      "helptext": "Vypĺňate len v prípade, ak ste nebytový priestor predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                      "helptextFooter": "Vypĺňate len v prípade, ak ste nebytový priestor predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
                     },
                     "ui:widget": "DatePicker",
                   },
@@ -34987,8 +34987,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_podiel_priestoru_86f78e3c99.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 124827/624441",
                   },
@@ -34998,8 +34998,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                   "cisloNebytovehoPriestoruVBytovomDome": {
                     "ui:label": false,
                     "ui:options": {
-                      "helptext": "Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}",
-                      "helptextMarkdown": true,
+                      "helptextFooter": "Napr. číslo parkovacieho státia alebo pivničnej kobky (malo by byť uvedené aj na LV). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_cislo_3d64bba380.png"}",
+                      "helptextFooterMarkdown": true,
                       "inputType": "text",
                     },
                     "ui:widget": "Input",
@@ -35007,7 +35007,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                   "ucelVyuzitiaNebytovehoPriestoruVBytovomDome": {
                     "ui:label": false,
                     "ui:options": {
-                      "helptext": "Napr. garážovanie, skladovanie, podnikanie alebo iné.",
+                      "helptextFooter": "Napr. garážovanie, skladovanie, podnikanie alebo iné.",
                       "inputType": "text",
                     },
                     "ui:widget": "Input",
@@ -35024,8 +35024,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "spoluvlastnickyPodiel": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_nebytovypriestor_spoluvlastnicky_podiel_79034be7a6.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 1/150",
                   },
@@ -35044,7 +35044,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "vymeraPodlahovychPlochNebytovehoPriestoruVBytovomDome": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte číslo zaokrúhlené nahor na celé číslo (príklad: 48,27 = 49).",
+                    "helptextFooter": "Zadávajte číslo zaokrúhlené nahor na celé číslo (príklad: 48,27 = 49).",
                   },
                   "ui:widget": "Number",
                 },
@@ -35109,8 +35109,8 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. Ak dom stojí na viacerých parcelách, uveďte prvú z nich. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_byt_cislo_parcely_a7124f13a3.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -35227,7 +35227,7 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                   "type": "additionalLinks",
                 },
               ],
-              "helptext": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
+              "helptextFooter": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
               "type": "dragAndDrop",
             },
             "ui:widget": "FileUploadMultiple",
@@ -35306,12 +35306,12 @@ exports[`Form definitions priznanie-k-dani-z-nehnutelnosti-test schemas match sn
                 "value": false,
               },
             ],
-            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
+            "helptextFooter": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednotlivým priestorom. Ide o tú časť LV, kde máte nadpis “Byty a nebytové priestory” v časti “ČASŤ B: VLASTNÍCI A INÉ OPRÁVNENÉ OSOBY Z PRÁVA K NEHNUTEĽNOSTI”.
 
 V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k bytovému domu]{src="https://cdn-api.bratislava.sk/general-strapi/upload/6_priznanie_f168d61548.png"}",
-            "helptextMarkdown": true,
+            "helptextFooterMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -35325,7 +35325,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu výmery pozemkov",
-            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
+            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a celkovú výmeru zastavanej plochy vypočítame pri každom pozemku za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -35360,7 +35360,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
           "pocetSpoluvlastnikov": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
+              "helptextFooter": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
               "size": "medium",
             },
             "ui:widget": "Number",
@@ -35370,8 +35370,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "celkovaVymeraPozemku": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Zadávajte číslo, nachádza sa ako 2. v poradí v tabuľke na LV. Pozemky pod stavbami sa nezdaňujú. Sčítate len tie, ktoré majú iný kód využitia ako “15”. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_celkova_vymera_67d9f26e23.png"}",
+                  "helptextFooterMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
@@ -35412,13 +35412,13 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "datumy": {
                 "datumVznikuDanovejPovinnosti": {
                   "ui:options": {
-                    "helptext": "Vypĺňate len v prípade, ak ste pozemok zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                    "helptextFooter": "Vypĺňate len v prípade, ak ste pozemok zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
                   },
                   "ui:widget": "DatePicker",
                 },
                 "datumZanikuDanovejPovinnosti": {
                   "ui:options": {
-                    "helptext": "Vypĺňate len v prípade, ak ste pozemok predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                    "helptextFooter": "Vypĺňate len v prípade, ak ste pozemok predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
                   },
                   "ui:widget": "DatePicker",
                 },
@@ -35467,8 +35467,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                       "value": "H",
                     },
                   ],
-                  "helptext": "V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "V prípade, že máte vydané právoplatné stavebné povolenie na stavbu vyberte možnosť G - Stavebné pozemky. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemky_druh_pozemku_dea5055c20.png"}",
+                  "helptextFooterMarkdown": true,
                 },
                 "ui:widget": "Select",
               },
@@ -35580,8 +35580,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "cisloParcely": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_cislo_parcely_d88349308a.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 7986/1",
                   },
@@ -35590,7 +35590,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "sposobVyuzitiaPozemku": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Vyplňte, ak na pozemok bolo vydané povolenie na dobývanie ložiska nevyhradeného nerastu alebo sa na pozemku nachádza zariadenie na výrobu elektriny zo slnečnej energie, transformačná stanica alebo predajný stánok slúžiaci k predaju tovaru a poskytovaniu služieb.",
+                    "helptextFooter": "Vyplňte, ak na pozemok bolo vydané povolenie na dobývanie ložiska nevyhradeného nerastu alebo sa na pozemku nachádza zariadenie na výrobu elektriny zo slnečnej energie, transformačná stanica alebo predajný stánok slúžiaci k predaju tovaru a poskytovaniu služieb.",
                     "inputType": "text",
                   },
                   "ui:widget": "Input",
@@ -35607,8 +35607,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu. Ak ho nemáte, zadajte 1/1. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_podiel_priestoru_2446155a08.png"}",
+                  "helptextFooterMarkdown": true,
                   "inputType": "text",
                   "placeholder": "Napr. 4827/624441",
                 },
@@ -35617,8 +35617,8 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "spoluvlastnickyPodiel": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_pozemok_spoluvlastnicky_podiel_a8753d1b69.png"}",
+                  "helptextFooterMarkdown": true,
                   "inputType": "text",
                   "placeholder": "Napr. 1/1 alebo 1/105",
                 },
@@ -35642,14 +35642,14 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
               "vymeraPozemku": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Zadajte výsledok výpočtu vašej časti/podielu na výmere pozemku ako číslo na dve desatinné čísla - bez zaokrúhlenia (napr. 0,65)",
+                  "helptextFooter": "Zadajte výsledok výpočtu vašej časti/podielu na výmere pozemku ako číslo na dve desatinné čísla - bez zaokrúhlenia (napr. 0,65)",
                 },
                 "ui:widget": "Number",
               },
               "znaleckyPosudok": {
                 "ui:options": {
-                  "helptext": "V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "V prvom kroku je potrebné nahratie skenu znaleckého posudku. Po odoslaní elektronického formulára doručte, prosím, znalecký posudok v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Z posudku sa následne použije hodnota pri výpočte dane z pozemku/ov.",
+                  "helptextFooterMarkdown": true,
                   "type": "dragAndDrop",
                 },
                 "ui:widget": "FileUploadMultiple",
@@ -35713,7 +35713,7 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                   "type": "additionalLinks",
                 },
               ],
-              "helptext": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
+              "helptextFooter": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
               "type": "dragAndDrop",
             },
             "ui:widget": "FileUploadMultiple",
@@ -35788,12 +35788,12 @@ V prípade, že sa vás daň z bytov a z nebytových priestorov netýka, túto �
                 "value": false,
               },
             ],
-            "helptext": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptextFooter": "K úspešnému vyplneniu oddielov k pozemkom potrebujete list vlastníctva (LV) k pozemkom. Ide o tú časť LV, kde máte nadpis “Parcely registra "C", resp. "E" evidované na katastrálnej mape” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k pozemkom]{src="https://cdn-api.bratislava.sk/general-strapi/upload/3_priznanie_376b4c7a44.png"}",
-            "helptextMarkdown": true,
+            "helptextFooterMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -35807,7 +35807,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výpočtu zastavanej plochy",
-            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
+            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte dva údaje z LV a celkovú výmeru zastavanej plochy vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -35843,7 +35843,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
             "celkovaVymeraPodlahovychPlochVsetkychPodlaziStavby": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Spočítajte výmeru na všetkých podlažiach. U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                "helptextFooter": "Spočítajte výmeru na všetkých podlažiach. U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
               },
               "ui:widget": "Number",
             },
@@ -35858,7 +35858,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
             "vymeraPodlahovychPlochCastiStavbyOslobodenejOdDaneZoStavieb": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                "helptextFooter": "U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
               },
               "ui:widget": "Number",
             },
@@ -35866,8 +35866,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "celkovaZastavanaPlocha": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}",
-              "helptextMarkdown": true,
+              "helptextFooter": "Uveďte výmeru zastavanej plochy pozemku/ov, na ktorom je umiestnená stavba. Nájdete ju na LV, v časti A. (druh pozemku - zastavaná plocha a nádvorie). :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_celkova_zastavana_plocha_5dac588a12.png"}",
+              "helptextFooterMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -35907,13 +35907,13 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "datumy": {
             "datumVznikuDanovejPovinnosti": {
               "ui:options": {
-                "helptext": "Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                "helptextFooter": "Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
               },
               "ui:widget": "DatePicker",
             },
             "datumZanikuDanovejPovinnosti": {
               "ui:options": {
-                "helptext": "Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                "helptextFooter": "Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
               },
               "ui:widget": "DatePicker",
             },
@@ -35946,14 +35946,14 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "pocetNadzemnychAPodzemnychPodlaziStavbyOkremPrvehoNadzemnehoPodlazia": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Napríklad, ak máte dom s dvomi podlažiami a s pivničným priestorom, zadáte 2.",
+              "helptextFooter": "Napríklad, ak máte dom s dvomi podlažiami a s pivničným priestorom, zadáte 2.",
             },
             "ui:widget": "Number",
           },
           "pocetSpoluvlastnikov": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
+              "helptextFooter": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
               "size": "medium",
             },
             "ui:widget": "Number",
@@ -36030,7 +36030,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                   "value": "i",
                 },
               ],
-              "helptext": "Vyberte stavbu, ktorú zdaňujete, podľa účelu využitia.",
+              "helptextFooter": "Vyberte stavbu, ktorú zdaňujete, podľa účelu využitia.",
             },
             "ui:widget": "Select",
           },
@@ -36060,8 +36060,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_cislo_parcely_ec11c9dbb0.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -36178,7 +36178,7 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                   "type": "additionalLinks",
                 },
               ],
-              "helptext": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
+              "helptextFooter": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
               "type": "dragAndDrop",
             },
             "ui:widget": "FileUploadMultiple",
@@ -36186,8 +36186,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "spoluvlastnickyPodiel": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}",
-              "helptextMarkdown": true,
+              "helptextFooter": "Nájdete ho na LV, časti B, vedľa údajov o vlastníkovi. Zadávajte celý zlomok. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_stavba_spoluvlastnicky_podiel_41513cd88b.png"}",
+              "helptextFooterMarkdown": true,
               "inputType": "text",
               "placeholder": "Napr. 1/1",
             },
@@ -36239,8 +36239,8 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
           "zakladDane": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.",
-              "helptextMarkdown": true,
+              "helptextFooter": "Výmera zastavanej plochy stavby, pri spoluvlastníctve do výšky spoluvlastníckych podielov. Zadajte ako číslo zaokrúhlené na celé m^2^ nahor.",
+              "helptextFooterMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -36282,12 +36282,12 @@ V prípade, že sa vás daň z pozemkov netýka, túto časť preskočte.
                 "value": false,
               },
             ],
-            "helptext": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
+            "helptextFooter": "K úspešnému vyplneniu oddielu potrebujete list vlastníctva (LV) k jednoúčelovej stavbe. Ide o tú časť LV, kde máte nadpis “Stavby” v časti “A: MAJETKOVÁ PODSTATA”.
 
 V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, túto časť preskočte (napr. podávate priznanie dani k nehnuteľností za byt/nebytový priestor v bytovom dome).
 
 :form-image-preview[Zobraziť ukážku LV k jednoúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/4_priznanie_bfb15a1f4a.png"}",
-            "helptextMarkdown": true,
+            "helptextFooterMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -36301,7 +36301,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
         "pouzitKalkulacku": {
           "ui:options": {
             "checkboxLabel": "Chcem pomôcť s výpočtom a použiť kalkulačku výmery podlahových plôch a základu dane",
-            "helptext": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
+            "helptextFooter": "Zjednodušili sme pre vás výpočet. Stačí ak zadáte tri údaje z LV a výmery podlahových plôch a základ dane vypočítame za vás.",
             "labelSize": "h3",
             "variant": "basic",
           },
@@ -36336,8 +36336,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "celkovaVymera": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}",
-              "helptextMarkdown": true,
+              "helptextFooter": "Výmera zastavanej plochy, na ktorej je postavená nebytová budova (pozrite LV s “Parcely registra “C” a parcelu s spôsobom využívania “16” alebo “15”). Ak je stavba na viacerých parceliach, sčítajte plochu. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_celkova_vymera_1c6b47124a.png"}",
+              "helptextFooterMarkdown": true,
             },
             "ui:widget": "Number",
           },
@@ -36353,13 +36353,13 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "datumy": {
             "datumVznikuDanovejPovinnosti": {
               "ui:options": {
-                "helptext": "Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
+                "helptextFooter": "Vypĺňate len v prípade, ak ste stavbu zdedili alebo vydražili (v tom prípade uvediete prvý deň mesiaca nasledujúceho po tom, v ktorom ste nehnuteľnosť nadobudli).",
               },
               "ui:widget": "DatePicker",
             },
             "datumZanikuDanovejPovinnosti": {
               "ui:options": {
-                "helptext": "Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
+                "helptextFooter": "Vypĺňate len v prípade, ak ste stavbu predali alebo darovali (uvediete dátum 31.12.rok predaja/darovania).",
               },
               "ui:widget": "DatePicker",
             },
@@ -36454,8 +36454,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "podielPriestoruNaSpolocnychCastiachAZariadeniachDomu": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o vchode, poschodí a čísle bytu resp. nebytového priestoru. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_podiel_priestoru_077a008b66.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 4827/624441",
                   },
@@ -36464,8 +36464,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "spoluvlastnickyPodiel": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte celý zlomok. Nájdete ho vedľa údajov o mene vlastníkov. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_spoluvlastnicky_podiel_d931ee97e7.png"}",
+                    "helptextFooterMarkdown": true,
                     "inputType": "text",
                     "placeholder": "Napr. 1/1 alebo 1/105",
                   },
@@ -36525,8 +36525,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "vymeraPodlahovejPlochy": {
                   "ui:label": false,
                   "ui:options": {
-                    "helptext": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
-                    "helptextMarkdown": true,
+                    "helptextFooter": "Zadávajte číslo zaokrúhlené nahor (napr. ak 12.3 m^2^, tak zadajte 13).",
+                    "helptextFooterMarkdown": true,
                   },
                   "ui:widget": "Number",
                 },
@@ -36549,16 +36549,16 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
               "vymeraPodlahovychPloch": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Celková výmera je zaokrúhlená na celé m^2^ nahor (vrátane tých, na ktoré si uplatňujete nárok na oslobodenie), u spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+                  "helptextFooterMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
               "zakladDane": {
                 "ui:label": false,
                 "ui:options": {
-                  "helptext": "Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.",
-                  "helptextMarkdown": true,
+                  "helptextFooter": "Celková výmera pozostáva zo súčtu podielov výmer častí stavby využívaných na jednotlivé účely na zastavanej ploche. Číslo sa zaokrúhľuje na celé m^2^ nahor.",
+                  "helptextFooterMarkdown": true,
                 },
                 "ui:widget": "Number",
               },
@@ -36575,14 +36575,14 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "pocetNadzemnychAPodzemnychPodlaziStavbyOkremPrvehoNadzemnehoPodlazia": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Napríklad ak máte stavbu s piatimi nadzemnými podlažiami a dvomi podzemnými podlažiami, uvádzate počet 6.",
+              "helptextFooter": "Napríklad ak máte stavbu s piatimi nadzemnými podlažiami a dvomi podzemnými podlažiami, uvádzate počet 6.",
             },
             "ui:widget": "Number",
           },
           "pocetSpoluvlastnikov": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
+              "helptextFooter": "Uveďte počet všetkých spoluvlastníkov, vrátane vás (napr. ja + súrodenec = 2).",
               "size": "medium",
             },
             "ui:widget": "Number",
@@ -36590,7 +36590,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "popisStavby": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Uveďte stručný popis stavby, napr. administratívna budova, polyfunkčná stavba a pod. (vychádzajte z LV).",
+              "helptextFooter": "Uveďte stručný popis stavby, napr. administratívna budova, polyfunkčná stavba a pod. (vychádzajte z LV).",
               "inputType": "text",
               "placeholder": "Napr. polyfunkčná budova",
             },
@@ -36654,8 +36654,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
             "cisloParcely": {
               "ui:label": false,
               "ui:options": {
-                "helptext": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}",
-                "helptextMarkdown": true,
+                "helptextFooter": "Zadávajte číslo s lomítkom. Nachádza sa na LV ako parcelné číslo. :form-image-preview[Zobraziť ukážku]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_stavba_cislo_parcely_f37ad2e4f7.png"}",
+                "helptextFooterMarkdown": true,
                 "inputType": "text",
                 "placeholder": "Napr. 7986/1",
               },
@@ -36772,7 +36772,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                   "type": "additionalLinks",
                 },
               ],
-              "helptext": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
+              "helptextFooter": "Pri dohode o určení zástupcu sa nevyžadujú úradne osvedčené podpisy spoluvlastníkov.",
               "type": "dragAndDrop",
             },
             "ui:widget": "FileUploadMultiple",
@@ -36821,7 +36821,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
           "vymeraPodlahovychPlochCastiStavbyOslobodenejOdDaneZoStavieb": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
+              "helptextFooter": "U spoluvlastníkov vo výške ich spoluvlastníckeho podielu.",
             },
             "ui:widget": "Number",
           },
@@ -36863,7 +36863,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na jeden účel netýka, t�
                 "value": false,
               },
             ],
-            "helptext": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
+            "helptextFooter": "Tento oddiel vypĺňate, ak máte nehnuteľnosť v stavbe, ktorá slúži na viaceré účely, na ktoré sú určené rôzne sadzby dane.
 
 K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 * k pozemkom, na ktorých stojí stavba (nadpis “Parcely registra „C" evidované na katastrálnej mape”)
@@ -36872,7 +36872,7 @@ K úspešnému vyplneniu potrebujete list(y) vlastníctva (LV):
 V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka, túto časť preskočte.
 
 :form-image-preview[Zobraziť ukážku LV k viacúčelovým stavbám]{src="https://cdn-api.bratislava.sk/general-strapi/upload/5_priznanie_6286b348e2.png"}",
-            "helptextMarkdown": true,
+            "helptextFooterMarkdown": true,
             "labelSize": "h3",
             "orientations": "row",
             "variant": "boxed",
@@ -36919,8 +36919,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
       "rok": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.",
-          "helptextMarkdown": true,
+          "helptextFooter": "Kúpili ste alebo predali nehnuteľnosť v roku :tax-year? Zadajte rok :tax-year-next.",
+          "helptextFooterMarkdown": true,
         },
         "ui:widget": "Number",
       },
@@ -36936,7 +36936,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
       "email": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
+          "helptextFooter": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
           "inputType": "email",
         },
         "ui:widget": "Input",
@@ -38103,7 +38103,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "email": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
+            "helptextFooter": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
             "inputType": "email",
           },
           "ui:widget": "Input",
@@ -38190,8 +38190,8 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         },
         "splnomocnenie": {
           "ui:options": {
-            "helptext": "Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.",
-            "helptextMarkdown": true,
+            "helptextFooter": "Keďže ste v predošlom kroku zvolili, že priznanie nepodávate vo svojom mene, je nutné nahratie skenu plnej moci. Následne, po odoslaní formulára je potrebné doručiť originál plnej moci v listinnej podobe na [oddelenie miestnych daní, poplatkov a licencií](https://bratislava.sk/mesto-bratislava/dane-a-poplatky). Splnomocnenie sa neprikladá v prípade zákonného zástupcu neplnoletej osoby.",
+            "helptextFooterMarkdown": true,
             "type": "dragAndDrop",
           },
           "ui:widget": "FileUploadMultiple",
@@ -39261,7 +39261,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
           "ulica": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Zadajte ulicu svojho trvalého pobytu.",
+              "helptextFooter": "Zadajte ulicu svojho trvalého pobytu.",
               "inputType": "text",
             },
             "ui:widget": "Input",
@@ -39286,7 +39286,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
           "ulica": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Zadajte ulicu sídla.",
+              "helptextFooter": "Zadajte ulicu sídla.",
               "inputType": "text",
             },
             "ui:widget": "Input",
@@ -39464,7 +39464,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
       "rodneCislo": {
         "ui:label": false,
         "ui:options": {
-          "helptext": "Rodné číslo zadávajte s lomítkom. V prípade, že nemáte rodné číslo, uveďte dátum narodenia v tvare DD.MM.YYYY.",
+          "helptextFooter": "Rodné číslo zadávajte s lomítkom. V prípade, že nemáte rodné číslo, uveďte dátum narodenia v tvare DD.MM.YYYY.",
           "inputType": "text",
         },
         "ui:widget": "Input",
@@ -40502,7 +40502,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "email": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
+            "helptextFooter": "E-mailová adresa nám pomôže komunikovať s vami rýchlejšie.",
             "inputType": "email",
           },
           "ui:widget": "Input",
@@ -41643,7 +41643,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
           "ulica": {
             "ui:label": false,
             "ui:options": {
-              "helptext": "Zadajte ulicu svojho trvalého pobytu.",
+              "helptextFooter": "Zadajte ulicu svojho trvalého pobytu.",
               "inputType": "text",
             },
             "ui:widget": "Input",
@@ -41693,7 +41693,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "ulica": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "Zadajte ulicu svojho trvalého pobytu.",
+            "helptextFooter": "Zadajte ulicu svojho trvalého pobytu.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -41718,7 +41718,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "ulica": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "Zadajte ulicu miesta podnikania podľa živnostenského registra.",
+            "helptextFooter": "Zadajte ulicu miesta podnikania podľa živnostenského registra.",
             "inputType": "text",
           },
           "ui:widget": "Input",
@@ -41743,7 +41743,7 @@ V prípade, že sa vás daň zo stavieb slúžiacich na viaceré účely netýka
         "ulica": {
           "ui:label": false,
           "ui:options": {
-            "helptext": "Zadajte ulicu sídla.",
+            "helptextFooter": "Zadajte ulicu sídla.",
             "inputType": "text",
           },
           "ui:widget": "Input",

--- a/next/components/forms/info-components/ConditionalFormMarkdown.tsx
+++ b/next/components/forms/info-components/ConditionalFormMarkdown.tsx
@@ -1,0 +1,18 @@
+import FormMarkdown, { FormMarkdownProps } from './FormMarkdown'
+
+type ConditionalFormMarkdownProps = FormMarkdownProps & {
+  isMarkdown?: boolean
+}
+
+const ConditionalFormMarkdown = ({
+  isMarkdown,
+  children,
+  ...rest
+}: ConditionalFormMarkdownProps) => {
+  if (isMarkdown) {
+    return <FormMarkdown {...rest}>{children}</FormMarkdown>
+  }
+  return <>{children}</>
+}
+
+export default ConditionalFormMarkdown

--- a/next/components/forms/info-components/FieldFooter.tsx
+++ b/next/components/forms/info-components/FieldFooter.tsx
@@ -4,14 +4,14 @@ import FieldErrorMessage, { FieldErrorMessageProps } from './FieldErrorMessage'
 import FieldHelptext from './FieldHelptext'
 
 export type FieldFooterProps = FieldErrorMessageProps & {
-  helptext?: string
+  helptextFooter?: string
   disabled?: boolean
   customErrorPlace?: boolean
   descriptionProps?: DOMAttributes<never>
 }
 
 const FieldFooter = ({
-  helptext,
+  helptextFooter,
   descriptionProps,
   disabled,
   customErrorPlace,
@@ -23,7 +23,9 @@ const FieldFooter = ({
       {!disabled && !customErrorPlace && (
         <FieldErrorMessage errorMessage={errorMessage} errorMessageProps={errorMessageProps} />
       )}
-      {helptext && <FieldHelptext helptext={helptext} descriptionProps={descriptionProps} />}
+      {helptextFooter && (
+        <FieldHelptext helptext={helptextFooter} descriptionProps={descriptionProps} />
+      )}
     </>
   )
 }

--- a/next/components/forms/info-components/FieldFooter.tsx
+++ b/next/components/forms/info-components/FieldFooter.tsx
@@ -5,6 +5,7 @@ import FieldHelptext from './FieldHelptext'
 
 export type FieldFooterProps = FieldErrorMessageProps & {
   helptextFooter?: string
+  helptextFooterMarkdown?: boolean
   disabled?: boolean
   customErrorPlace?: boolean
   descriptionProps?: DOMAttributes<never>
@@ -12,6 +13,7 @@ export type FieldFooterProps = FieldErrorMessageProps & {
 
 const FieldFooter = ({
   helptextFooter,
+  helptextFooterMarkdown,
   descriptionProps,
   disabled,
   customErrorPlace,
@@ -24,7 +26,11 @@ const FieldFooter = ({
         <FieldErrorMessage errorMessage={errorMessage} errorMessageProps={errorMessageProps} />
       )}
       {helptextFooter && (
-        <FieldHelptext helptext={helptextFooter} descriptionProps={descriptionProps} />
+        <FieldHelptext
+          helptext={helptextFooter}
+          helptextMarkdown={helptextFooterMarkdown}
+          descriptionProps={descriptionProps}
+        />
       )}
     </>
   )

--- a/next/components/forms/info-components/FieldHeader.tsx
+++ b/next/components/forms/info-components/FieldHeader.tsx
@@ -15,6 +15,7 @@ export type FieldHeaderProps = {
   htmlFor?: string
   labelProps?: DOMAttributes<never>
   helptext?: string
+  helptextMarkdown?: boolean
   descriptionProps?: DOMAttributes<never>
   /**
    * Some field types (radio, checkbox, upload...) need more spacing between the title and the field itself.
@@ -36,6 +37,7 @@ const FieldHeader = ({
   tooltip,
   labelSize = 'default',
   helptext,
+  helptextMarkdown,
   descriptionProps,
   customHeaderBottomMargin = 'mb-1',
   displayOptionalLabel,
@@ -85,7 +87,13 @@ const FieldHeader = ({
           </div>
         )}
       </div>
-      {helptext && <FieldHelptext helptext={helptext} descriptionProps={descriptionProps} />}
+      {helptext && (
+        <FieldHelptext
+          helptext={helptext}
+          helptextMarkdown={helptextMarkdown}
+          descriptionProps={descriptionProps}
+        />
+      )}
     </div>
   )
 }

--- a/next/components/forms/info-components/FieldHeader.tsx
+++ b/next/components/forms/info-components/FieldHeader.tsx
@@ -14,7 +14,7 @@ export type FieldHeaderProps = {
   labelSize?: LabelSize
   htmlFor?: string
   labelProps?: DOMAttributes<never>
-  helptextHeader?: string
+  helptext?: string
   descriptionProps?: DOMAttributes<never>
   /**
    * Some field types (radio, checkbox, upload...) need more spacing between the title and the field itself.
@@ -35,14 +35,14 @@ const FieldHeader = ({
   labelProps,
   tooltip,
   labelSize = 'default',
-  helptextHeader,
+  helptext,
   descriptionProps,
   customHeaderBottomMargin = 'mb-1',
   displayOptionalLabel,
 }: FieldHeaderProps) => {
   const { t } = useTranslation('account', { keyPrefix: 'FieldHeader' })
 
-  const useCustomBottomMargin = labelSize === 'default' || !helptextHeader
+  const useCustomBottomMargin = labelSize === 'default' || !helptext
 
   const wrapperStyle = cx('flex w-full flex-col', {
     'gap-1': labelSize === 'default',
@@ -85,9 +85,7 @@ const FieldHeader = ({
           </div>
         )}
       </div>
-      {helptextHeader && (
-        <FieldHelptext helptext={helptextHeader} descriptionProps={descriptionProps} />
-      )}
+      {helptext && <FieldHelptext helptext={helptext} descriptionProps={descriptionProps} />}
     </div>
   )
 }

--- a/next/components/forms/info-components/FieldHelptext.tsx
+++ b/next/components/forms/info-components/FieldHelptext.tsx
@@ -1,13 +1,18 @@
 import React, { DOMAttributes } from 'react'
 
-import FormMarkdown from './FormMarkdown'
+import ConditionalFormMarkdown from './ConditionalFormMarkdown'
 
 type FieldHelptextProps = {
   helptext?: string
+  helptextMarkdown?: boolean
   descriptionProps?: DOMAttributes<never>
 }
 
-const FieldHelptext = ({ helptext, descriptionProps = {} }: FieldHelptextProps) => {
+const FieldHelptext = ({
+  helptext,
+  helptextMarkdown,
+  descriptionProps = {},
+}: FieldHelptextProps) => {
   if (!helptext) {
     return null
   }
@@ -18,7 +23,7 @@ const FieldHelptext = ({ helptext, descriptionProps = {} }: FieldHelptextProps) 
         {...descriptionProps}
         className="text-p3 sm:text-16 mt-1 whitespace-pre-wrap text-gray-700"
       >
-        <FormMarkdown>{helptext}</FormMarkdown>
+        <ConditionalFormMarkdown isMarkdown={helptextMarkdown}>{helptext}</ConditionalFormMarkdown>
       </div>
     </div>
   )

--- a/next/components/forms/info-components/FormMarkdown.tsx
+++ b/next/components/forms/info-components/FormMarkdown.tsx
@@ -1,4 +1,3 @@
-import { markdownTextPrefix } from 'forms-shared/generator/uiOptionsTypes'
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeSanitize from 'rehype-sanitize'
@@ -17,7 +16,7 @@ function getTaxYear() {
   return today < februaryFirst ? currentYear - 1 : currentYear
 }
 
-type FormMarkdownProps = {
+export type FormMarkdownProps = {
   children: string
   /**
    * By default, the text in markdown is wrapped in a paragraph. In some cases we don't want to create a new paragraph.
@@ -30,78 +29,71 @@ type FormMarkdownProps = {
  * special directives such as `form-image-preview`.
  */
 const FormMarkdown = ({ children, pAsSpan }: FormMarkdownProps) => {
-  if (children.startsWith(markdownTextPrefix)) {
-    // eslint-disable-next-line security/detect-non-literal-regexp
-    const withoutPrefix = children.replace(new RegExp(`^${markdownTextPrefix}`), '')
-
-    return (
-      <ReactMarkdown
-        remarkPlugins={[remarkSupersub, remarkDirective, remarkDirectiveRehype]}
-        rehypePlugins={[
-          [
-            rehypeSanitize,
-            {
-              tagNames: [
-                'strong',
-                'em',
-                'sub',
-                'sup',
-                'p',
-                'a',
-                'ul',
-                'ol',
-                'li',
-                'form-image-preview',
-                'tax-year',
-                'tax-year-next',
-              ],
-              attributes: {
-                'form-image-preview': ['src'],
-                a: ['href'],
-              },
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkSupersub, remarkDirective, remarkDirectiveRehype]}
+      rehypePlugins={[
+        [
+          rehypeSanitize,
+          {
+            tagNames: [
+              'strong',
+              'em',
+              'sub',
+              'sup',
+              'p',
+              'a',
+              'ul',
+              'ol',
+              'li',
+              'form-image-preview',
+              'tax-year',
+              'tax-year-next',
+            ],
+            attributes: {
+              'form-image-preview': ['src'],
+              a: ['href'],
             },
-          ],
-        ]}
-        components={{
-          // @ts-expect-error https://github.com/remarkjs/react-markdown/issues/622
-          'form-image-preview': ({ children: childrenInner, node }) => {
-            return (
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              <FormLightboxModal imageUrl={node?.properties?.src ?? ''}>
-                {childrenInner}
-              </FormLightboxModal>
-            )
           },
-          a: ({ href, children: childrenInner }) => (
-            <MLinkNew
-              href={href ?? '#'}
-              target={href?.startsWith('http') ? '_blank' : ''}
-              variant="underlined"
-            >
+        ],
+      ]}
+      components={{
+        // @ts-expect-error https://github.com/remarkjs/react-markdown/issues/622
+        'form-image-preview': ({ children: childrenInner, node }) => {
+          return (
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            <FormLightboxModal imageUrl={node?.properties?.src ?? ''}>
               {childrenInner}
-            </MLinkNew>
-          ),
-          ul: ({ children: childrenInner }) => (
-            <ul className="list-disc whitespace-normal pl-8">{childrenInner}</ul>
-          ),
-          ol: ({ children: childrenInner }) => (
-            <ol className="list-decimal  whitespace-normal pl-8">{childrenInner}</ol>
-          ),
-          'tax-year': () => <>{getTaxYear()}</>,
-          'tax-year-next': () => <>{getTaxYear() + 1}</>,
-          ...(pAsSpan
-            ? {
-                p: ({ children: childrenInner }) => <span>{childrenInner}</span>,
-              }
-            : {}),
-        }}
-      >
-        {withoutPrefix}
-      </ReactMarkdown>
-    )
-  }
-
-  return <>{children}</>
+            </FormLightboxModal>
+          )
+        },
+        a: ({ href, children: childrenInner }) => (
+          <MLinkNew
+            href={href ?? '#'}
+            target={href?.startsWith('http') ? '_blank' : ''}
+            variant="underlined"
+          >
+            {childrenInner}
+          </MLinkNew>
+        ),
+        ul: ({ children: childrenInner }) => (
+          <ul className="list-disc whitespace-normal pl-8">{childrenInner}</ul>
+        ),
+        ol: ({ children: childrenInner }) => (
+          <ol className="list-decimal  whitespace-normal pl-8">{childrenInner}</ol>
+        ),
+        'tax-year': () => <>{getTaxYear()}</>,
+        'tax-year-next': () => <>{getTaxYear() + 1}</>,
+        ...(pAsSpan
+          ? {
+              p: ({ children: childrenInner }) => <span>{childrenInner}</span>,
+            }
+          : {}),
+      }}
+    >
+      {children}
+    </ReactMarkdown>
+  )
 }
 
 export default FormMarkdown

--- a/next/components/forms/segments/FormCalculator/FormCalculator.tsx
+++ b/next/components/forms/segments/FormCalculator/FormCalculator.tsx
@@ -13,7 +13,7 @@ import get from 'lodash/get'
 import React, { useMemo } from 'react'
 import { useNumberFormatter } from 'react-aria'
 
-import FormMarkdown from '../../info-components/FormMarkdown'
+import ConditionalFormMarkdown from '../../info-components/ConditionalFormMarkdown'
 import { useFormWidget } from '../../useFormWidget'
 import AccountMarkdown from '../AccountMarkdown/AccountMarkdown'
 
@@ -62,6 +62,7 @@ const Calculator = ({
   variant,
   missingFieldsMessage,
   unit,
+  unitMarkdown,
 }: CustomComponentCalculator & {
   isLast: boolean
   variant: CustomComponentCalculatorProps['variant']
@@ -106,7 +107,10 @@ const Calculator = ({
         <>
           <div className={labelClassName}>{label}</div>
           <div className={valueClassName}>
-            {formatter.format(value)} <FormMarkdown pAsSpan>{unit}</FormMarkdown>
+            {formatter.format(value)}{' '}
+            <ConditionalFormMarkdown isMarkdown={unitMarkdown} pAsSpan>
+              {unit}
+            </ConditionalFormMarkdown>
           </div>
         </>
       )}

--- a/next/components/forms/widget-components/Checkbox/CheckboxGroup.tsx
+++ b/next/components/forms/widget-components/Checkbox/CheckboxGroup.tsx
@@ -25,7 +25,7 @@ const CheckboxGroup = (props: CheckboxGroupProps) => {
     size,
     labelSize,
     helptext,
-    helptextHeader,
+    helptextFooter,
     displayOptionalLabel,
   } = props
   const state: CheckboxGroupState = useCheckboxGroupState(props)
@@ -46,7 +46,7 @@ const CheckboxGroup = (props: CheckboxGroupProps) => {
         size={size}
         labelSize={labelSize}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         customHeaderBottomMargin="mb-4"
         displayOptionalLabel={displayOptionalLabel}
       >

--- a/next/components/forms/widget-components/Checkbox/CheckboxGroup.tsx
+++ b/next/components/forms/widget-components/Checkbox/CheckboxGroup.tsx
@@ -25,7 +25,9 @@ const CheckboxGroup = (props: CheckboxGroupProps) => {
     size,
     labelSize,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
     displayOptionalLabel,
   } = props
   const state: CheckboxGroupState = useCheckboxGroupState(props)
@@ -46,7 +48,9 @@ const CheckboxGroup = (props: CheckboxGroupProps) => {
         size={size}
         labelSize={labelSize}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         customHeaderBottomMargin="mb-4"
         displayOptionalLabel={displayOptionalLabel}
       >

--- a/next/components/forms/widget-components/DateTimePicker/DateField.tsx
+++ b/next/components/forms/widget-components/DateTimePicker/DateField.tsx
@@ -24,7 +24,9 @@ const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
       label,
       tooltip,
       helptext,
+      helptextMarkdown,
       helptextFooter,
+      helptextFooterMarkdown,
       isOpen,
       required,
       customErrorPlace,
@@ -68,7 +70,9 @@ const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
         labelProps={labelProps}
         tooltip={tooltip}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         descriptionProps={descriptionProps}
         required={required}
         disabled={disabled}

--- a/next/components/forms/widget-components/DateTimePicker/DateField.tsx
+++ b/next/components/forms/widget-components/DateTimePicker/DateField.tsx
@@ -24,7 +24,7 @@ const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
       label,
       tooltip,
       helptext,
-      helptextHeader,
+      helptextFooter,
       isOpen,
       required,
       customErrorPlace,
@@ -68,7 +68,7 @@ const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
         labelProps={labelProps}
         tooltip={tooltip}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         descriptionProps={descriptionProps}
         required={required}
         disabled={disabled}

--- a/next/components/forms/widget-components/DateTimePicker/DatePicker.tsx
+++ b/next/components/forms/widget-components/DateTimePicker/DatePicker.tsx
@@ -29,7 +29,9 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       required,
       tooltip,
       helptext,
+      helptextMarkdown,
       helptextFooter,
+      helptextFooterMarkdown,
       value,
       minValue,
       maxValue,
@@ -103,7 +105,9 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
           {...fieldProps}
           label={label}
           helptext={helptext}
+          helptextMarkdown={helptextMarkdown}
           helptextFooter={helptextFooter}
+          helptextFooterMarkdown={helptextFooterMarkdown}
           required={required}
           disabled={disabled}
           tooltip={tooltip}

--- a/next/components/forms/widget-components/DateTimePicker/DatePicker.tsx
+++ b/next/components/forms/widget-components/DateTimePicker/DatePicker.tsx
@@ -29,7 +29,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       required,
       tooltip,
       helptext,
-      helptextHeader,
+      helptextFooter,
       value,
       minValue,
       maxValue,
@@ -103,7 +103,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
           {...fieldProps}
           label={label}
           helptext={helptext}
-          helptextHeader={helptextHeader}
+          helptextFooter={helptextFooter}
           required={required}
           disabled={disabled}
           tooltip={tooltip}

--- a/next/components/forms/widget-components/DateTimePicker/TimeField.tsx
+++ b/next/components/forms/widget-components/DateTimePicker/TimeField.tsx
@@ -21,7 +21,9 @@ const TimeField = (props: TimeFieldProps) => {
   const {
     label,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
     tooltip,
     required,
     children,
@@ -75,7 +77,9 @@ const TimeField = (props: TimeFieldProps) => {
       labelProps={labelProps}
       tooltip={tooltip}
       helptext={helptext}
+      helptextMarkdown={helptextMarkdown}
       helptextFooter={helptextFooter}
+      helptextFooterMarkdown={helptextFooterMarkdown}
       descriptionProps={descriptionProps}
       required={required}
       disabled={disabled}

--- a/next/components/forms/widget-components/DateTimePicker/TimeField.tsx
+++ b/next/components/forms/widget-components/DateTimePicker/TimeField.tsx
@@ -21,7 +21,7 @@ const TimeField = (props: TimeFieldProps) => {
   const {
     label,
     helptext,
-    helptextHeader,
+    helptextFooter,
     tooltip,
     required,
     children,
@@ -75,7 +75,7 @@ const TimeField = (props: TimeFieldProps) => {
       labelProps={labelProps}
       tooltip={tooltip}
       helptext={helptext}
-      helptextHeader={helptextHeader}
+      helptextFooter={helptextFooter}
       descriptionProps={descriptionProps}
       required={required}
       disabled={disabled}

--- a/next/components/forms/widget-components/DateTimePicker/TimePicker.tsx
+++ b/next/components/forms/widget-components/DateTimePicker/TimePicker.tsx
@@ -33,7 +33,9 @@ const TimePicker = forwardRef<HTMLDivElement, TimePickerProps>(
       required,
       tooltip,
       helptext,
+      helptextMarkdown,
       helptextFooter,
+      helptextFooterMarkdown,
       onChange = () => {},
       onBlur = () => {},
       value,
@@ -71,7 +73,9 @@ const TimePicker = forwardRef<HTMLDivElement, TimePickerProps>(
             // {...fieldProps}
             label={label}
             helptext={helptext}
+            helptextMarkdown={helptextMarkdown}
             helptextFooter={helptextFooter}
+            helptextFooterMarkdown={helptextFooterMarkdown}
             required={required}
             disabled={disabled}
             tooltip={tooltip}

--- a/next/components/forms/widget-components/DateTimePicker/TimePicker.tsx
+++ b/next/components/forms/widget-components/DateTimePicker/TimePicker.tsx
@@ -33,7 +33,7 @@ const TimePicker = forwardRef<HTMLDivElement, TimePickerProps>(
       required,
       tooltip,
       helptext,
-      helptextHeader,
+      helptextFooter,
       onChange = () => {},
       onBlur = () => {},
       value,
@@ -71,7 +71,7 @@ const TimePicker = forwardRef<HTMLDivElement, TimePickerProps>(
             // {...fieldProps}
             label={label}
             helptext={helptext}
-            helptextHeader={helptextHeader}
+            helptextFooter={helptextFooter}
             required={required}
             disabled={disabled}
             tooltip={tooltip}

--- a/next/components/forms/widget-components/InputField/InputField.tsx
+++ b/next/components/forms/widget-components/InputField/InputField.tsx
@@ -35,7 +35,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       placeholder,
       errorMessage = [],
       helptext,
-      helptextHeader,
+      helptextFooter,
       tooltip,
       required,
       value = '',
@@ -141,7 +141,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
         labelProps={labelProps}
         htmlFor={inputProps.id}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         descriptionProps={descriptionProps}
         required={required}
         tooltip={tooltip}

--- a/next/components/forms/widget-components/InputField/InputField.tsx
+++ b/next/components/forms/widget-components/InputField/InputField.tsx
@@ -35,7 +35,9 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       placeholder,
       errorMessage = [],
       helptext,
+      helptextMarkdown,
       helptextFooter,
+      helptextFooterMarkdown,
       tooltip,
       required,
       value = '',
@@ -141,7 +143,9 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
         labelProps={labelProps}
         htmlFor={inputProps.id}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         descriptionProps={descriptionProps}
         required={required}
         tooltip={tooltip}

--- a/next/components/forms/widget-components/PasswordField/PasswordField.tsx
+++ b/next/components/forms/widget-components/PasswordField/PasswordField.tsx
@@ -20,7 +20,7 @@ const PasswordField = forwardRef<HTMLInputElement, Props>(
       placeholder,
       errorMessage = [],
       helptext,
-      helptextHeader,
+      helptextFooter,
       tooltip,
       required,
       value = '',
@@ -56,7 +56,7 @@ const PasswordField = forwardRef<HTMLInputElement, Props>(
         placeholder={placeholder}
         errorMessage={errorMessage}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         value={value}
         className={className}
         required={required}

--- a/next/components/forms/widget-components/PasswordField/PasswordField.tsx
+++ b/next/components/forms/widget-components/PasswordField/PasswordField.tsx
@@ -20,7 +20,9 @@ const PasswordField = forwardRef<HTMLInputElement, Props>(
       placeholder,
       errorMessage = [],
       helptext,
+      helptextMarkdown,
       helptextFooter,
+      helptextFooterMarkdown,
       tooltip,
       required,
       value = '',
@@ -56,7 +58,9 @@ const PasswordField = forwardRef<HTMLInputElement, Props>(
         placeholder={placeholder}
         errorMessage={errorMessage}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         value={value}
         className={className}
         required={required}

--- a/next/components/forms/widget-components/RadioButton/RadioGroup.tsx
+++ b/next/components/forms/widget-components/RadioButton/RadioGroup.tsx
@@ -36,7 +36,7 @@ const RadioGroup = (props: RadioGroupProps) => {
     disabled,
     errorMessage,
     helptext,
-    helptextHeader,
+    helptextFooter,
     tooltip,
     value,
     size,
@@ -74,7 +74,7 @@ const RadioGroup = (props: RadioGroupProps) => {
         labelProps={labelProps}
         htmlFor={radioGroupProps.id}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         tooltip={tooltip}
         required={required}
         disabled={disabled}

--- a/next/components/forms/widget-components/RadioButton/RadioGroup.tsx
+++ b/next/components/forms/widget-components/RadioButton/RadioGroup.tsx
@@ -36,7 +36,9 @@ const RadioGroup = (props: RadioGroupProps) => {
     disabled,
     errorMessage,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
     tooltip,
     value,
     size,
@@ -74,7 +76,9 @@ const RadioGroup = (props: RadioGroupProps) => {
         labelProps={labelProps}
         htmlFor={radioGroupProps.id}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         tooltip={tooltip}
         required={required}
         disabled={disabled}

--- a/next/components/forms/widget-components/SearchField/SearchField.tsx
+++ b/next/components/forms/widget-components/SearchField/SearchField.tsx
@@ -20,7 +20,9 @@ const SearchField = ({
   placeholder,
   errorMessage = [],
   helptext,
+  helptextMarkdown,
   helptextFooter,
+  helptextFooterMarkdown,
   tooltip,
   required,
   value = '',
@@ -75,7 +77,9 @@ const SearchField = ({
         labelProps={labelProps}
         htmlFor={inputProps?.id}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         descriptionProps={descriptionProps}
         required={required}
         tooltip={tooltip}

--- a/next/components/forms/widget-components/SearchField/SearchField.tsx
+++ b/next/components/forms/widget-components/SearchField/SearchField.tsx
@@ -20,7 +20,7 @@ const SearchField = ({
   placeholder,
   errorMessage = [],
   helptext,
-  helptextHeader,
+  helptextFooter,
   tooltip,
   required,
   value = '',
@@ -75,7 +75,7 @@ const SearchField = ({
         labelProps={labelProps}
         htmlFor={inputProps?.id}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         descriptionProps={descriptionProps}
         required={required}
         tooltip={tooltip}

--- a/next/components/forms/widget-components/SelectField/SelectField.tsx
+++ b/next/components/forms/widget-components/SelectField/SelectField.tsx
@@ -143,7 +143,9 @@ const SelectField = <
   value,
   label,
   helptext,
+  helptextMarkdown,
   helptextFooter,
+  helptextFooterMarkdown,
   tooltip,
   errorMessage,
   options,
@@ -165,7 +167,9 @@ const SelectField = <
       <FieldWrapper
         label={label}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         tooltip={tooltip}
         required={rest.required}
         errorMessage={errorMessage}

--- a/next/components/forms/widget-components/SelectField/SelectField.tsx
+++ b/next/components/forms/widget-components/SelectField/SelectField.tsx
@@ -143,7 +143,7 @@ const SelectField = <
   value,
   label,
   helptext,
-  helptextHeader,
+  helptextFooter,
   tooltip,
   errorMessage,
   options,
@@ -165,7 +165,7 @@ const SelectField = <
       <FieldWrapper
         label={label}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         tooltip={tooltip}
         required={rest.required}
         errorMessage={errorMessage}

--- a/next/components/forms/widget-components/TextAreaField/TextAreaField.tsx
+++ b/next/components/forms/widget-components/TextAreaField/TextAreaField.tsx
@@ -18,7 +18,7 @@ const TextAreaField = ({
   placeholder,
   errorMessage = [],
   helptext,
-  helptextHeader,
+  helptextFooter,
   tooltip,
   required,
   value,
@@ -88,7 +88,7 @@ const TextAreaField = ({
         labelProps={labelProps}
         htmlFor={inputProps.id}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         descriptionProps={descriptionProps}
         required={required}
         tooltip={tooltip}

--- a/next/components/forms/widget-components/TextAreaField/TextAreaField.tsx
+++ b/next/components/forms/widget-components/TextAreaField/TextAreaField.tsx
@@ -18,7 +18,9 @@ const TextAreaField = ({
   placeholder,
   errorMessage = [],
   helptext,
+  helptextMarkdown,
   helptextFooter,
+  helptextFooterMarkdown,
   tooltip,
   required,
   value,
@@ -88,7 +90,9 @@ const TextAreaField = ({
         labelProps={labelProps}
         htmlFor={inputProps.id}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         descriptionProps={descriptionProps}
         required={required}
         tooltip={tooltip}

--- a/next/components/forms/widget-components/Upload/Upload.tsx
+++ b/next/components/forms/widget-components/Upload/Upload.tsx
@@ -30,7 +30,7 @@ const Upload = forwardRef<HTMLButtonElement, UploadProps>(
       multiple,
       value,
       helptext,
-      helptextHeader,
+      helptextFooter,
       disabled,
       sizeLimit,
       supportedFormats,
@@ -53,7 +53,7 @@ const Upload = forwardRef<HTMLButtonElement, UploadProps>(
           label={label}
           required={required}
           helptext={helptext}
-          helptextHeader={helptextHeader}
+          helptextFooter={helptextFooter}
           disabled={disabled}
           errorMessage={errorMessage}
           size={size}

--- a/next/components/forms/widget-components/Upload/Upload.tsx
+++ b/next/components/forms/widget-components/Upload/Upload.tsx
@@ -30,7 +30,9 @@ const Upload = forwardRef<HTMLButtonElement, UploadProps>(
       multiple,
       value,
       helptext,
+      helptextMarkdown,
       helptextFooter,
+      helptextFooterMarkdown,
       disabled,
       sizeLimit,
       supportedFormats,
@@ -53,7 +55,9 @@ const Upload = forwardRef<HTMLButtonElement, UploadProps>(
           label={label}
           required={required}
           helptext={helptext}
+          helptextMarkdown={helptextMarkdown}
           helptextFooter={helptextFooter}
+          helptextFooterMarkdown={helptextFooterMarkdown}
           disabled={disabled}
           errorMessage={errorMessage}
           size={size}

--- a/next/components/forms/widget-wrappers/BAArrayFieldTemplate.tsx
+++ b/next/components/forms/widget-wrappers/BAArrayFieldTemplate.tsx
@@ -13,8 +13,8 @@ import { ArrayFieldUiOptions } from 'forms-shared/generator/uiOptionsTypes'
 import { ComponentType } from 'react'
 
 import Alert from '../info-components/Alert'
+import ConditionalFormMarkdown from '../info-components/ConditionalFormMarkdown'
 import FieldErrorMessage from '../info-components/FieldErrorMessage'
-import FormMarkdown from '../info-components/FormMarkdown'
 import ButtonNew from '../simple-components/ButtonNew'
 import WidgetWrapper from './WidgetWrapper'
 
@@ -38,7 +38,14 @@ const BAArrayFieldTemplate = <
   rawErrors,
 }: ArrayFieldTemplateProps<T, S, F>) => {
   const uiOptions = getUiOptions(uiSchema) as ArrayFieldUiOptions
-  const { variant, description, addButtonLabel, hideTitle, cannotAddItemMessage } = uiOptions
+  const {
+    variant,
+    description,
+    descriptionMarkdown,
+    addButtonLabel,
+    hideTitle,
+    cannotAddItemMessage,
+  } = uiOptions
   const ArrayFieldItemTemplate = getTemplate<'ArrayFieldItemTemplate', T, S, F>(
     'ArrayFieldItemTemplate',
     registry,
@@ -77,7 +84,11 @@ const BAArrayFieldTemplate = <
         <Alert
           type="info"
           hasIcon={false}
-          message={<FormMarkdown>{description}</FormMarkdown>}
+          message={
+            <ConditionalFormMarkdown isMarkdown={descriptionMarkdown}>
+              {description}
+            </ConditionalFormMarkdown>
+          }
           fullWidth
           className="mb-6 whitespace-pre-wrap"
         />

--- a/next/components/forms/widget-wrappers/BAObjectFieldTemplate.tsx
+++ b/next/components/forms/widget-wrappers/BAObjectFieldTemplate.tsx
@@ -4,7 +4,7 @@ import { getObjectFieldInfo } from 'forms-shared/form-utils/getObjectFieldInfo'
 import { ObjectFieldUiOptions } from 'forms-shared/generator/uiOptionsTypes'
 import { PropsWithChildren } from 'react'
 
-import FormMarkdown from '../info-components/FormMarkdown'
+import ConditionalFormMarkdown from '../info-components/ConditionalFormMarkdown'
 import { WidgetSpacingContextProvider } from './useWidgetSpacingContext'
 import WidgetWrapper from './WidgetWrapper'
 
@@ -82,7 +82,9 @@ const BAObjectFieldTemplate = ({
             {options.title && <h3 className="text-h3 mb-3">{options.title}</h3>}
             {options.description && (
               <div className="text-p2 mb-3 whitespace-pre-wrap">
-                <FormMarkdown>{options.description}</FormMarkdown>
+                <ConditionalFormMarkdown isMarkdown={options.descriptionMarkdown}>
+                  {options.description}
+                </ConditionalFormMarkdown>
               </div>
             )}
           </>

--- a/next/components/forms/widget-wrappers/CheckboxGroupWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/CheckboxGroupWidgetRJSF.tsx
@@ -34,7 +34,9 @@ const CheckboxGroupWidgetRJSF = ({
     size,
     labelSize,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
   } = options
 
   const mergedOptions = useMemo(
@@ -59,7 +61,9 @@ const CheckboxGroupWidgetRJSF = ({
         size={size}
         labelSize={labelSize}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         displayOptionalLabel
       >
         {mergedOptions.map((option) => {

--- a/next/components/forms/widget-wrappers/CheckboxGroupWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/CheckboxGroupWidgetRJSF.tsx
@@ -34,7 +34,7 @@ const CheckboxGroupWidgetRJSF = ({
     size,
     labelSize,
     helptext,
-    helptextHeader,
+    helptextFooter,
   } = options
 
   const mergedOptions = useMemo(
@@ -59,7 +59,7 @@ const CheckboxGroupWidgetRJSF = ({
         size={size}
         labelSize={labelSize}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         displayOptionalLabel
       >
         {mergedOptions.map((option) => {

--- a/next/components/forms/widget-wrappers/CheckboxWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/CheckboxWidgetRJSF.tsx
@@ -29,7 +29,7 @@ const CheckboxWidgetRJSF = ({
     size,
     labelSize,
     helptext,
-    helptextHeader,
+    helptextFooter,
     checkboxLabel,
   } = options
 
@@ -52,7 +52,7 @@ const CheckboxWidgetRJSF = ({
         size={size}
         labelSize={labelSize}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         displayOptionalLabel
       >
         <Checkbox value="true" variant={variant} isDisabled={readonly}>

--- a/next/components/forms/widget-wrappers/CheckboxWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/CheckboxWidgetRJSF.tsx
@@ -29,7 +29,9 @@ const CheckboxWidgetRJSF = ({
     size,
     labelSize,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
     checkboxLabel,
   } = options
 
@@ -52,7 +54,9 @@ const CheckboxWidgetRJSF = ({
         size={size}
         labelSize={labelSize}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         displayOptionalLabel
       >
         <Checkbox value="true" variant={variant} isDisabled={readonly}>

--- a/next/components/forms/widget-wrappers/DatePickerWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/DatePickerWidgetRJSF.tsx
@@ -24,7 +24,15 @@ const DatePickerWidgetRJSF = ({
   onChange,
   readonly,
 }: DatePickerWidgetRJSFProps) => {
-  const { helptext, helptextFooter, tooltip, size, labelSize } = options
+  const {
+    helptext,
+    helptextMarkdown,
+    helptextFooter,
+    helptextFooterMarkdown,
+    tooltip,
+    size,
+    labelSize,
+  } = options
 
   return (
     <WidgetWrapper id={id} options={options}>
@@ -34,7 +42,9 @@ const DatePickerWidgetRJSF = ({
         required={required}
         disabled={disabled || readonly}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         tooltip={tooltip}
         value={value ?? null}
         onChange={(value) => onChange(value ?? undefined)}

--- a/next/components/forms/widget-wrappers/DatePickerWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/DatePickerWidgetRJSF.tsx
@@ -24,7 +24,7 @@ const DatePickerWidgetRJSF = ({
   onChange,
   readonly,
 }: DatePickerWidgetRJSFProps) => {
-  const { helptext, helptextHeader, tooltip, size, labelSize } = options
+  const { helptext, helptextFooter, tooltip, size, labelSize } = options
 
   return (
     <WidgetWrapper id={id} options={options}>
@@ -34,7 +34,7 @@ const DatePickerWidgetRJSF = ({
         required={required}
         disabled={disabled || readonly}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         tooltip={tooltip}
         value={value ?? null}
         onChange={(value) => onChange(value ?? undefined)}

--- a/next/components/forms/widget-wrappers/FileUploadMultipleWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/FileUploadMultipleWidgetRJSF.tsx
@@ -27,7 +27,7 @@ const FileUploadMultipleWidgetRJSF = ({
     sizeLimit,
     accept,
     helptext,
-    helptextHeader,
+    helptextFooter,
     type = 'button',
     className,
     size,
@@ -78,7 +78,7 @@ const FileUploadMultipleWidgetRJSF = ({
         multiple
         className={className}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         sizeLimit={sizeLimit}
         supportedFormats={supportedFormats}
         disabled={disabled || readonly}

--- a/next/components/forms/widget-wrappers/FileUploadMultipleWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/FileUploadMultipleWidgetRJSF.tsx
@@ -27,7 +27,9 @@ const FileUploadMultipleWidgetRJSF = ({
     sizeLimit,
     accept,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
     type = 'button',
     className,
     size,
@@ -78,7 +80,9 @@ const FileUploadMultipleWidgetRJSF = ({
         multiple
         className={className}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         sizeLimit={sizeLimit}
         supportedFormats={supportedFormats}
         disabled={disabled || readonly}

--- a/next/components/forms/widget-wrappers/FileUploadWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/FileUploadWidgetRJSF.tsx
@@ -27,7 +27,9 @@ const FileUploadWidgetRJSF = ({
     sizeLimit,
     accept,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
     type = 'button',
     className,
     size,
@@ -74,7 +76,9 @@ const FileUploadWidgetRJSF = ({
         multiple={false}
         className={className}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         sizeLimit={sizeLimit}
         supportedFormats={supportedFormats}
         disabled={disabled || readonly}

--- a/next/components/forms/widget-wrappers/FileUploadWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/FileUploadWidgetRJSF.tsx
@@ -27,7 +27,7 @@ const FileUploadWidgetRJSF = ({
     sizeLimit,
     accept,
     helptext,
-    helptextHeader,
+    helptextFooter,
     type = 'button',
     className,
     size,
@@ -74,7 +74,7 @@ const FileUploadWidgetRJSF = ({
         multiple={false}
         className={className}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         sizeLimit={sizeLimit}
         supportedFormats={supportedFormats}
         disabled={disabled || readonly}

--- a/next/components/forms/widget-wrappers/InputWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/InputWidgetRJSF.tsx
@@ -27,7 +27,9 @@ const InputWidgetRJSF = ({
 }: InputWidgetRJSFProps) => {
   const {
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
     tooltip,
     className,
     resetIcon,
@@ -59,7 +61,9 @@ const InputWidgetRJSF = ({
             required={required}
             disabled={disabled || readonly}
             helptext={helptext}
+            helptextMarkdown={helptextMarkdown}
             helptextFooter={helptextFooter}
+            helptextFooterMarkdown={helptextFooterMarkdown}
             tooltip={tooltip}
             className={className}
             resetIcon={resetIcon}

--- a/next/components/forms/widget-wrappers/InputWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/InputWidgetRJSF.tsx
@@ -27,7 +27,7 @@ const InputWidgetRJSF = ({
 }: InputWidgetRJSFProps) => {
   const {
     helptext,
-    helptextHeader,
+    helptextFooter,
     tooltip,
     className,
     resetIcon,
@@ -59,7 +59,7 @@ const InputWidgetRJSF = ({
             required={required}
             disabled={disabled || readonly}
             helptext={helptext}
-            helptextHeader={helptextHeader}
+            helptextFooter={helptextFooter}
             tooltip={tooltip}
             className={className}
             resetIcon={resetIcon}

--- a/next/components/forms/widget-wrappers/NumberWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/NumberWidgetRJSF.tsx
@@ -26,7 +26,7 @@ const NumberWidgetRJSF = ({
   readonly,
   name,
 }: NumberWidgetRJSFProps) => {
-  const { helptext, helptextHeader, tooltip, className, resetIcon, leftIcon, size, labelSize } =
+  const { helptext, helptextFooter, tooltip, className, resetIcon, leftIcon, size, labelSize } =
     options
 
   const handleOnChange = (newValue: number | undefined) => {
@@ -53,7 +53,7 @@ const NumberWidgetRJSF = ({
             required={required}
             disabled={disabled || readonly}
             helptext={helptext}
-            helptextHeader={helptextHeader}
+            helptextFooter={helptextFooter}
             tooltip={tooltip}
             className={className}
             resetIcon={resetIcon}

--- a/next/components/forms/widget-wrappers/NumberWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/NumberWidgetRJSF.tsx
@@ -26,8 +26,18 @@ const NumberWidgetRJSF = ({
   readonly,
   name,
 }: NumberWidgetRJSFProps) => {
-  const { helptext, helptextFooter, tooltip, className, resetIcon, leftIcon, size, labelSize } =
-    options
+  const {
+    helptext,
+    helptextMarkdown,
+    helptextFooter,
+    helptextFooterMarkdown,
+    tooltip,
+    className,
+    resetIcon,
+    leftIcon,
+    size,
+    labelSize,
+  } = options
 
   const handleOnChange = (newValue: number | undefined) => {
     if (isDefined(newValue)) {
@@ -53,7 +63,9 @@ const NumberWidgetRJSF = ({
             required={required}
             disabled={disabled || readonly}
             helptext={helptext}
+            helptextMarkdown={helptextMarkdown}
             helptextFooter={helptextFooter}
+            helptextFooterMarkdown={helptextFooterMarkdown}
             tooltip={tooltip}
             className={className}
             resetIcon={resetIcon}

--- a/next/components/forms/widget-wrappers/RadioGroupWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/RadioGroupWidgetRJSF.tsx
@@ -90,7 +90,9 @@ const RadioGroupWidgetRJSF = ({
     size,
     labelSize,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
   } = options
 
   const mergedOptions = useMemo(
@@ -116,7 +118,9 @@ const RadioGroupWidgetRJSF = ({
             size={size}
             labelSize={labelSize}
             helptext={helptext}
+            helptextMarkdown={helptextMarkdown}
             helptextFooter={helptextFooter}
+            helptextFooterMarkdown={helptextFooterMarkdown}
             displayOptionalLabel
           >
             {mergedOptions.map((option) => {

--- a/next/components/forms/widget-wrappers/RadioGroupWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/RadioGroupWidgetRJSF.tsx
@@ -90,7 +90,7 @@ const RadioGroupWidgetRJSF = ({
     size,
     labelSize,
     helptext,
-    helptextHeader,
+    helptextFooter,
   } = options
 
   const mergedOptions = useMemo(
@@ -116,7 +116,7 @@ const RadioGroupWidgetRJSF = ({
             size={size}
             labelSize={labelSize}
             helptext={helptext}
-            helptextHeader={helptextHeader}
+            helptextFooter={helptextFooter}
             displayOptionalLabel
           >
             {mergedOptions.map((option) => {

--- a/next/components/forms/widget-wrappers/SelectMultipleWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/SelectMultipleWidgetRJSF.tsx
@@ -30,7 +30,7 @@ const SelectMultipleWidgetRJSF = ({
     enumOptions,
     enumMetadata,
     helptext,
-    helptextHeader,
+    helptextFooter,
     tooltip,
     className,
     size,
@@ -60,7 +60,7 @@ const SelectMultipleWidgetRJSF = ({
         isMulti
         label={label}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         tooltip={tooltip}
         errorMessage={rawErrors}
         required={required}

--- a/next/components/forms/widget-wrappers/SelectMultipleWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/SelectMultipleWidgetRJSF.tsx
@@ -30,7 +30,9 @@ const SelectMultipleWidgetRJSF = ({
     enumOptions,
     enumMetadata,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
     tooltip,
     className,
     size,
@@ -60,7 +62,9 @@ const SelectMultipleWidgetRJSF = ({
         isMulti
         label={label}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         tooltip={tooltip}
         errorMessage={rawErrors}
         required={required}

--- a/next/components/forms/widget-wrappers/SelectWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/SelectWidgetRJSF.tsx
@@ -29,7 +29,9 @@ const SelectWidgetRJSF = ({
     enumOptions,
     enumMetadata,
     helptext,
+    helptextMarkdown,
     helptextFooter,
+    helptextFooterMarkdown,
     tooltip,
     className,
     size,
@@ -51,7 +53,9 @@ const SelectWidgetRJSF = ({
         isMulti={false}
         label={label}
         helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
         helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
         tooltip={tooltip}
         errorMessage={rawErrors}
         required={required}

--- a/next/components/forms/widget-wrappers/SelectWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/SelectWidgetRJSF.tsx
@@ -29,7 +29,7 @@ const SelectWidgetRJSF = ({
     enumOptions,
     enumMetadata,
     helptext,
-    helptextHeader,
+    helptextFooter,
     tooltip,
     className,
     size,
@@ -51,7 +51,7 @@ const SelectWidgetRJSF = ({
         isMulti={false}
         label={label}
         helptext={helptext}
-        helptextHeader={helptextHeader}
+        helptextFooter={helptextFooter}
         tooltip={tooltip}
         errorMessage={rawErrors}
         required={required}

--- a/next/components/forms/widget-wrappers/TextAreaWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/TextAreaWidgetRJSF.tsx
@@ -25,7 +25,7 @@ const TextAreaWidgetRJSF = ({
   onChange,
   readonly,
 }: TextAreaWidgetRJSFProps) => {
-  const { helptext, helptextHeader, tooltip, className, size, labelSize } = options
+  const { helptext, helptextFooter, tooltip, className, size, labelSize } = options
 
   const handleOnChange = (newValue?: string) => {
     if (!newValue || newValue === '') {
@@ -46,7 +46,7 @@ const TextAreaWidgetRJSF = ({
             required={required}
             disabled={disabled || readonly}
             helptext={helptext}
-            helptextHeader={helptextHeader}
+            helptextFooter={helptextFooter}
             tooltip={tooltip}
             className={cx('h-[196px]', className)}
             onChange={wrapperOnChange}

--- a/next/components/forms/widget-wrappers/TextAreaWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/TextAreaWidgetRJSF.tsx
@@ -25,7 +25,16 @@ const TextAreaWidgetRJSF = ({
   onChange,
   readonly,
 }: TextAreaWidgetRJSFProps) => {
-  const { helptext, helptextFooter, tooltip, className, size, labelSize } = options
+  const {
+    helptext,
+    helptextMarkdown,
+    helptextFooter,
+    helptextFooterMarkdown,
+    tooltip,
+    className,
+    size,
+    labelSize,
+  } = options
 
   const handleOnChange = (newValue?: string) => {
     if (!newValue || newValue === '') {
@@ -46,7 +55,9 @@ const TextAreaWidgetRJSF = ({
             required={required}
             disabled={disabled || readonly}
             helptext={helptext}
+            helptextMarkdown={helptextMarkdown}
             helptextFooter={helptextFooter}
+            helptextFooterMarkdown={helptextFooterMarkdown}
             tooltip={tooltip}
             className={cx('h-[196px]', className)}
             onChange={wrapperOnChange}

--- a/next/components/forms/widget-wrappers/TimePickerWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/TimePickerWidgetRJSF.tsx
@@ -25,7 +25,7 @@ const TimePickerWidgetRJSF = ({
   onChange,
   readonly,
 }: TimePickerWidgetRJSFProps) => {
-  const { helptext, helptextHeader, tooltip, size, labelSize } = options
+  const { helptext, helptextFooter, tooltip, size, labelSize } = options
 
   return (
     <WidgetWrapper id={id} options={options}>
@@ -37,7 +37,7 @@ const TimePickerWidgetRJSF = ({
             required={required}
             disabled={disabled || readonly}
             helptext={helptext}
-            helptextHeader={helptextHeader}
+            helptextFooter={helptextFooter}
             tooltip={tooltip}
             value={wrapperValue ?? null}
             onChange={(value) => wrapperOnChange(value ?? undefined)}

--- a/next/components/forms/widget-wrappers/TimePickerWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/TimePickerWidgetRJSF.tsx
@@ -25,7 +25,15 @@ const TimePickerWidgetRJSF = ({
   onChange,
   readonly,
 }: TimePickerWidgetRJSFProps) => {
-  const { helptext, helptextFooter, tooltip, size, labelSize } = options
+  const {
+    helptext,
+    helptextMarkdown,
+    helptextFooter,
+    helptextFooterMarkdown,
+    tooltip,
+    size,
+    labelSize,
+  } = options
 
   return (
     <WidgetWrapper id={id} options={options}>
@@ -37,7 +45,9 @@ const TimePickerWidgetRJSF = ({
             required={required}
             disabled={disabled || readonly}
             helptext={helptext}
+            helptextMarkdown={helptextMarkdown}
             helptextFooter={helptextFooter}
+            helptextFooterMarkdown={helptextFooterMarkdown}
             tooltip={tooltip}
             value={wrapperValue ?? null}
             onChange={(value) => wrapperOnChange(value ?? undefined)}

--- a/next/components/styleguide/showcases/FieldHeaderShowCase.tsx
+++ b/next/components/styleguide/showcases/FieldHeaderShowCase.tsx
@@ -29,14 +29,14 @@ const FieldHeaderShowCase = () => {
           <FieldHeader
             label="Description"
             htmlFor="input-name"
-            helptextHeader="This is simple description"
+            helptext="This is simple description"
           />
         </Stack>
         <Stack>
           <FieldHeader
             label="Everything"
             htmlFor="input-name"
-            helptextHeader="This is is simple description"
+            helptext="This is is simple description"
             tooltip="This is some tooltip"
             required
           />
@@ -45,7 +45,7 @@ const FieldHeaderShowCase = () => {
           <FieldHeader
             label="Everything - optional"
             htmlFor="input-name"
-            helptextHeader="This is is simple description"
+            helptext="This is is simple description"
             tooltip="This is some tooltip"
           />
         </Stack>
@@ -53,7 +53,7 @@ const FieldHeaderShowCase = () => {
           <FieldHeader
             label="Everything with forced optional"
             htmlFor="input-name"
-            helptextHeader="This is is simple description"
+            helptext="This is is simple description"
             tooltip="This is some tooltip"
           />
         </Stack>


### PR DESCRIPTION
Many changes but what is happening is:
 - Previously there was `helptextHeader` and `helptext` (footer - which was default). Now there's `helptext` (header) and `helptextFooter`. `helptextFooter` is probably gonna be removed. And it is `helptext` (without header postfix) because header version is the default now for everything.
 - Got rid of `markdownText` function that prefixed text with special string and then when displayed it got removed. Now there are `helptextMarkdown`, `helptextFooterMarkdown`, `unitMarkdown` and `descriptionMarkdown` boolean flags. 
 - `ConditionalFormMarkdown` was created to display markdown or text based on the flag ⬆️.
 - At the end "Priznanie k dani z nehnutelnosti" was reverted (as the only form to footer helptext), it looks kinda ugly and don't want to surprise anyone (product owners), let them decide what to do in the next iteration. - https://github.com/bratislava/konto.bratislava.sk/issues/1818
 
![chrome_Zu7fCwedLx](https://github.com/user-attachments/assets/45952a0e-671d-45d4-af70-23071ed1b59a)

 