### PR TITLE
Initial summary JSON precalculate on server

### DIFF
--- a/next/components/forms/useFormContext.tsx
+++ b/next/components/forms/useFormContext.tsx
@@ -6,6 +6,7 @@ import {
   isSlovenskoSkTaxFormDefinition,
 } from 'forms-shared/definitions/formDefinitionTypes'
 import { ClientFileInfo } from 'forms-shared/form-files/fileStatus'
+import { SummaryJsonForm } from 'forms-shared/summary-json/summaryJsonTypes'
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
 import { useIsClient } from 'usehooks-ts'
 
@@ -26,6 +27,7 @@ export type FormServerContext = {
   initialClientFiles?: ClientFileInfo[]
   initialServerFiles: GetFileResponseReducedDto[]
   initialSignature?: FormSignature | null
+  initialSummaryJson?: SummaryJsonForm | null
   formSent: boolean
   formMigrationRequired: boolean
   isEmbedded: boolean

--- a/next/components/forms/useFormCurrentStepIndex.ts
+++ b/next/components/forms/useFormCurrentStepIndex.ts
@@ -26,7 +26,7 @@ const getQueryParamByStepIndex = (steps: FormStepperStep[], stepIndex: FormStepI
   return step?.queryParam ?? null
 }
 
-export const STEP_QUERY_PARAM = 'krok'
+export const STEP_QUERY_PARAM_KEY = 'krok'
 
 /**
  * A hook that holds the state of the current step index and synchronizes its value with `krok` query param in the URL.
@@ -53,7 +53,7 @@ export const useFormCurrentStepIndex = (stepperData: FormStepperStep[]) => {
     [],
   )
 
-  const [currentStepIndex, setCurrentStepIndex] = useQueryState(STEP_QUERY_PARAM, parser)
+  const [currentStepIndex, setCurrentStepIndex] = useQueryState(STEP_QUERY_PARAM_KEY, parser)
 
   useEffectOnce(() => {
     // Initially if the query param is not present this sets it (`currentStepIndex` already contains default value)

--- a/next/components/forms/useFormCurrentStepIndex.ts
+++ b/next/components/forms/useFormCurrentStepIndex.ts
@@ -26,7 +26,7 @@ const getQueryParamByStepIndex = (steps: FormStepperStep[], stepIndex: FormStepI
   return step?.queryParam ?? null
 }
 
-const STEP_QUERY_PARAM = 'krok'
+export const STEP_QUERY_PARAM = 'krok'
 
 /**
  * A hook that holds the state of the current step index and synchronizes its value with `krok` query param in the URL.

--- a/next/frontend/utils/formState.ts
+++ b/next/frontend/utils/formState.ts
@@ -7,7 +7,7 @@ import pick from 'lodash/pick'
 import { FormStepperStep } from '../../components/forms/types/Steps'
 import { isDefined } from './general'
 
-export const SUMMARY_QUERY_PARAM = 'sumar'
+export const STEP_QUERY_PARAM_VALUE_SUMMARY = 'sumar'
 
 /**
  * Evaluates each step with current form data and returns an array of schemas.
@@ -91,7 +91,7 @@ export const getStepperData = (
     {
       index: 'summary',
       displayIndex: displayIndex + 1,
-      queryParam: SUMMARY_QUERY_PARAM,
+      queryParam: STEP_QUERY_PARAM_VALUE_SUMMARY,
     } satisfies FormStepperStep,
   ]
 }

--- a/next/frontend/utils/getInitialSummaryJson.ts
+++ b/next/frontend/utils/getInitialSummaryJson.ts
@@ -4,15 +4,15 @@ import { GenericObjectType } from '@rjsf/utils'
 import { FormDefinition } from 'forms-shared/definitions/formDefinitionTypes'
 import { getSummaryJsonNode } from 'forms-shared/summary-json/getSummaryJsonNode'
 
-import { STEP_QUERY_PARAM } from '../../components/forms/useFormCurrentStepIndex'
-import { SUMMARY_QUERY_PARAM } from './formState'
+import { STEP_QUERY_PARAM_KEY } from '../../components/forms/useFormCurrentStepIndex'
+import { STEP_QUERY_PARAM_VALUE_SUMMARY } from './formState'
 
 export const getInitialSummaryJson = (
   query: ParsedUrlQuery,
   formDefinition: FormDefinition,
   formData: GenericObjectType,
 ) => {
-  if (query[STEP_QUERY_PARAM] !== SUMMARY_QUERY_PARAM) {
+  if (query[STEP_QUERY_PARAM_KEY] !== STEP_QUERY_PARAM_VALUE_SUMMARY) {
     return null
   }
 

--- a/next/frontend/utils/getInitialSummaryJson.ts
+++ b/next/frontend/utils/getInitialSummaryJson.ts
@@ -1,0 +1,24 @@
+import { ParsedUrlQuery } from 'node:querystring'
+
+import { GenericObjectType } from '@rjsf/utils'
+import { FormDefinition } from 'forms-shared/definitions/formDefinitionTypes'
+import { getSummaryJsonNode } from 'forms-shared/summary-json/getSummaryJsonNode'
+
+import { STEP_QUERY_PARAM } from '../../components/forms/useFormCurrentStepIndex'
+import { SUMMARY_QUERY_PARAM } from './formState'
+
+export const getInitialSummaryJson = (
+  query: ParsedUrlQuery,
+  formDefinition: FormDefinition,
+  formData: GenericObjectType,
+) => {
+  if (query[STEP_QUERY_PARAM] !== SUMMARY_QUERY_PARAM) {
+    return null
+  }
+
+  return getSummaryJsonNode(
+    formDefinition.schemas.schema,
+    formDefinition.schemas.uiSchema,
+    formData,
+  )
+}

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -141,11 +141,6 @@ const nextConfig = {
       }),
     )
 
-    if (!isServer) {
-      // Prevents `getSummaryJsonNode` from being included, see function description for more info
-      config.resolve.alias['jsdom'] = false
-    }
-
     // https://github.com/konvajs/konva/issues/1458#issuecomment-1356122802
     config.externals = [...config.externals, { canvas: 'canvas' }]
 

--- a/next/pages/mestske-sluzby/[slug]/[id].tsx
+++ b/next/pages/mestske-sluzby/[slug]/[id].tsx
@@ -13,6 +13,7 @@ import { amplifyGetServerSideProps } from '../../../frontend/utils/amplifyServer
 import { handleEmbeddedFormRequest } from '../../../frontend/utils/embeddedFormsHelpers'
 import { getDefaultFormDataForFormDefinition } from '../../../frontend/utils/getDefaultFormDataForFormDefinition'
 import { getInitialFormSignature } from '../../../frontend/utils/getInitialFormSignature'
+import { getInitialSummaryJson } from '../../../frontend/utils/getInitialSummaryJson'
 import { redirectQueryParam } from '../../../frontend/utils/queryParamRedirect'
 import { slovakServerSideTranslations } from '../../../frontend/utils/slovakServerSideTranslations'
 import type { GlobalAppProps } from '../../_app'
@@ -76,17 +77,23 @@ export const getServerSideProps = amplifyGetServerSideProps<
     if (!embeddedSuccess) {
       return { notFound: true }
     }
+    const initialFormDataJson =
+      form.formDataJson ?? getDefaultFormDataForFormDefinition(formDefinition)
 
     return {
       props: {
         formServerContext: {
           formDefinition: makeSerializableFormDefinition(formDefinition),
           formId,
-          initialFormDataJson:
-            form.formDataJson ?? getDefaultFormDataForFormDefinition(formDefinition),
+          initialFormDataJson,
           initialServerFiles: files,
           initialSignature,
           formSent,
+          initialSummaryJson: getInitialSummaryJson(
+            context.query,
+            formDefinition,
+            initialFormDataJson,
+          ),
           formMigrationRequired,
           isEmbedded,
           strapiForm: strapiForm ?? null,


### PR DESCRIPTION
The previous solution that used `getSummaryJsonNode` in React component and then filter it in Webpack out was bad. Now the initial summary JSON is explicitly calculated and added to props, no-frills.

Besides this, it will allow to use Turbopack in the future (doesn't use webpack internally).