### PR TITLE
Open only security dependabot PRs in next

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     directory: '/next'
     schedule:
       interval: 'weekly'
+    # Open only security updates https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+    open-pull-requests-limit: 0
   - package-ecosystem: 'npm'
     directory: '/nest-forms-backend'
     schedule:


### PR DESCRIPTION
Turns off dependabot alerts for the next package, should open only security updates (as mentioned in [github documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit))