### PR TITLE
Validator registry

### DIFF
--- a/forms-shared/src/form-utils/defaultFormState.ts
+++ b/forms-shared/src/form-utils/defaultFormState.ts
@@ -3,11 +3,9 @@ import {
   GenericObjectType,
   getDefaultFormState,
   RJSFSchema,
-  ValidatorType,
 } from '@rjsf/utils'
-
-import { baRjsfValidator } from './validators'
 import { isEqual } from 'lodash'
+import { BaRjsfValidatorRegistry } from './validatorRegistry'
 import { baFastMergeAllOf } from './fastMergeAllOf'
 
 /**
@@ -74,11 +72,11 @@ export const baDefaultFormStateBehavior: Experimental_DefaultFormStateBehavior =
 export const baGetDefaultFormState = (
   schema: RJSFSchema,
   formData: GenericObjectType,
+  validatorRegistry: BaRjsfValidatorRegistry,
   rootSchema?: RJSFSchema,
-  customValidator?: ValidatorType,
 ) =>
   getDefaultFormState(
-    customValidator ?? baRjsfValidator,
+    validatorRegistry.getValidator(schema),
     schema,
     formData,
     rootSchema,
@@ -99,15 +97,25 @@ export const baGetDefaultFormState = (
 export const baGetDefaultFormStateStable = (
   schema: RJSFSchema,
   formData: GenericObjectType,
+  validatorRegistry: BaRjsfValidatorRegistry,
   rootSchema?: RJSFSchema,
-  customValidator?: ValidatorType,
   maxIterations: number = 10,
 ) => {
   let currentFormData = formData
   let iteration = 0
+  const validator = validatorRegistry.getValidator(schema)
+  // For subsequent calls we want to reuse the same validator, so we create a new registry with the same validator
+  const reuseValidatorRegistry = {
+    getValidator: () => validator,
+  }
 
   while (iteration < maxIterations) {
-    const newFormData = baGetDefaultFormState(schema, currentFormData, rootSchema, customValidator)
+    const newFormData = baGetDefaultFormState(
+      schema,
+      currentFormData,
+      reuseValidatorRegistry,
+      rootSchema,
+    )
 
     if (isEqual(currentFormData, newFormData)) {
       return newFormData

--- a/forms-shared/src/form-utils/formDefaults.ts
+++ b/forms-shared/src/form-utils/formDefaults.ts
@@ -1,12 +1,16 @@
-import { baRjsfValidator } from './validators'
 import { baDefaultFormStateBehavior } from './defaultFormState'
 import { baFastMergeAllOf } from './fastMergeAllOf'
+import { BAJSONSchema7 } from './ajvKeywords'
+import { BaRjsfValidatorRegistry } from './validatorRegistry'
 
 /**
  * Default RJSF props that should be used for all forms to work consistently.
  */
-export const baFormDefaults = {
-  validator: baRjsfValidator,
+export const getBaFormDefaults = (
+  schema: BAJSONSchema7,
+  validatorRegistry: BaRjsfValidatorRegistry,
+) => ({
+  validator: validatorRegistry.getValidator(schema),
   experimental_defaultFormStateBehavior: baDefaultFormStateBehavior,
   experimental_customMergeAllOf: baFastMergeAllOf,
-}
+})

--- a/forms-shared/src/form-utils/omitExtraData.ts
+++ b/forms-shared/src/form-utils/omitExtraData.ts
@@ -1,7 +1,7 @@
 import { createSchemaUtils, GenericObjectType, RJSFSchema } from '@rjsf/utils'
 import Form from '@rjsf/core'
-import { baRjsfValidator } from './validators'
 import { baDefaultFormStateBehavior } from './defaultFormState'
+import { BaRjsfValidatorRegistry } from './validatorRegistry'
 import { baFastMergeAllOf } from './fastMergeAllOf'
 
 /**
@@ -10,14 +10,19 @@ import { baFastMergeAllOf } from './fastMergeAllOf'
  * Until https://github.com/rjsf-team/react-jsonschema-form/issues/4081 is resolved this is the only way how to omit
  * extra data from form data.
  */
