### PR TITLE
useIsSSR instead of useIsClient

### DIFF
--- a/next/components/forms/signer/useFormSignature.tsx
+++ b/next/components/forms/signer/useFormSignature.tsx
@@ -12,7 +12,8 @@ import React, {
   useEffect,
   useState,
 } from 'react'
-import { useIsClient, useIsMounted } from 'usehooks-ts'
+import { useIsSSR } from 'react-aria'
+import { useIsMounted } from 'usehooks-ts'
 
 import useSnackbar from '../../../frontend/hooks/useSnackbar'
 import { createFormSignatureId } from '../../../frontend/utils/formSignature'
@@ -66,7 +67,7 @@ const useGetContext = () => {
   const isMounted = useIsMounted()
 
   const [showSignatureInConsole, setShowSignatureInConsole] = useState(false)
-  const isClient = useIsClient()
+  const isSSR = useIsSSR()
 
   const handleSignatureChange = (newSignature: FormSignature | null) => {
     setSignature(newSignature)
@@ -75,11 +76,11 @@ const useGetContext = () => {
 
   useEffect(() => {
     // Dev only debugging feature
-    if (isClient) {
+    if (!isSSR) {
       // eslint-disable-next-line no-underscore-dangle
       window.__DEV_SHOW_SIGNATURE = () => setShowSignatureInConsole(true)
     }
-  }, [isClient, setShowSignatureInConsole])
+  }, [isSSR, setShowSignatureInConsole])
 
   const signData = async (
     formDataRequest: GenericObjectType,

--- a/next/components/forms/steps/Summary/SummaryDetails.tsx
+++ b/next/components/forms/steps/Summary/SummaryDetails.tsx
@@ -13,7 +13,7 @@ import {
 } from 'forms-shared/summary-renderer/SummaryRenderer'
 import { useTranslation } from 'next-i18next'
 import React, { useMemo } from 'react'
-import { useIsClient } from 'usehooks-ts'
+import { useIsSSR } from 'react-aria'
 
 import { useFormContext } from '../../useFormContext'
 import { useFormState } from '../../useFormState'
@@ -147,17 +147,17 @@ const SummaryDetails = () => {
     initialSummaryJson,
   } = useFormContext()
   const validatorRegistry = useFormValidatorRegistry()
-  const isClient = useIsClient()
+  const isSSR = useIsSSR()
 
   const summaryJson = useMemo(() => {
-    if (!isClient) {
+    if (isSSR) {
       // Node needs to use a different method to get the summary JSON (see `getSummaryJsonNode`).
       // No need to check if schema/formData matches the summary JSON as it is rendered only once on the server.
       return initialSummaryJson
     }
 
     return getSummaryJsonBrowser(schema, uiSchema, formData, validatorRegistry)
-  }, [isClient, initialSummaryJson, schema, uiSchema, formData, validatorRegistry])
+  }, [isSSR, initialSummaryJson, schema, uiSchema, formData, validatorRegistry])
 
   if (!summaryJson) {
     return null

--- a/next/components/forms/useFormContext.tsx
+++ b/next/components/forms/useFormContext.tsx
@@ -8,7 +8,7 @@ import {
 import { ClientFileInfo } from 'forms-shared/form-files/fileStatus'
 import { SummaryJsonForm } from 'forms-shared/summary-json/summaryJsonTypes'
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
-import { useIsClient } from 'usehooks-ts'
+import { useIsSSR } from 'react-aria'
 
 import { useSsrAuth } from '../../frontend/hooks/useSsrAuth'
 import { SerializableFormDefinition } from './serializableFormDefinition'
@@ -36,7 +36,7 @@ export type FormServerContext = {
 }
 
 const useGetContext = (formServerContext: FormServerContext) => {
-  const isClient = useIsClient()
+  const isSSR = useIsSSR()
   const { isSignedIn, tierStatus } = useSsrAuth()
   const { eIdTaxFormAllowed } = useSsrAuth()
 
@@ -69,11 +69,11 @@ const useGetContext = (formServerContext: FormServerContext) => {
 
   useEffect(() => {
     // Dev only debugging feature
-    if (isClient) {
+    if (!isSSR) {
       // eslint-disable-next-line no-underscore-dangle
       window.__DEV_ALLOW_IMPORT_EXPORT_JSON = () => setJsonImportExportAllowed(true)
     }
-  }, [isClient, setJsonImportExportAllowed])
+  }, [isSSR, setJsonImportExportAllowed])
 
   const isReadonly = formMigrationRequired || formSent
   const isDeletable = formMigrationRequired && !formSent


### PR DESCRIPTION
Causes flickering of form summary because it relies on `useEffect` - https://usehooks-ts.com/react-hook/use-is-client. Use [much better](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/ssr/src/SSRProvider.tsx) `useIsSSR` instead.