-export function omitExtraData(schema: RJSFSchema, formData: GenericObjectType): GenericObjectType {
+export function omitExtraData(
+  schema: RJSFSchema,
+  formData: GenericObjectType,
+  validatorRegistry: BaRjsfValidatorRegistry,
+): GenericObjectType {
+  const validator = validatorRegistry.getValidator(schema)
   const schemaUtils = createSchemaUtils(
-    baRjsfValidator,
+    validator,
     schema,
     baDefaultFormStateBehavior,
     baFastMergeAllOf,
   )
-  const formInstance = new Form({ schema, validator: baRjsfValidator })
+  const formInstance = new Form({ schema, validator })
 
   const retrievedSchema = schemaUtils.retrieveSchema(schema, formData)
   const pathSchema = schemaUtils.toPathSchema(retrievedSchema, undefined, formData)

--- a/forms-shared/src/form-utils/validatorRegistry.ts
+++ b/forms-shared/src/form-utils/validatorRegistry.ts
@@ -1,0 +1,80 @@
+import { BAJSONSchema7 } from './ajvKeywords'
+import { getBaRjsfValidator } from './validators'
+
+export type BaRjsfValidator = ReturnType<typeof getBaRjsfValidator>
+
+/**
+ * Registry interface for managing RJSF validators.
+ *
+ * Previously, a single validator instance was used:
+ * ```ts
+ * const validator = getBaRjsfValidator()
+ * functionWithValidator(...args, validator)
+ * ```
+ *
+ * The registry pattern was introduced because:
+ * 1. Ajv/RJSF validator is stateful and contains information of previous validations
+ *    - On backend, it's safer to use new instance for each validation
+ *
+ * 2. RJSF internally calls handleSchemaUpdate on each isValid call:
+ *    ```ts
+ *    isValid(schema, data, rootSchema) {
+ *      // On each validation, checks if schema exists or has changed
+ *      if (this.ajv.getSchema(ROOT_PREFIX) === undefined) {
+ *        this.ajv.addSchema(rootSchema, ROOT_PREFIX)  // Compiles schema
+ *      } else if (!deepEquals(rootSchema, this.ajv.getSchema(ROOT_PREFIX).schema)) {
+ *        this.ajv.removeSchema(ROOT_PREFIX)
+ *        this.ajv.addSchema(rootSchema, ROOT_PREFIX)  // Recompiles schema
+ *      }
+ *      return this.ajv.validate()
+ *    }
+ *    ```
+ *
+ * On frontend, the validator is called with multiple different schemas, which previously caused
+ * very expensive `handleSchemaUpdate` to be called between all validations, significantly slowing
+ * down the application.
+ *
+ * Two implementations are provided:
+ * - SingleUseValidatorRegistry: Creates new validator for each getValidator call
+ *   - Used on backend where state isolation is important
+ *
+ * - WeakMapRegistry: Caches validators by schema reference
+ *   - Used on frontend to prevent repeated schema compilations
+ *   - Uses WeakMap to allow garbage collection of unused schemas
+ */
+export type BaRjsfValidatorRegistry = {
+  getValidator(schema: BAJSONSchema7): BaRjsfValidator
+}
+
+/**
+ * Creates a registry that returns a new validator instance for each call.
+ * Used on backend where state isolation is important.
+ */
+export const createSingleUseValidatorRegistry = (): BaRjsfValidatorRegistry => {
+  return {
+    getValidator() {
+      return getBaRjsfValidator()
+    },
+  }
+}
+
+/**
+ * Creates a registry that caches validators by schema reference.
+ * Used on frontend to prevent repeated schema compilations when validating the same schema multiple times.
+ */
+export const createWeakMapRegistry = (): BaRjsfValidatorRegistry => {
+  const validatorCache = new WeakMap<BAJSONSchema7, BaRjsfValidator>()
+
+  return {
+    getValidator(schema: BAJSONSchema7) {
+      let validator = validatorCache.get(schema)
+
+      if (!validator) {
+        validator = getBaRjsfValidator()
+        validatorCache.set(schema, validator)
+      }
+
+      return validator
+    },
+  }
+}

--- a/forms-shared/src/form-utils/validators.ts
+++ b/forms-shared/src/form-utils/validators.ts
@@ -5,7 +5,7 @@ import { SchemaValidateFunction, Vocabulary } from 'ajv'
 import { baAjvFormats } from './ajvFormats'
 import { baAjvKeywords } from './ajvKeywords'
 
-const getBaRjsfValidator = (customKeywords?: Vocabulary) =>
+export const getBaRjsfValidator = (customKeywords?: Vocabulary) =>
   customizeValidator({
     // The type in @rjsf/validator-ajv8 is wrong.
     customFormats: baAjvFormats as unknown as CustomValidatorOptionsType['customFormats'],
@@ -13,11 +13,6 @@ const getBaRjsfValidator = (customKeywords?: Vocabulary) =>
       keywords: customKeywords ?? baAjvKeywords,
     },
   })
-
-/**
- * Default RJSF validator that should be used for all forms.
- */
-export const baRjsfValidator = getBaRjsfValidator()
 
 /**
  * Generates keywords with custom file validation function.

--- a/forms-shared/src/slovensko-sk/generateXml.ts
+++ b/forms-shared/src/slovensko-sk/generateXml.ts
@@ -4,6 +4,7 @@ import { renderSlovenskoXmlSummary } from './renderXmlSummary'
 import removeMarkdown from 'remove-markdown'
 import { FormsBackendFile } from '../form-files/serverFilesTypes'
 import { getSlovenskoSkXmlns } from './urls'
+import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
 function getSlovenskoSkXmlObjectBase(
   formDefinition: FormDefinitionSlovenskoSk,
@@ -44,6 +45,7 @@ export function getEmptySlovenskoSkXmlObject(formDefinition: FormDefinitionSlove
 export async function generateSlovenskoSkXmlObject(
   formDefinition: FormDefinitionSlovenskoSk,
   formData: GenericObjectType,
+  validatorRegistry: BaRjsfValidatorRegistry,
   serverFiles?: FormsBackendFile[],
 ) {
   return getSlovenskoSkXmlObjectBase(formDefinition, {
@@ -51,7 +53,12 @@ export async function generateSlovenskoSkXmlObject(
     // in Slovensko.sk XMLs beforehand to accommodate for future changes.
     JsonVersion: '1.0',
     Json: JSON.stringify(formData),
-    Summary: await renderSlovenskoXmlSummary(formDefinition, formData, serverFiles),
+    Summary: await renderSlovenskoXmlSummary(
+      formDefinition,
+      formData,
+      validatorRegistry,
+      serverFiles,
+    ),
     TermsAndConditions: removeMarkdown(formDefinition.termsAndConditions),
   })
 }

--- a/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
+++ b/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
@@ -18,6 +18,7 @@ import { getSummaryJsonNode } from '../summary-json/getSummaryJsonNode'
 import { Parser } from 'xml2js'
 import { FormsBackendFile } from '../form-files/serverFilesTypes'
 import { mergeClientAndServerFilesSummary } from '../form-files/mergeClientAndServerFiles'
+import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
 type SlovenskoSkSummaryXmlProps = {
   summaryJson: SummaryJsonForm
@@ -139,15 +140,22 @@ const parser = new Parser({
 export async function renderSlovenskoXmlSummary(
   formDefinition: FormDefinition,
   formData: GenericObjectType,
+  validatorRegistry: BaRjsfValidatorRegistry,
   serverFiles?: FormsBackendFile[],
 ) {
   const summaryJson = getSummaryJsonNode(
     formDefinition.schemas.schema,
     formDefinition.schemas.uiSchema,
     formData,
+    validatorRegistry,
   )
   const fileInfos = mergeClientAndServerFilesSummary([], serverFiles)
-  const validatedSummary = validateSummary(formDefinition.schemas.schema, formData, fileInfos)
+  const validatedSummary = validateSummary(
+    formDefinition.schemas.schema,
+    formData,
+    fileInfos,
+    validatorRegistry,
+  )
 
   const stringXml = renderToString(
     <SlovenskoSkSummaryXml summaryJson={summaryJson} validatedSummary={validatedSummary} />,

--- a/forms-shared/src/summary-email/renderSummaryEmail.tsx
+++ b/forms-shared/src/summary-email/renderSummaryEmail.tsx
@@ -7,6 +7,7 @@ import { validateSummary } from '../summary-renderer/validateSummary'
 import { render } from '@react-email/components'
 import { SummaryEmail } from './SummaryEmail'
 import { FormDefinition } from '../definitions/formDefinitionTypes'
+import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
 export type FileIdInfoMap = Record<string, { url: string; fileName: string }>
 
@@ -14,6 +15,7 @@ export type RenderSummaryEmailPayload = {
   formDefinition: FormDefinition
   formData: GenericObjectType
   fileIdInfoMap: FileIdInfoMap
+  validatorRegistry: BaRjsfValidatorRegistry
   serverFiles?: FormsBackendFile[]
   withHtmlBodyTags?: boolean
 }
@@ -22,6 +24,7 @@ export const renderSummaryEmail = async ({
   formDefinition,
   formData,
   fileIdInfoMap,
+  validatorRegistry,
   serverFiles,
   withHtmlBodyTags = false,
 }: RenderSummaryEmailPayload) => {
@@ -29,9 +32,15 @@ export const renderSummaryEmail = async ({
     formDefinition.schemas.schema,
     formDefinition.schemas.uiSchema,
     formData,
+    validatorRegistry,
   )
   const fileInfos = mergeClientAndServerFilesSummary([], serverFiles)
-  const validatedSummary = validateSummary(formDefinition.schemas.schema, formData, fileInfos)
+  const validatedSummary = validateSummary(
+    formDefinition.schemas.schema,
+    formData,
+    fileInfos,
+    validatorRegistry,
+  )
 
   return render(
     <SummaryEmail

--- a/forms-shared/src/summary-json/SummaryXmlForm.tsx
+++ b/forms-shared/src/summary-json/SummaryXmlForm.tsx
@@ -19,8 +19,9 @@ import React, {
 import { getArrayItemTitle } from '../form-utils/getArrayItemTitle'
 import { ArrayFieldUiOptions, BaFieldType, BaWidgetType } from '../generator/uiOptionsTypes'
 import { getSummaryDisplayValues } from './getSummaryDisplayValue'
-import { baFormDefaults } from '../form-utils/formDefaults'
+import { getBaFormDefaults } from '../form-utils/formDefaults'
 import { getObjectFieldInfo } from '../form-utils/getObjectFieldInfo'
+import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
 export enum SummaryXmlFormTag {
   Form = 'summary-form',
@@ -188,7 +189,9 @@ const theme: ThemeProps = {
 
 const ThemedForm = withTheme(theme)
 
-type SummaryXmlFormProps = Pick<FormProps, 'schema' | 'uiSchema' | 'formData'>
+type SummaryXmlFormProps = Pick<FormProps, 'schema' | 'uiSchema' | 'formData'> & {
+  validatorRegistry: BaRjsfValidatorRegistry
+}
 
 /**
  * Generates a summary XML form based on the provided schema, UI schema, and form data.
@@ -198,7 +201,12 @@ type SummaryXmlFormProps = Pick<FormProps, 'schema' | 'uiSchema' | 'formData'>
  * Unfortunately, it is not possible to generate a JSON summary directly, so the XML is later parsed into JSON.
  * The generated XML is tightly coupled with its parsing in `getSummaryJson` function, and it is not used anywhere else.
  */
-export const SummaryXmlForm = ({ schema, uiSchema, formData }: SummaryXmlFormProps) => {
+export const SummaryXmlForm = ({
+  schema,
+  uiSchema,
+  formData,
+  validatorRegistry,
+}: SummaryXmlFormProps) => {
   return (
     <ThemedForm
       schema={schema}
@@ -206,7 +214,7 @@ export const SummaryXmlForm = ({ schema, uiSchema, formData }: SummaryXmlFormPro
       formData={formData}
       // RJSF renders the form in <form> tag by default.
       tagName={({ children }: PropsWithChildren) => <>{children}</>}
-      {...baFormDefaults}
+      {...getBaFormDefaults(schema, validatorRegistry)}
     >
       {/* There must be an empty fragment inside the form, otherwise RJSF renders submit button
        * inside the form. */}

--- a/forms-shared/src/summary-json/getSummaryJson.tsx
+++ b/forms-shared/src/summary-json/getSummaryJson.tsx
@@ -12,6 +12,7 @@ import {
   SummaryJsonType,
 } from './summaryJsonTypes'
 import { SummaryXmlForm, SummaryXmlFormTag } from './SummaryXmlForm'
+import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
 const allowedChildren: Record<SummaryXmlFormTag, SummaryXmlFormTag[]> = {
   [SummaryXmlFormTag.Form]: [SummaryXmlFormTag.Step],
@@ -147,10 +148,16 @@ export const getSummaryJson = (
   uiSchema: UiSchema,
   data: GenericObjectType,
   domParserInstance: DOMParser,
+  validatorRegistry: BaRjsfValidatorRegistry,
 ) => {
   // eslint-disable-next-line testing-library/render-result-naming-convention
   const renderedString = renderToString(
-    <SummaryXmlForm schema={jsonSchema} uiSchema={uiSchema} formData={data} />,
+    <SummaryXmlForm
+      schema={jsonSchema}
+      uiSchema={uiSchema}
+      formData={data}
+      validatorRegistry={validatorRegistry}
+    />,
   )
 
   return parseXml(domParserInstance, renderedString)

--- a/forms-shared/src/summary-json/getSummaryJsonBrowser.ts
+++ b/forms-shared/src/summary-json/getSummaryJsonBrowser.ts
@@ -1,6 +1,7 @@
 import { GenericObjectType, RJSFSchema, UiSchema } from '@rjsf/utils'
 
 import { getSummaryJson } from './getSummaryJson'
+import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
 /**
  * Browser implementation of `getSummaryJson`. It cannot be used in Node.js environment, because
@@ -10,8 +11,9 @@ export const getSummaryJsonBrowser = (
   jsonSchema: RJSFSchema,
   uiSchema: UiSchema,
   data: GenericObjectType,
+  validatorRegistry: BaRjsfValidatorRegistry,
 ) => {
   const domParserInstance = new window.DOMParser()
 
-  return getSummaryJson(jsonSchema, uiSchema, data, domParserInstance)
+  return getSummaryJson(jsonSchema, uiSchema, data, domParserInstance, validatorRegistry)
 }

--- a/forms-shared/src/summary-json/getSummaryJsonNode.ts
+++ b/forms-shared/src/summary-json/getSummaryJsonNode.ts
@@ -2,6 +2,7 @@ import { GenericObjectType, RJSFSchema, UiSchema } from '@rjsf/utils'
 import jsdom from 'jsdom'
 
 import { getSummaryJson } from './getSummaryJson'
+import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
 /**
  * Node.js implementation of `getSummaryJson`. Instead of `window.DOMParser` (which is not available
@@ -13,9 +14,10 @@ export const getSummaryJsonNode = (
   jsonSchema: RJSFSchema,
   uiSchema: UiSchema,
   data: GenericObjectType,
+  validatorRegistry: BaRjsfValidatorRegistry,
 ) => {
   const jsDomInstance = new jsdom.JSDOM()
   const domParserInstance = new jsDomInstance.window.DOMParser()
 
-  return getSummaryJson(jsonSchema, uiSchema, data, domParserInstance)
+  return getSummaryJson(jsonSchema, uiSchema, data, domParserInstance, validatorRegistry)
 }

--- a/forms-shared/src/summary-pdf/renderSummaryPdf.tsx
+++ b/forms-shared/src/summary-pdf/renderSummaryPdf.tsx
@@ -10,6 +10,7 @@ import { mergeClientAndServerFilesSummary } from '../form-files/mergeClientAndSe
 import { validateSummary } from '../summary-renderer/validateSummary'
 import summaryPdfCss from '../generated-assets/summaryPdfCss'
 import { FormDefinition } from '../definitions/formDefinitionTypes'
+import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
 export type RenderSummaryPdfPayload = {
   formDefinition: FormDefinition
@@ -19,6 +20,7 @@ export type RenderSummaryPdfPayload = {
    * only a peer dependency of this package.
    */
   launchBrowser: () => Promise<Browser>
+  validatorRegistry: BaRjsfValidatorRegistry
   serverFiles?: FormsBackendFile[]
   clientFiles?: ClientFileInfo[]
 }
@@ -30,14 +32,15 @@ export const renderSummaryPdf = async ({
   formDefinition,
   formData,
   launchBrowser,
+  validatorRegistry,
   clientFiles,
   serverFiles,
 }: RenderSummaryPdfPayload) => {
   const { schema, uiSchema } = formDefinition.schemas
-  const summaryJson = getSummaryJsonNode(schema, uiSchema, formData)
+  const summaryJson = getSummaryJsonNode(schema, uiSchema, formData, validatorRegistry)
 
   const fileInfos = mergeClientAndServerFilesSummary(clientFiles, serverFiles)
-  const validatedSummary = validateSummary(schema, formData, fileInfos)
+  const validatedSummary = validateSummary(schema, formData, fileInfos, validatorRegistry)
 
   const renderedString = renderToString(
     <SummaryPdf

--- a/forms-shared/src/summary-renderer/validateSummary.ts
+++ b/forms-shared/src/summary-renderer/validateSummary.ts
@@ -4,6 +4,8 @@ import { SchemaValidateFunction } from 'ajv'
 import { getFileValidatorBaRjsf } from '../form-utils/validators'
 import { baGetDefaultFormStateStable } from '../form-utils/defaultFormState'
 import { checkPathForErrors } from './checkPathForErrors'
+import { validateBaFileUuid } from '../form-utils/ajvFormats'
+import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
 export type ValidatedSummary = {
   hasErrors: boolean
@@ -23,15 +25,26 @@ export const validateSummary = (
   schema: RJSFSchema,
   formData: GenericObjectType,
   fileInfos: Record<string, FileInfoSummary>,
+  validatorRegistry: BaRjsfValidatorRegistry,
 ): ValidatedSummary => {
-  const filesInFormData: FileInfoSummary[] = []
+  // When displaying summary, all the default data must be present to get correct error schema for each field, e.g. when
+  // we have schema like this:
+  //  - `wrapper` (object, required)
+  //    - `field1` (string, required)
+  //    - `field2` (string, optional)
+  // but the initial data is `{}`, the error schema will be:
+  // { property: 'wrapper', message: "must have required property 'wrapper'" }
+  // if default data are added it correctly returns:
+  // { property: 'wrapper.field1', message: "must have required property 'wrapper.field1'" }
+  const defaultFormData = baGetDefaultFormStateStable(schema, formData, validatorRegistry)
 
+  const filesInFormData: FileInfoSummary[] = []
   const fileValidateFn: SchemaValidateFunction = (schemaInner, id) => {
     if (!id) {
       return true
     }
 
-    if (typeof id !== 'string') {
+    if (!validateBaFileUuid(id)) {
       return false
     }
 
@@ -45,19 +58,8 @@ export const validateSummary = (
     return !isErrorFileStatusType(fileInfo.statusType)
   }
 
-  const validator = getFileValidatorBaRjsf(fileValidateFn)
-
-  // When displaying summary, all the default data must be present to get correct error schema for each field, e.g. when
-  // we have schema like this:
-  //  - `wrapper` (object, required)
-  //    - `field1` (string, required)
-  //    - `field2` (string, optional)
-  // but the initial data is `{}`, the error schema will be:
-  // { property: 'wrapper', message: "must have required property 'wrapper'" }
-  // if default data are added it correctly returns:
-  // { property: 'wrapper.field1', message: "must have required property 'wrapper.field1'" }
-  const defaultFormData = baGetDefaultFormStateStable(schema, formData, undefined, validator)
-  const validationResults = validator.validateFormData(defaultFormData, schema)
+  const fileValidator = getFileValidatorBaRjsf(fileValidateFn)
+  const validationResults = fileValidator.validateFormData(defaultFormData, schema)
 
   const hasErrors = Object.keys(validationResults.errorSchema).length > 0
   const pathHasError = (path: string) => checkPathForErrors(path, validationResults.errorSchema)

--- a/forms-shared/test-utils/validatorRegistry.ts
+++ b/forms-shared/test-utils/validatorRegistry.ts
@@ -1,0 +1,3 @@
+import { createSingleUseValidatorRegistry } from '../src/form-utils/validatorRegistry'
+
+export const testValidatorRegistry = createSingleUseValidatorRegistry()

--- a/forms-shared/tests/definitions/formDefinitions.ts
+++ b/forms-shared/tests/definitions/formDefinitions.ts
@@ -1,9 +1,9 @@
 import { formDefinitions } from '../../src/definitions/formDefinitions'
 import { FormDefinition } from '../../src/definitions/formDefinitionTypes'
-import { baRjsfValidator } from '../../src/form-utils/validators'
 import { filterConsole } from '../../test-utils/filterConsole'
 import { baGetDefaultFormState } from '../../src/form-utils/defaultFormState'
 import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 describe('Form definitions', () => {
   formDefinitions.forEach((formDefinition) => {
@@ -13,7 +13,8 @@ describe('Form definitions', () => {
       })
 
       it('is valid schema', () => {
-        expect(baRjsfValidator.ajv.validateSchema(formDefinition.schemas.schema, true)).toBe(true)
+        const validator = testValidatorRegistry.getValidator(formDefinition.schemas.schema)
+        expect(validator.ajv.validateSchema(formDefinition.schemas.schema, true)).toBe(true)
       })
 
       it('default form state should match snapshot', () => {
@@ -23,7 +24,9 @@ describe('Form definitions', () => {
             typeof message === 'string' && message.includes('could not merge subschemas in allOf'),
         )
 
-        expect(baGetDefaultFormState(formDefinition.schemas.schema, {})).toMatchSnapshot()
+        expect(
+          baGetDefaultFormState(formDefinition.schemas.schema, {}, testValidatorRegistry),
+        ).toMatchSnapshot()
       })
 
       it('for selected forms, has at least one example form', () => {

--- a/forms-shared/tests/form-utils/defaultFormState.ts
+++ b/forms-shared/tests/form-utils/defaultFormState.ts
@@ -16,6 +16,7 @@ import {
 import { ArrayFieldUiOptions } from '../../src/generator/uiOptionsTypes'
 import { filterConsole } from '../../test-utils/filterConsole'
 import { createCondition } from '../../src/generator/helpers'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 describe('defaultFormState', () => {
   it('isFileMultipleSchema should return true for file array schema', () => {
@@ -95,7 +96,7 @@ describe('defaultFormState', () => {
       (message) =>
         typeof message === 'string' && message.includes('could not merge subschemas in allOf'),
     )
-    expect(baGetDefaultFormState(definition.schema, {})).toEqual({
+    expect(baGetDefaultFormState(definition.schema, {}, testValidatorRegistry)).toEqual({
       fileMultiple: [],
       fileMultipleRequired: [],
       select: [],
@@ -115,7 +116,7 @@ describe('defaultFormState', () => {
       ),
     ])
 
-    expect(baGetDefaultFormState(definition.schema, {})).toEqual({})
+    expect(baGetDefaultFormState(definition.schema, {}, testValidatorRegistry)).toEqual({})
   })
 })
 
@@ -134,8 +135,8 @@ describe('baGetDefaultFormStateStable', () => {
         typeof message === 'string' && message.includes('could not merge subschemas in allOf'),
     )
 
-    const result = baGetDefaultFormState(schema, {})
-    const resultStable = baGetDefaultFormStateStable(schema, {})
+    const result = baGetDefaultFormState(schema, {}, testValidatorRegistry)
+    const resultStable = baGetDefaultFormStateStable(schema, {}, testValidatorRegistry)
 
     expect(result).toEqual({ input1: 'value1' })
     expect(resultStable).toEqual({ input1: 'value1', input2: 'value2' })

--- a/forms-shared/tests/form-utils/fastMergeAllOfComparision.tsx
+++ b/forms-shared/tests/form-utils/fastMergeAllOfComparision.tsx
@@ -3,8 +3,9 @@ import type { baFastMergeAllOf } from '../../src/form-utils/fastMergeAllOf'
 import type mergeAllOf from 'json-schema-merge-allof'
 import { BAJSONSchema7 } from '../../src/form-utils/ajvKeywords'
 import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs'
-import { baFormDefaults } from '../../src/form-utils/formDefaults'
+import { getBaFormDefaults } from '../../src/form-utils/formDefaults'
 import { JSONSchema7 } from 'json-schema'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 const mockFastMergeAllOf = jest.fn(
   jest.requireActual('../../src/form-utils/fastMergeAllOf')
@@ -89,7 +90,7 @@ describe('fastMergeAllOfComparision', () => {
           schema: formDefinition.schemas.schema,
           uiSchema: formDefinition.schemas.uiSchema,
           formData: exampleForm.formData,
-          ...baFormDefaults,
+          ...getBaFormDefaults(formDefinition.schemas.schema, testValidatorRegistry),
           experimental_customMergeAllOf: undefined,
         })
         originalFormCalls = mockOriginalMergeAllOf.mock.calls
@@ -103,7 +104,7 @@ describe('fastMergeAllOfComparision', () => {
           schema: formDefinition.schemas.schema,
           uiSchema: formDefinition.schemas.uiSchema,
           formData: exampleForm.formData,
-          ...baFormDefaults,
+          ...getBaFormDefaults(formDefinition.schemas.schema, testValidatorRegistry),
         })
         fastFormCalls = mockFastMergeAllOf.mock.calls
         fastFormResults = mockFastMergeAllOf.mock.results

--- a/forms-shared/tests/form-utils/omitExtraData.ts
+++ b/forms-shared/tests/form-utils/omitExtraData.ts
@@ -3,6 +3,7 @@ import { omitExtraData } from '../../src/form-utils/omitExtraData'
 import priznanieKDaniZNehnutelnosti from '../../src/schemas/priznanieKDaniZNehnutelnosti'
 import { filterConsole } from '../../test-utils/filterConsole'
 import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 describe('omitExtraData', () => {
   beforeEach(() => {
@@ -18,88 +19,96 @@ describe('omitExtraData', () => {
       input('input', { type: 'text', title: 'Input title' }, {}),
     ])
 
-    const result = omitExtraData(schema, {
-      input: 'value',
-      extraField: 'extra value',
-    })
+    const result = omitExtraData(
+      schema,
+      {
+        input: 'value',
+        extraField: 'extra value',
+      },
+      testValidatorRegistry,
+    )
     expect(result).toEqual({ input: 'value' })
   })
 
   // "Údaje o daňovníkovi" step in "Priznanie k dani z nehnuteľnosti" contains a lot of conditional fields, the original
   // data consists of all possible fields, therefore it is a good test case for omitting extra data.
   it('should omit extra data for complex schema', () => {
-    const result = omitExtraData(priznanieKDaniZNehnutelnosti.schema, {
-      udajeODanovnikovi: {
-        voSvojomMene: true,
-        priznanieAko: 'fyzickaOsoba',
-        obecPsc: {
-          psc: '82108',
-          obec: 'Bratislava',
-        },
-        stat: '703',
-        menoTitul: {
-          meno: 'Ján',
-          titul: 'Ing.',
-        },
-        ulicaCisloFyzickaOsoba: {
-          cislo: '12',
-          ulica: 'Mierová',
-        },
-        korespondencnaAdresa: {
-          korespondencnaAdresaRovnaka: false,
-          ulicaCisloKorespondencnaAdresa: {
-            cislo: '34',
-            ulica: 'Dunajská',
-          },
+    const result = omitExtraData(
+      priznanieKDaniZNehnutelnosti.schema,
+      {
+        udajeODanovnikovi: {
+          voSvojomMene: true,
+          priznanieAko: 'fyzickaOsoba',
           obecPsc: {
-            psc: '82109',
-            obec: 'Bratislava',
-          },
-          stat: '703',
-        },
-        opravnenaOsoba: {
-          splnomocnenie: [],
-          splnomocnenecTyp: 'fyzickaOsoba',
-          obecPsc: {
-            obec: 'Bratislava',
             psc: '82108',
+            obec: 'Bratislava',
           },
           stat: '703',
           menoTitul: {
-            meno: 'Peter',
-            titul: 'Mgr.',
+            meno: 'Ján',
+            titul: 'Ing.',
           },
           ulicaCisloFyzickaOsoba: {
-            ulica: 'Šancová',
-            cislo: '56',
+            cislo: '12',
+            ulica: 'Mierová',
+          },
+          korespondencnaAdresa: {
+            korespondencnaAdresaRovnaka: false,
+            ulicaCisloKorespondencnaAdresa: {
+              cislo: '34',
+              ulica: 'Dunajská',
+            },
+            obecPsc: {
+              psc: '82109',
+              obec: 'Bratislava',
+            },
+            stat: '703',
+          },
+          opravnenaOsoba: {
+            splnomocnenie: [],
+            splnomocnenecTyp: 'fyzickaOsoba',
+            obecPsc: {
+              obec: 'Bratislava',
+              psc: '82108',
+            },
+            stat: '703',
+            menoTitul: {
+              meno: 'Peter',
+              titul: 'Mgr.',
+            },
+            ulicaCisloFyzickaOsoba: {
+              ulica: 'Šancová',
+              cislo: '56',
+            },
+            ulicaCisloPravnickaOsoba: {
+              ulica: 'Karadžičova',
+              cislo: '8',
+            },
+            priezvisko: 'Horváth',
+            email: 'peter.horvath@priklad.sk',
+            telefon: '+421902345678',
+            obchodneMenoAleboNazov: 'Peter Horváth Consulting',
           },
           ulicaCisloPravnickaOsoba: {
             ulica: 'Karadžičova',
             cislo: '8',
           },
-          priezvisko: 'Horváth',
-          email: 'peter.horvath@priklad.sk',
-          telefon: '+421902345678',
-          obchodneMenoAleboNazov: 'Peter Horváth Consulting',
+          ulicaCisloFyzickaOsobaPodnikatel: {
+            ulica: 'Šancová',
+            cislo: '56',
+          },
+          email: 'jan.novak@priklad.sk',
+          telefon: '+421905123456',
+          priezvisko: 'Novák',
+          rodneCislo: '8501011234',
+          ico: '12345678',
+          obchodneMenoAleboNazov: 'Novák Consulting',
+          pravnyVztahKPO: 'statutarnyZastupca',
+          pravnaForma: '113',
         },
-        ulicaCisloPravnickaOsoba: {
-          ulica: 'Karadžičova',
-          cislo: '8',
-        },
-        ulicaCisloFyzickaOsobaPodnikatel: {
-          ulica: 'Šancová',
-          cislo: '56',
-        },
-        email: 'jan.novak@priklad.sk',
-        telefon: '+421905123456',
-        priezvisko: 'Novák',
-        rodneCislo: '8501011234',
-        ico: '12345678',
-        obchodneMenoAleboNazov: 'Novák Consulting',
-        pravnyVztahKPO: 'statutarnyZastupca',
-        pravnaForma: '113',
       },
-    })
+      testValidatorRegistry,
+    )
 
     expect(result).toEqual({
       udajeODanovnikovi: {
@@ -140,7 +149,11 @@ describe('omitExtraData', () => {
 
   getExampleFormPairs().forEach(({ formDefinition, exampleForm }) => {
     it(`${exampleForm.name} should not contain extra data`, () => {
-      const result = omitExtraData(formDefinition.schemas.schema, exampleForm.formData)
+      const result = omitExtraData(
+        formDefinition.schemas.schema,
+        exampleForm.formData,
+        testValidatorRegistry,
+      )
       expect(result).toEqual(exampleForm.formData)
     })
   })

--- a/forms-shared/tests/form-utils/validatorRegistry.ts
+++ b/forms-shared/tests/form-utils/validatorRegistry.ts
@@ -1,0 +1,94 @@
+import { ROOT_SCHEMA_PREFIX } from '@rjsf/utils'
+import { BAJSONSchema7 } from '../../src/form-utils/ajvKeywords'
+import {
+  createSingleUseValidatorRegistry,
+  createWeakMapRegistry,
+} from '../../src/form-utils/validatorRegistry'
+import Ajv from 'ajv'
+
+describe('Validator Registry', () => {
+  let addSchemaSpy: jest.SpyInstance<Ajv, Parameters<typeof Ajv.prototype.addSchema>>
+
+  beforeEach(() => {
+    addSchemaSpy = jest.spyOn(Ajv.prototype, 'addSchema')
+  })
+
+  afterEach(() => {
+    addSchemaSpy.mockRestore()
+  })
+
+  const mockSchema1: BAJSONSchema7 = { type: 'object', properties: {} }
+  const mockSchema2: BAJSONSchema7 = { type: 'object', properties: { foo: { type: 'string' } } }
+
+  // `addSchema` is called 3 times for each schema, but we want to filter out only the calls from RJSF `handleSchemaUpdate`,
+  // which provide `ROOT_SCHEMA_PREFIX` as second argument
+  const getHandleSchemaUpdateCalls = () =>
+    addSchemaSpy.mock.calls.filter(([, key]) => key === ROOT_SCHEMA_PREFIX)
+
+  describe('SingleUseValidatorRegistry', () => {
+    it('should create new validator instance for each call', () => {
+      const registry = createSingleUseValidatorRegistry()
+
+      const validator1 = registry.getValidator(mockSchema1)
+      const validator2 = registry.getValidator(mockSchema2)
+      const validator3 = registry.getValidator(mockSchema1)
+
+      expect(validator1).not.toBe(validator2)
+      expect(validator2).not.toBe(validator3)
+      expect(validator1).not.toBe(validator3)
+    })
+
+    it('should compile schema for each validation', () => {
+      const registry = createSingleUseValidatorRegistry()
+
+      // First schema validation
+      const validator1 = registry.getValidator(mockSchema1)
+      validator1.isValid(mockSchema1, {}, mockSchema1)
+      expect(getHandleSchemaUpdateCalls()).toHaveLength(1)
+
+      // Different schema validation
+      const validator2 = registry.getValidator(mockSchema2)
+      validator2.isValid(mockSchema2, {}, mockSchema2)
+      expect(getHandleSchemaUpdateCalls()).toHaveLength(2)
+
+      // Back to first schema
+      const validator3 = registry.getValidator(mockSchema1)
+      validator3.isValid(mockSchema1, {}, mockSchema1)
+      // Should compile schema again
+      expect(getHandleSchemaUpdateCalls()).toHaveLength(3)
+    })
+  })
+
+  describe('WeakMapRegistry', () => {
+    it('should cache validator instances', () => {
+      const registry = createWeakMapRegistry()
+
+      const validator1 = registry.getValidator(mockSchema1)
+      const validator2 = registry.getValidator(mockSchema2)
+      const validator3 = registry.getValidator(mockSchema1)
+
+      expect(validator1).toBe(validator3)
+      expect(validator2).not.toBe(validator3)
+    })
+
+    it('should compile schema only once per unique schema', () => {
+      const registry = createWeakMapRegistry()
+
+      // First schema validation
+      const validator1 = registry.getValidator(mockSchema1)
+      validator1.isValid(mockSchema1, {}, mockSchema1)
+      expect(getHandleSchemaUpdateCalls()).toHaveLength(1)
+
+      // Different schema validation
+      const validator2 = registry.getValidator(mockSchema2)
+      validator2.isValid(mockSchema2, {}, mockSchema2)
+      expect(getHandleSchemaUpdateCalls()).toHaveLength(2)
+
+      // Back to first schema
+      const validator3 = registry.getValidator(mockSchema1)
+      validator3.isValid(mockSchema1, {}, mockSchema1)
+      // Should reuse already compiled schema
+      expect(getHandleSchemaUpdateCalls()).toHaveLength(2)
+    })
+  })
+})

--- a/forms-shared/tests/form-utils/validators.ts
+++ b/forms-shared/tests/form-utils/validators.ts
@@ -1,11 +1,12 @@
 import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs'
-import { baRjsfValidator } from '../../src/form-utils/validators'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 describe('Validators', () => {
   getExampleFormPairs().forEach(({ formDefinition, exampleForm }) => {
     it(`${exampleForm.name} validate correctly`, () => {
+      const validator = testValidatorRegistry.getValidator(formDefinition.schemas.schema)
       expect(
-        baRjsfValidator.isValid(
+        validator.isValid(
           formDefinition.schemas.schema,
           exampleForm.formData,
           formDefinition.schemas.schema,

--- a/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
+++ b/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
@@ -14,6 +14,7 @@ import { fetchSlovenskoSkFormMetadata } from '../../test-utils/fetchSlovenskoSkF
 import { extractJsonFromSlovenskoSkXml } from '../../src/slovensko-sk/extractJson'
 import { buildSlovenskoSkXml } from '../../src/slovensko-sk/xmlBuilder'
 import { screenshotTestTimeout } from '../../test-utils/consts'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 describe('slovenskoSkForm', () => {
   formDefinitions.filter(isSlovenskoSkFormDefinition).forEach((formDefinition) => {
@@ -50,6 +51,7 @@ describe('slovenskoSkForm', () => {
           const xmlObject = await generateSlovenskoSkXmlObject(
             formDefinition,
             exampleForm.formData,
+            testValidatorRegistry,
             exampleForm.serverFiles,
           )
           xmlString = buildSlovenskoSkXml(xmlObject, { headless: false, pretty: true })

--- a/forms-shared/tests/summary-email/renderSummaryEmail.ts
+++ b/forms-shared/tests/summary-email/renderSummaryEmail.ts
@@ -4,6 +4,7 @@ import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs
 import { renderSummaryEmail } from '../../src/summary-email/renderSummaryEmail'
 import { mapValues } from 'lodash'
 import { screenshotTestTimeout } from '../../test-utils/consts'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 expect.extend({ toMatchImageSnapshot })
 
@@ -28,6 +29,7 @@ describe('renderSummaryEmail', () => {
           formData: exampleForm.formData,
           serverFiles: exampleForm.serverFiles,
           fileIdInfoMap,
+          validatorRegistry: testValidatorRegistry,
           withHtmlBodyTags: true,
         })
       })

--- a/forms-shared/tests/summary-json/getSummaryDisplayValue.tsx
+++ b/forms-shared/tests/summary-json/getSummaryDisplayValue.tsx
@@ -21,7 +21,8 @@ import { RJSFSchema, WidgetProps } from '@rjsf/utils'
 import { withTheme } from '@rjsf/core'
 import { renderToString } from 'react-dom/server'
 import React from 'react'
-import { baFormDefaults } from '../../src/form-utils/formDefaults'
+import { getBaFormDefaults } from '../../src/form-utils/formDefaults'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 /**
  * RJSF heavily processes the schema and the uiSchema before rendering the specific widget. For example, for select-like
@@ -45,7 +46,13 @@ const retrieveRuntimeValues = ({ schema, uiSchema }: Field) => {
     },
   })
 
-  renderToString(<Form schema={schema} uiSchema={uiSchema} {...baFormDefaults} />)
+  renderToString(
+    <Form
+      schema={schema}
+      uiSchema={uiSchema}
+      {...getBaFormDefaults(schema, testValidatorRegistry)}
+    />,
+  )
 
   // @ts-expect-error TypeScript cannot detect that `retrievedSchema` and `retrievedOptions` are set in the widget
   if (!retrievedSchema || !retrievedOptions) {

--- a/forms-shared/tests/summary-json/getSummaryJson.ts
+++ b/forms-shared/tests/summary-json/getSummaryJson.ts
@@ -1,5 +1,6 @@
 import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs'
 import { getSummaryJsonNode } from '../../src/summary-json/getSummaryJsonNode'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 describe('getSummaryJson', () => {
   getExampleFormPairs().forEach(({ formDefinition, exampleForm }) => {
@@ -8,6 +9,7 @@ describe('getSummaryJson', () => {
         formDefinition.schemas.schema,
         formDefinition.schemas.uiSchema,
         exampleForm.formData,
+        testValidatorRegistry,
       )
       expect(result).toMatchSnapshot()
     })

--- a/forms-shared/tests/summary-pdf/renderSummaryPdf.ts
+++ b/forms-shared/tests/summary-pdf/renderSummaryPdf.ts
@@ -4,6 +4,7 @@ import { renderSummaryPdf } from '../../src/summary-pdf/renderSummaryPdf'
 import { launchPlaywrightTest } from '../../test-utils/launchPlaywright'
 import { expectPdfToMatchSnapshot } from '../../test-utils/expectPdfToMatchSnapshot'
 import { screenshotTestTimeout } from '../../test-utils/consts'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 describe('getSummaryJson', () => {
   getExampleFormPairs().forEach(({ formDefinition, exampleForm }) => {
@@ -24,6 +25,7 @@ describe('getSummaryJson', () => {
           formData: exampleForm.formData,
           launchBrowser: launchPlaywrightTest,
           serverFiles: exampleForm.serverFiles,
+          validatorRegistry: testValidatorRegistry,
         })
 
         await expectPdfToMatchSnapshot(pdfBuffer)

--- a/forms-shared/tests/summary-renderer/validateSummary.ts
+++ b/forms-shared/tests/summary-renderer/validateSummary.ts
@@ -2,6 +2,7 @@ import { fileUpload, input, object } from '../../src/generator/functions'
 import { validateSummary } from '../../src/summary-renderer/validateSummary'
 import { FileStatusType } from '../../src/form-files/fileStatus'
 import { filterConsole } from '../../test-utils/filterConsole'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 describe('validateSummary', () => {
   beforeEach(() => {
@@ -19,7 +20,12 @@ describe('validateSummary', () => {
     ])
 
     it('should validate successfully when required field is provided', () => {
-      const result = validateSummary(schema, { requiredInput: 'some value' }, {})
+      const result = validateSummary(
+        schema,
+        { requiredInput: 'some value' },
+        {},
+        testValidatorRegistry,
+      )
 
       expect(result.hasErrors).toBe(false)
       expect(result.pathHasError('root_requiredInput')).toBe(false)
@@ -28,7 +34,7 @@ describe('validateSummary', () => {
     })
 
     it('should report errors for missing required field', () => {
-      const result = validateSummary(schema, {}, {})
+      const result = validateSummary(schema, {}, {}, testValidatorRegistry)
 
       expect(result.hasErrors).toBe(true)
       expect(result.pathHasError('root_requiredInput')).toBe(true)
@@ -51,6 +57,7 @@ describe('validateSummary', () => {
             fileName: '',
           },
         },
+        testValidatorRegistry,
       )
 
       expect(result.hasErrors).toBe(false)
@@ -71,6 +78,7 @@ describe('validateSummary', () => {
             fileName: '',
           },
         },
+        testValidatorRegistry,
       )
 
       expect(result.hasErrors).toBe(true)
@@ -81,7 +89,12 @@ describe('validateSummary', () => {
     })
 
     it('should report errors for missing file information', () => {
-      const result = validateSummary(schema, { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' }, {})
+      const result = validateSummary(
+        schema,
+        { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' },
+        {},
+        testValidatorRegistry,
+      )
 
       expect(result.hasErrors).toBe(true)
       expect(result.pathHasError('root_file')).toBe(true)
@@ -124,6 +137,7 @@ describe('validateSummary', () => {
             fileName: '',
           },
         },
+        testValidatorRegistry,
       )
 
       expect(result.hasErrors).toBe(true)

--- a/nest-forms-backend/src/app.module.ts
+++ b/nest-forms-backend/src/app.module.ts
@@ -11,6 +11,7 @@ import AuthModule from './auth/auth.module'
 import ConvertModule from './convert/convert.module'
 import ConvertPdfModule from './convert-pdf/convert-pdf.module'
 import FilesModule from './files/files.module'
+import FormValidatorRegistryModule from './form-validator-registry/form-validator-registry.module'
 import FormsModule from './forms/forms.module'
 import GinisModule from './ginis/ginis.module'
 import NasesModule from './nases/nases.module'
@@ -51,6 +52,7 @@ import SharepointSubservice from './utils/subservices/sharepoint.subservice'
     ConvertPdfModule,
     GinisModule,
     TaxModule,
+    FormValidatorRegistryModule,
     // BEWARE: If Bull doesn't connect to Redis successfully, it will silently fail!
     // https://github.com/nestjs/bull/issues/1076
     BullModule.forRootAsync({

--- a/nest-forms-backend/src/convert/convert.module.ts
+++ b/nest-forms-backend/src/convert/convert.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 
 import FilesModule from '../files/files.module'
+import FormValidatorRegistryModule from '../form-validator-registry/form-validator-registry.module'
 import FormsHelper from '../forms/forms.helper'
 import FormsModule from '../forms/forms.module'
 import FormsService from '../forms/forms.service'
@@ -15,7 +16,13 @@ import ConvertService from './convert.service'
 
 @Module({
   controllers: [ConvertController],
-  imports: [FormsModule, ScannerClientModule, FilesModule, TaxModule],
+  imports: [
+    FormsModule,
+    ScannerClientModule,
+    FilesModule,
+    TaxModule,
+    FormValidatorRegistryModule,
+  ],
   providers: [
     ConvertService,
     ThrowerErrorGuard,

--- a/nest-forms-backend/src/convert/convert.service.spec.ts
+++ b/nest-forms-backend/src/convert/convert.service.spec.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 
 import prismaMock from '../../test/singleton'
+import FormValidatorRegistryService from '../form-validator-registry/form-validator-registry.service'
 import FormsService from '../forms/forms.service'
 import PrismaService from '../prisma/prisma.service'
 import TaxService from '../tax/tax.service'
@@ -33,6 +34,10 @@ describe('ConvertService', () => {
         {
           provide: MinioClientSubservice,
           useValue: createMock<MinioClientSubservice>(),
+        },
+        {
+          provide: FormValidatorRegistryService,
+          useValue: createMock<FormValidatorRegistryService>(),
         },
       ],
     }).compile()

--- a/nest-forms-backend/src/convert/convert.service.ts
+++ b/nest-forms-backend/src/convert/convert.service.ts
@@ -22,6 +22,7 @@ import { renderSummaryPdf } from 'forms-shared/summary-pdf/renderSummaryPdf'
 import { chromium } from 'playwright'
 
 import { CognitoGetUserData } from '../auth/dtos/cognito.dto'
+import FormValidatorRegistryService from '../form-validator-registry/form-validator-registry.service'
 import {
   FormsErrorsEnum,
   FormsErrorsResponseEnum,
@@ -56,6 +57,7 @@ export default class ConvertService {
     private readonly formsService: FormsService,
     private readonly prismaService: PrismaService,
     private readonly minioClientSubservice: MinioClientSubservice,
+    private readonly formValidatorRegistryService: FormValidatorRegistryService,
   ) {
     this.logger = new Logger('ConvertService')
   }
@@ -80,6 +82,7 @@ export default class ConvertService {
         ? patchConvertServiceTaxFormDefinition(formDefinition)
         : formDefinition,
       formDataJson as GenericObjectType,
+      this.formValidatorRegistryService.getRegistry(),
       formWithFiles.files,
     )
   }
@@ -241,6 +244,7 @@ export default class ConvertService {
         launchBrowser: () => chromium.launch(),
         clientFiles,
         serverFiles: form.files,
+        validatorRegistry: this.formValidatorRegistryService.getRegistry(),
       })
     } catch (error) {
       this.logger.error(`Error during generating PDF: ${<string>error}`)

--- a/nest-forms-backend/src/form-validator-registry/form-validator-registry.module.ts
+++ b/nest-forms-backend/src/form-validator-registry/form-validator-registry.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common'
+
+import FormValidatorRegistryService from './form-validator-registry.service'
+
+@Module({
+  providers: [FormValidatorRegistryService],
+  exports: [FormValidatorRegistryService],
+})
+export default class FormValidatorRegistryModule {}

--- a/nest-forms-backend/src/form-validator-registry/form-validator-registry.service.ts
+++ b/nest-forms-backend/src/form-validator-registry/form-validator-registry.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common'
+import {
+  BaRjsfValidatorRegistry,
+  createSingleUseValidatorRegistry,
+} from 'forms-shared/form-utils/validatorRegistry'
+
+@Injectable()
+export default class FormValidatorRegistryService {
+  private readonly validatorRegistry: BaRjsfValidatorRegistry
+
+  constructor() {
+    this.validatorRegistry = createSingleUseValidatorRegistry()
+  }
+
+  getRegistry(): BaRjsfValidatorRegistry {
+    return this.validatorRegistry
+  }
+}

--- a/nest-forms-backend/src/forms/forms.module.ts
+++ b/nest-forms-backend/src/forms/forms.module.ts
@@ -3,6 +3,7 @@ import { forwardRef, Module } from '@nestjs/common'
 // eslint-disable-next-line import/no-cycle
 import FilesModule from '../files/files.module'
 import FilesService from '../files/files.service'
+import FormValidatorRegistryModule from '../form-validator-registry/form-validator-registry.module'
 import NasesConsumerHelper from '../nases-consumer/nases-consumer.helper'
 import PrismaModule from '../prisma/prisma.module'
 import ScannerClientModule from '../scanner-client/scanner-client.module'
@@ -14,7 +15,12 @@ import FormsService from './forms.service'
 import FormsTaskSubservice from './subservices/forms-task.subservice'
 
 @Module({
-  imports: [PrismaModule, ScannerClientModule, forwardRef(() => FilesModule)],
+  imports: [
+    PrismaModule,
+    ScannerClientModule,
+    forwardRef(() => FilesModule),
+    FormValidatorRegistryModule,
+  ],
   providers: [
     FormsService,
     FormsHelper,

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.module.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common'
 import ConvertModule from '../convert/convert.module'
 import ConvertPdfModule from '../convert-pdf/convert-pdf.module'
 import FilesModule from '../files/files.module'
+import FormValidatorRegistryModule from '../form-validator-registry/form-validator-registry.module'
 import FormsModule from '../forms/forms.module'
 import GinisModule from '../ginis/ginis.module'
 import NasesUtilsService from '../nases/utils-services/tokens.nases.service'
@@ -25,6 +26,7 @@ import WebhookSubservice from './subservices/webhook.subservice'
     ConvertModule,
     ConvertPdfModule,
     TaxModule,
+    FormValidatorRegistryModule,
   ],
   providers: [
     NasesConsumerService,

--- a/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
@@ -11,6 +11,7 @@ import * as renderSummaryEmail from 'forms-shared/summary-email/renderSummaryEma
 
 import prismaMock from '../../../../test/singleton'
 import ConvertService from '../../../convert/convert.service'
+import FormValidatorRegistryService from '../../../form-validator-registry/form-validator-registry.service'
 import { FormsErrorsResponseEnum } from '../../../forms/forms.errors.enum'
 import PrismaService from '../../../prisma/prisma.service'
 import MailgunService from '../../../utils/global-services/mailgun/mailgun.service'
@@ -47,6 +48,10 @@ describe('EmailFormsSubservice', () => {
         {
           provide: ConvertService,
           useValue: createMock<ConvertService>(),
+        },
+        {
+          provide: FormValidatorRegistryService,
+          useValue: createMock<FormValidatorRegistryService>(),
         },
         ThrowerErrorGuard,
       ],

--- a/nest-forms-backend/src/nases-consumer/subservices/__test__/webhook.subservice.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/__test__/webhook.subservice.spec.ts
@@ -12,6 +12,7 @@ import * as getFormDefinitionBySlug from 'forms-shared/definitions/getFormDefini
 import * as omitExtraData from 'forms-shared/form-utils/omitExtraData'
 
 import prismaMock from '../../../../test/singleton'
+import FormValidatorRegistryService from '../../../form-validator-registry/form-validator-registry.service'
 import { FormsErrorsResponseEnum } from '../../../forms/forms.errors.enum'
 import PrismaService from '../../../prisma/prisma.service'
 import ThrowerErrorGuard from '../../../utils/guards/thrower-error.guard'
@@ -36,6 +37,10 @@ describe('WebhookSubservice', () => {
         },
         ThrowerErrorGuard,
         { provide: ConfigService, useValue: createMock<ConfigService>() },
+        {
+          provide: FormValidatorRegistryService,
+          useValue: createMock<FormValidatorRegistryService>(),
+        },
       ],
     }).compile()
 

--- a/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
@@ -8,6 +8,7 @@ import { omitExtraData } from 'forms-shared/form-utils/omitExtraData'
 import { renderSummaryEmail } from 'forms-shared/summary-email/renderSummaryEmail'
 
 import ConvertService from '../../convert/convert.service'
+import FormValidatorRegistryService from '../../form-validator-registry/form-validator-registry.service'
 import {
   FormsErrorsEnum,
   FormsErrorsResponseEnum,
@@ -37,6 +38,7 @@ export default class EmailFormsSubservice {
     private mailgunService: MailgunService,
     private configService: ConfigService,
     private convertService: ConvertService,
+    private formValidatorRegistryService: FormValidatorRegistryService,
   ) {
     this.logger = new Logger('EmailFormsSubservice')
   }
@@ -91,6 +93,7 @@ export default class EmailFormsSubservice {
     const jsonDataExtraDataOmitted = omitExtraData(
       formDefinition.schemas.schema,
       form.formDataJson as GenericObjectType,
+      this.formValidatorRegistryService.getRegistry(),
     )
 
     const jwtSecret = this.configService.getOrThrow<string>('JWT_SECRET')
@@ -110,6 +113,7 @@ export default class EmailFormsSubservice {
             formData: jsonDataExtraDataOmitted,
             serverFiles: form.files,
             fileIdInfoMap: getFileIdsToInfoMap(form, jwtSecret, selfUrl),
+            validatorRegistry: this.formValidatorRegistryService.getRegistry(),
           }),
         },
       },

--- a/nest-forms-backend/src/nases-consumer/subservices/webhook.subservice.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/webhook.subservice.ts
@@ -7,6 +7,7 @@ import { isWebhookFormDefinition } from 'forms-shared/definitions/formDefinition
 import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinitionBySlug'
 import { omitExtraData } from 'forms-shared/form-utils/omitExtraData'
 
+import FormValidatorRegistryService from '../../form-validator-registry/form-validator-registry.service'
 import {
   FormsErrorsEnum,
   FormsErrorsResponseEnum,
@@ -29,6 +30,7 @@ export default class WebhookSubservice {
     private readonly prismaService: PrismaService,
     private readonly throwerErrorGuard: ThrowerErrorGuard,
     private readonly configService: ConfigService,
+    private readonly formValidatorRegistryService: FormValidatorRegistryService,
   ) {}
 
   async sendWebhook(formId: string): Promise<void> {
@@ -70,6 +72,7 @@ export default class WebhookSubservice {
     const formData = omitExtraData(
       formDefinition.schemas.schema,
       form.formDataJson as GenericObjectType,
+      this.formValidatorRegistryService.getRegistry(),
     )
 
     this.logger.log(

--- a/nest-forms-backend/src/nases/nases.module.ts
+++ b/nest-forms-backend/src/nases/nases.module.ts
@@ -5,6 +5,7 @@ import ConvertPdfModule from '../convert-pdf/convert-pdf.module'
 import FilesHelper from '../files/files.helper'
 import FilesModule from '../files/files.module'
 import FilesService from '../files/files.service'
+import FormValidatorRegistryModule from '../form-validator-registry/form-validator-registry.module'
 import FormsHelper from '../forms/forms.helper'
 import FormsModule from '../forms/forms.module'
 import NasesConsumerModule from '../nases-consumer/nases-consumer.module'
@@ -28,6 +29,7 @@ import NasesUtilsService from './utils-services/tokens.nases.service'
     ConvertModule,
     TaxModule,
     ConvertPdfModule,
+    FormValidatorRegistryModule,
   ],
   providers: [
     NasesService,

--- a/nest-forms-backend/src/nases/nases.service.ts
+++ b/nest-forms-backend/src/nases/nases.service.ts
@@ -3,11 +3,11 @@ import { FormError, FormOwnerType, Forms, FormState } from '@prisma/client'
 import axios, { AxiosResponse } from 'axios'
 import { isSlovenskoSkFormDefinition } from 'forms-shared/definitions/formDefinitionTypes'
 import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinitionBySlug'
-import { baRjsfValidator } from 'forms-shared/form-utils/validators'
 
 import { CognitoGetUserData } from '../auth/dtos/cognito.dto'
 import verifyUserByEidToken from '../common/utils/city-account'
 import FilesService from '../files/files.service'
+import FormValidatorRegistryService from '../form-validator-registry/form-validator-registry.service'
 import { FormUpdateBodyDto } from '../forms/dtos/forms.requests.dto'
 import {
   FormsErrorsEnum,
@@ -56,6 +56,7 @@ export default class NasesService {
     private throwerErrorGuard: ThrowerErrorGuard,
     private readonly nasesUtilsService: NasesUtilsService,
     private readonly prisma: PrismaService,
+    private readonly formValidatorRegistryService: FormValidatorRegistryService,
   ) {
     this.logger = new Logger('NasesService')
   }
@@ -309,7 +310,10 @@ export default class NasesService {
       )
     }
 
-    const validationResult = baRjsfValidator.validateFormData(
+    const validator = this.formValidatorRegistryService
+      .getRegistry()
+      .getValidator(formDefinition.schemas.schema)
+    const validationResult = validator.validateFormData(
       form.formDataJson,
       formDefinition.schemas.schema,
     )
@@ -398,7 +402,10 @@ export default class NasesService {
       )
     }
 
-    const validationResult = baRjsfValidator.validateFormData(
+    const validator = this.formValidatorRegistryService
+      .getRegistry()
+      .getValidator(formDefinition.schemas.schema)
+    const validationResult = validator.validateFormData(
       form.formDataJson,
       formDefinition.schemas.schema,
     )

--- a/nest-forms-backend/src/utils/subservices/__test__/sharepoint.subservice.spec.ts
+++ b/nest-forms-backend/src/utils/subservices/__test__/sharepoint.subservice.spec.ts
@@ -1,3 +1,4 @@
+import { createMock } from '@golevelup/ts-jest'
 import { HttpException, HttpStatus } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
@@ -15,6 +16,7 @@ import * as getValuesForSharepoint from 'forms-shared/sharepoint/getValuesForSha
 import { SharepointDataAllColumnMappingsToFields } from 'forms-shared/sharepoint/types'
 
 import prismaMock from '../../../../test/singleton'
+import FormValidatorRegistryService from '../../../form-validator-registry/form-validator-registry.service'
 import PrismaService from '../../../prisma/prisma.service'
 import ThrowerErrorGuard from '../../guards/thrower-error.guard'
 import * as textHandler from '../../handlers/text.handler'
@@ -36,6 +38,10 @@ describe('SharepointSubservice', () => {
         ThrowerErrorGuard,
         { provide: PrismaService, useValue: prismaMock },
         { provide: ConfigService, useValue: configServiceMock },
+        {
+          provide: FormValidatorRegistryService,
+          useValue: createMock<FormValidatorRegistryService>(),
+        },
       ],
     }).compile()
 

--- a/nest-forms-backend/src/utils/subservices/sharepoint.subservice.ts
+++ b/nest-forms-backend/src/utils/subservices/sharepoint.subservice.ts
@@ -22,6 +22,7 @@ import {
 import { SharepointDataAllColumnMappingsToFields } from 'forms-shared/sharepoint/types'
 import { escape, get as lodashGet } from 'lodash'
 
+import FormValidatorRegistryService from '../../form-validator-registry/form-validator-registry.service'
 import {
   FormsErrorsEnum,
   FormsErrorsResponseEnum,
@@ -47,6 +48,7 @@ export default class SharepointSubservice {
     private throwerErrorGuard: ThrowerErrorGuard,
     private prismaService: PrismaService,
     private configService: ConfigService,
+    private formValidatorRegistryService: FormValidatorRegistryService,
   ) {
     this.logger = new Logger('SharepointSubservice')
 
@@ -210,6 +212,7 @@ export default class SharepointSubservice {
     const jsonDataExtraDataOmitted = omitExtraData(
       schemas.schema,
       form.formDataJson as GenericObjectType,
+      this.formValidatorRegistryService.getRegistry(),
     )
     const valuesForFields = getValuesForFields(
       sharepointData,

--- a/next/components/forms/FormPage.tsx
+++ b/next/components/forms/FormPage.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import MenuList from 'components/forms/steps/MenuList'
-import { baFormDefaults } from 'forms-shared/form-utils/formDefaults'
+import { getBaFormDefaults } from 'forms-shared/form-utils/formDefaults'
 import { useIsomorphicLayoutEffect } from 'usehooks-ts'
 
 import FormControls from './FormControls'
@@ -14,6 +14,7 @@ import { useFormContext } from './useFormContext'
 import { useFormData } from './useFormData'
 import { useFormErrorTranslations } from './useFormErrorTranslations'
 import { useFormState } from './useFormState'
+import { useFormValidatorRegistry } from './useFormValidatorRegistry'
 
 const FormPage = () => {
   const {
@@ -32,6 +33,7 @@ const FormPage = () => {
     handleFormOnChange,
     popScrollToFieldId,
   } = useFormState()
+  const validatorRegistry = useFormValidatorRegistry()
 
   const { transformErrors } = useFormErrorTranslations()
 
@@ -86,7 +88,7 @@ const FormPage = () => {
               liveOmit
               // HTML validation doesn't work for our use case, therefore it's turned off.
               noHtml5Validate
-              {...baFormDefaults}
+              {...getBaFormDefaults(currentStepSchema!, validatorRegistry)}
             >
               {
                 // returning null would make RJSF render the default submit button

--- a/next/components/forms/FormProviders.tsx
+++ b/next/components/forms/FormProviders.tsx
@@ -12,6 +12,7 @@ import { FormModalsProvider } from './useFormModals'
 import { FormRedirectsProvider } from './useFormRedirects'
 import { FormSendProvider } from './useFormSend'
 import { FormStateProvider } from './useFormState'
+import { FormValidatorRegistryProvider } from './useFormValidatorRegistry'
 
 type FormProvidersProps = {
   formServerContext: FormServerContext
@@ -19,29 +20,31 @@ type FormProvidersProps = {
 
 const FormProviders = ({ formServerContext, children }: PropsWithChildren<FormProvidersProps>) => {
   return (
-    <FormContextProvider formServerContext={formServerContext}>
-      <FormFileUploadProvider>
-        <FormLeaveProtectionProvider>
-          <FormModalsProvider>
-            <FormSignerLoaderProvider>
-              <FormDataProvider>
-                <FormStateProvider>
-                  <FormSignatureProvider>
-                    <FormRedirectsProvider>
-                      <FormSummaryProvider>
-                        <FormSendProvider>
-                          <FormExportImportProvider>{children}</FormExportImportProvider>
-                        </FormSendProvider>
-                      </FormSummaryProvider>
-                    </FormRedirectsProvider>
-                  </FormSignatureProvider>
-                </FormStateProvider>
-              </FormDataProvider>
-            </FormSignerLoaderProvider>
-          </FormModalsProvider>
-        </FormLeaveProtectionProvider>
-      </FormFileUploadProvider>
-    </FormContextProvider>
+    <FormValidatorRegistryProvider>
+      <FormContextProvider formServerContext={formServerContext}>
+        <FormFileUploadProvider>
+          <FormLeaveProtectionProvider>
+            <FormModalsProvider>
+              <FormSignerLoaderProvider>
+                <FormDataProvider>
+                  <FormStateProvider>
+                    <FormSignatureProvider>
+                      <FormRedirectsProvider>
+                        <FormSummaryProvider>
+                          <FormSendProvider>
+                            <FormExportImportProvider>{children}</FormExportImportProvider>
+                          </FormSendProvider>
+                        </FormSummaryProvider>
+                      </FormRedirectsProvider>
+                    </FormSignatureProvider>
+                  </FormStateProvider>
+                </FormDataProvider>
+              </FormSignerLoaderProvider>
+            </FormModalsProvider>
+          </FormLeaveProtectionProvider>
+        </FormFileUploadProvider>
+      </FormContextProvider>
+    </FormValidatorRegistryProvider>
   )
 }
 

--- a/next/components/forms/steps/Summary/SummaryDetails.tsx
+++ b/next/components/forms/steps/Summary/SummaryDetails.tsx
@@ -17,6 +17,7 @@ import { useIsClient } from 'usehooks-ts'
 
 import { useFormContext } from '../../useFormContext'
 import { useFormState } from '../../useFormState'
+import { useFormValidatorRegistry } from '../../useFormValidatorRegistry'
 import SummaryFile from './SummaryFile'
 import SummaryRow from './SummaryRow'
 import { useFormSummary } from './useFormSummary'
@@ -145,7 +146,9 @@ const SummaryDetails = () => {
     },
     initialSummaryJson,
   } = useFormContext()
+  const validatorRegistry = useFormValidatorRegistry()
   const isClient = useIsClient()
+
   const summaryJson = useMemo(() => {
     if (!isClient) {
       // Node needs to use a different method to get the summary JSON (see `getSummaryJsonNode`).
@@ -153,8 +156,8 @@ const SummaryDetails = () => {
       return initialSummaryJson
     }
 
-    return getSummaryJsonBrowser(schema, uiSchema, formData)
-  }, [isClient, initialSummaryJson, schema, uiSchema, formData])
+    return getSummaryJsonBrowser(schema, uiSchema, formData, validatorRegistry)
+  }, [isClient, initialSummaryJson, schema, uiSchema, formData, validatorRegistry])
 
   if (!summaryJson) {
     return null

--- a/next/components/forms/steps/Summary/useFormSummary.tsx
+++ b/next/components/forms/steps/Summary/useFormSummary.tsx
@@ -16,6 +16,7 @@ import { environment } from '../../../../environment'
 import { useFormContext } from '../../useFormContext'
 import { useFormFileUpload } from '../../useFormFileUpload'
 import { useFormState } from '../../useFormState'
+import { useFormValidatorRegistry } from '../../useFormValidatorRegistry'
 
 const memoizedValidateSummary = memoizeOne(validateSummary)
 
@@ -41,6 +42,7 @@ const useGetContext = () => {
   } = useFormContext()
   const { formData } = useFormData()
   const { currentStepIndex } = useFormState()
+  const validatorRegistry = useFormValidatorRegistry()
 
   const { clientFiles, serverFiles } = useFormFileUpload()
   // Don't use directly!
@@ -67,9 +69,9 @@ const useGetContext = () => {
         throw new Error('getValidatedSummary should never be called on a form step')
       }
 
-      return memoizedValidateSummary(schema, formData, fileInfos)
+      return memoizedValidateSummary(schema, formData, fileInfos, validatorRegistry)
     },
-    [formData, schema, fileInfos, currentStepIndex],
+    [formData, schema, fileInfos, currentStepIndex, validatorRegistry],
   )
 
   const getInfectedFiles = useCreateGetFilesByStatusType(

--- a/next/components/forms/useFormValidatorRegistry.tsx
+++ b/next/components/forms/useFormValidatorRegistry.tsx
@@ -1,0 +1,33 @@
+import { createWeakMapRegistry } from 'forms-shared/form-utils/validatorRegistry'
+import { createContext, PropsWithChildren, useContext, useState } from 'react'
+
+const useGetContext = () => {
+  // Safe way how to create a validator registry instance, similar to:
+  // https://tanstack.com/query/v4/docs/framework/react/guides/ssr#using-hydration
+  const [validator] = useState(() => createWeakMapRegistry())
+
+  return { validator }
+}
+
+const FormValidatorRegistryContext = createContext<ReturnType<typeof useGetContext> | undefined>(
+  undefined,
+)
+
+export const FormValidatorRegistryProvider = ({ children }: PropsWithChildren) => {
+  const context = useGetContext()
+
+  return (
+    <FormValidatorRegistryContext.Provider value={context}>
+      {children}
+    </FormValidatorRegistryContext.Provider>
+  )
+}
+
+export const useFormValidatorRegistry = () => {
+  const context = useContext(FormValidatorRegistryContext)
+  if (!context) {
+    throw new Error('useFormValidatorRegistry must be used within a FormValidatorRegistryProvider')
+  }
+
+  return context.validator
+}

--- a/next/components/forms/widget-wrappers/InputWidgetRJSF.tsx
+++ b/next/components/forms/widget-wrappers/InputWidgetRJSF.tsx
@@ -4,8 +4,6 @@ import WidgetWrapper from 'components/forms/widget-wrappers/WidgetWrapper'
 import { InputUiOptions } from 'forms-shared/generator/uiOptionsTypes'
 import React from 'react'
 
-import FieldBlurWrapper from '../widget-components/FieldBlurWrapper/FieldBlurWrapper'
-
 interface InputWidgetRJSFProps extends WidgetProps {
   options: InputUiOptions
   value: string | undefined
@@ -49,33 +47,28 @@ const InputWidgetRJSF = ({
 
   return (
     <WidgetWrapper id={id} options={options}>
-      <FieldBlurWrapper value={value} onChange={handleOnChange}>
-        {({ value: wrapperValue, onChange: wrapperOnChange, onBlur }) => (
-          <InputField
-            name={name}
-            label={label}
-            type={inputType}
-            placeholder={placeholder}
-            value={wrapperValue ?? undefined}
-            errorMessage={rawErrors}
-            required={required}
-            disabled={disabled || readonly}
-            helptext={helptext}
-            helptextMarkdown={helptextMarkdown}
-            helptextFooter={helptextFooter}
-            helptextFooterMarkdown={helptextFooterMarkdown}
-            tooltip={tooltip}
-            className={className}
-            resetIcon={resetIcon}
-            leftIcon={leftIcon}
-            onChange={wrapperOnChange}
-            onBlur={onBlur}
-            size={size}
-            labelSize={labelSize}
-            displayOptionalLabel
-          />
-        )}
-      </FieldBlurWrapper>
+      <InputField
+        name={name}
+        label={label}
+        type={inputType}
+        placeholder={placeholder}
+        value={value ?? undefined}
+        errorMessage={rawErrors}
+        required={required}
+        disabled={disabled || readonly}
+        helptext={helptext}
+        helptextMarkdown={helptextMarkdown}
+        helptextFooter={helptextFooter}
+        helptextFooterMarkdown={helptextFooterMarkdown}
+        tooltip={tooltip}
+        className={className}
+        resetIcon={resetIcon}
+        leftIcon={leftIcon}
+        onChange={handleOnChange}
+        size={size}
+        labelSize={labelSize}
+        displayOptionalLabel
+      />
     </WidgetWrapper>
   )
 }

--- a/next/frontend/utils/getDefaultFormDataForFormDefinition.ts
+++ b/next/frontend/utils/getDefaultFormDataForFormDefinition.ts
@@ -1,6 +1,9 @@
 import { FormDefinition } from 'forms-shared/definitions/formDefinitionTypes'
 import { baGetDefaultFormStateStable } from 'forms-shared/form-utils/defaultFormState'
+import { createSingleUseValidatorRegistry } from 'forms-shared/form-utils/validatorRegistry'
 import memoize from 'lodash/memoize'
+
+const validatorRegistry = createSingleUseValidatorRegistry()
 
 /**
  * Returns default form data for the given form definition.
@@ -8,5 +11,5 @@ import memoize from 'lodash/memoize'
  * It is expensive to compute, so it is memoized.
  */
 export const getDefaultFormDataForFormDefinition = memoize((formDefinition: FormDefinition) =>
-  baGetDefaultFormStateStable(formDefinition.schemas.schema, {}),
+  baGetDefaultFormStateStable(formDefinition.schemas.schema, {}, validatorRegistry),
 )

--- a/next/frontend/utils/getInitialSummaryJson.ts
+++ b/next/frontend/utils/getInitialSummaryJson.ts
@@ -2,10 +2,13 @@ import { ParsedUrlQuery } from 'node:querystring'
 
 import { GenericObjectType } from '@rjsf/utils'
 import { FormDefinition } from 'forms-shared/definitions/formDefinitionTypes'
+import { createSingleUseValidatorRegistry } from 'forms-shared/form-utils/validatorRegistry'
 import { getSummaryJsonNode } from 'forms-shared/summary-json/getSummaryJsonNode'
 
 import { STEP_QUERY_PARAM_KEY } from '../../components/forms/useFormCurrentStepIndex'
 import { STEP_QUERY_PARAM_VALUE_SUMMARY } from './formState'
+
+const validatorRegistry = createSingleUseValidatorRegistry()
 
 export const getInitialSummaryJson = (
   query: ParsedUrlQuery,
@@ -21,5 +24,6 @@ export const getInitialSummaryJson = (
     formDefinition.schemas.schema,
     formDefinition.schemas.uiSchema,
     formData,
+    validatorRegistry,
   )
 }

--- a/tests/cypress/e2e/form/formRegistrationRedirect-mobile.cy.ts
+++ b/tests/cypress/e2e/form/formRegistrationRedirect-mobile.cy.ts
@@ -56,10 +56,7 @@ describe('F04 -', { testIsolation: false }, () => {
 
             cy.wrap(Cypress.$('[data-cy=input-telefon]', form)).type(this.fileData.phone_number)
 
-            // TODO - Continue button needs to be clicked twice to work. After first click, phone validation shows false error.
-            cy.wrap(Cypress.$(`[data-cy=continue-button-${device}]`, form))
-              .click()
-              .click()
+            cy.wrap(Cypress.$(`[data-cy=continue-button-${device}]`, form)).click()
           })
         })
 

--- a/tests/cypress/e2e/form/formRegistrationRedirect.cy.ts
+++ b/tests/cypress/e2e/form/formRegistrationRedirect.cy.ts
@@ -61,10 +61,7 @@ describe('F04 -', { testIsolation: false }, () => {
 
             cy.wrap(Cypress.$('[data-cy=input-telefon]', form)).type(this.fileData.phone_number)
 
-            // TODO - Continue button needs to be clicked twice to work. After first click, phone validation shows false error.
-            cy.wrap(Cypress.$(`[data-cy=continue-button-${device}]`, form))
-              .click()
-              .click()
+            cy.wrap(Cypress.$(`[data-cy=continue-button-${device}]`, form)).click()
           })
         })
 

--- a/tests/cypress/e2e/form/formSIZ.cy.ts
+++ b/tests/cypress/e2e/form/formSIZ.cy.ts
@@ -66,10 +66,7 @@ describe('F01 -', { testIsolation: false }, () => {
             cy.wrap(Cypress.$('[data-cy=input-telefon]', form)).focus().clear()
             cy.wrap(Cypress.$('[data-cy=input-telefon]', form)).type(this.fileData.phone_number)
 
-            // TODO - Continue button needs to be clicked twice to work. After first click, phone validation shows false error.
-            cy.wrap(Cypress.$(`[data-cy=continue-button-${device}]`, form))
-              .click()
-              .click()
+            cy.wrap(Cypress.$(`[data-cy=continue-button-${device}]`, form)).click()
           })
         })
 

--- a/tests/cypress/e2e/form/formSIZ.cy.ts
+++ b/tests/cypress/e2e/form/formSIZ.cy.ts
@@ -102,8 +102,11 @@ describe('F01 -', { testIsolation: false }, () => {
             )
 
             cy.checkFormValidation(device, form, 4, designerErrorBorderFields)
+          })
+          cy.dataCy('form-container').then((form) => {
             cy.wrap(Cypress.$('[data-cy=error-message]', form)).should('have.length', 5)
           })
+
           cy.dataCy('form-container').should('be.visible') //.matchImage()
         })
 

--- a/tests/cypress/e2e/form/formZSIZ.cy.ts
+++ b/tests/cypress/e2e/form/formZSIZ.cy.ts
@@ -101,6 +101,8 @@ describe('F02 -', { testIsolation: false }, () => {
             )
 
             cy.checkFormValidation(device, form, 4, designerErrorBorderFields)
+          })
+          cy.dataCy('form-container').then((form) => {
             cy.wrap(Cypress.$('[data-cy=error-message]', form)).should('have.length', 5)
           })
           cy.dataCy('form-container').should('be.visible') //.matchImage()

--- a/tests/cypress/e2e/form/formZSIZ.cy.ts
+++ b/tests/cypress/e2e/form/formZSIZ.cy.ts
@@ -65,8 +65,6 @@ describe('F02 -', { testIsolation: false }, () => {
             cy.wrap(Cypress.$('[data-cy=input-telefon]', form)).focus().clear()
             cy.wrap(Cypress.$('[data-cy=input-telefon]', form)).type(this.fileData.phone_number)
 
-            // TODO - Continue button needs to be clicked twice to work. After first click, phone validation shows false error.
-            cy.wrap(Cypress.$(`[data-cy=continue-button-${device}]`, form)).click()
             cy.wrap(Cypress.$(`[data-cy=continue-button-${device}]`, form)).click()
           })
         })


### PR DESCRIPTION
I've implemented a validator registry pattern to address significant performance issues with RJSF's validator handling. Previously, we used a single shared validator instance across the application, which became a bottleneck due to how RJSF handles schema validation internally.

The core issue stems from RJSF's `handleSchemaUpdate` mechanism, which is called on every validation. This process compiles the schema through Ajv's `addSchema` - both when encountering a new schema and when detecting schema changes through deep comparison. On the frontend, where we validate multiple different schemas frequently, this led to constant recompilations between validations, significantly impacting performance.

The solution introduces two registry implementations tailored for different use cases. For frontend, the `WeakMapRegistry` caches validators by schema reference, preventing unnecessary recompilations of the same schema while using WeakMap for proper garbage collection. For backend, where state isolation is more critical than performance, the `SingleUseValidatorRegistry` creates a fresh validator instance for each validation.

Changing the value of any field:
Before (showing multiple expensive schema compilations):
![image](https://github.com/user-attachments/assets/aaf7efea-4508-4214-abd5-9f1924285513)

After (showing cached schema usage):
![image](https://github.com/user-attachments/assets/c0cd91d4-886c-4315-8f16-67601b407bd3)

The implementation includes comprehensive tests that verify both the caching behavior and the actual reduction in schema compilations by monitoring Ajv's `addSchema` calls. This ensures we maintain correct validation behavior while significantly improving frontend performance.

This change is part of our ongoing effort to optimize form rendering performance, particularly for complex forms with conditional fields where validation happens frequently.


I considered making `validatorRegistry` optional with a default `singleUseValidatorRegistry` like this:
```
validatorRegistry: BaRjsfValidatorRegistry = singleUseValidatorRegistry,
```
but decided against it. While it would reduce boilerplate in simple cases, it could lead to subtle issues when the parameter is passed through multiple levels of function calls. If not handled correctly at every level, it might silently fall back to `singleUseValidatorRegistry` even in frontend code where we want to use `WeakMapRegistry` for performance. Making it required forces explicit registry choice and prevents accidental performance regressions or unwanted behavior changes.