### PR TITLE
.env.example and docker-compose updates for local nest-forms development

### DIFF
--- a/nest-forms-backend/.env.example
+++ b/nest-forms-backend/.env.example
@@ -18,7 +18,7 @@ NODE_ENV=development
 
 # services accessible from outside of our cluster (can be reused in local development)
 # USER_ACCOUNT_API should match you cognito settings below (use staging if you are usign the defaults from .env.example)
-USER_ACCOUNT_API="https://nest-city-account.staging.bratislava.sk/"
+USER_ACCOUNT_API="https://nest-city-account.staging.bratislava.sk"
 SLOVENSKO_SK_CONTAINER_URI="https://fix.slovensko-sk-api.bratislava.sk"
 
 # postgres

--- a/nest-forms-backend/.env.example
+++ b/nest-forms-backend/.env.example
@@ -1,89 +1,93 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
+# Example setup for local development
+# Key takeaways:
+# - should get you up and running, with the ability to send NASES forms to fix environment
+# - the postgres, redis and rabbitmq credentials are set to match docker-compose
+# - MINIO_UNSCANNED_BUCKET & MINIO_SAFE_BUCKET are the same - this allows you to skip virus-scanning services and update the file status from UPLOADED to SAFE directly in db
 
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB (Preview).
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-# minio
-MINIO_ACCESS_KEY=acceskey
-MINIO_ENDPOINT=cdn-api.bratislava.sk
-MINIO_HOST=cdn-api.bratislava.sk:443
-MINIO_PORT=443
-MINIO_SECRET_KEY=secretkey
-MINIO_USE_SSL=true
-MINIO_UNSCANNED_BUCKET=calmav-unscanned-bucket
-MINIO_SAFE_BUCKET=calmav-clean-bucket
-MINIO_INFECTED_BUCKET=calmav-quarantined-bucket
+# Get the following secrets from team before starting development:
+# - MINIO_SECRET_KEY
+# - AWS_COGNITO_ACCESS
+# - AWS_COGNITO_SECRET
+# - API_TOKEN_PRIVATE
+# - OBO_TOKEN_PUBLIC
 
-# cognito
-AWS_COGNITO_ACCESS=banana
-AWS_COGNITO_CLIENT_ID=banana
-AWS_COGNITO_REGION=eu-central-1
-AWS_COGNITO_SECRET=banana
-AWS_COGNITO_USERPOOL_ID=banana
+# Get the other omitted secrets as needed when developing specific forms or subservices
+
+PORT=3100
+NODE_ENV=development
+
+# services accessible from outside of our cluster (can be reused in local development)
+# USER_ACCOUNT_API should match you cognito settings below (use staging if you are usign the defaults from .env.example)
+USER_ACCOUNT_API="https://nest-city-account.staging.bratislava.sk/"
+SLOVENSKO_SK_CONTAINER_URI="https://fix.slovensko-sk-api.bratislava.sk"
 
 # postgres
-POSTGRES_USER=forms
-POSTGRES_PASSWORD=password
-POSTGRES_DB=forms
-DATABASE_URL="postgresql://forms:password@localhost:5432/forms?connect_timeout=30&schema=public"
+DATABASE_URL="postgresql://forms:password@localhost:54321/forms?schema=public&connect_timeout=30"
 
-# ginis
+# minio
+MINIO_ACCESS_KEY=forms-dev
+MINIO_ENDPOINT=s3.bratislava.sk
+MINIO_HOST=s3.bratislava.sk:443
+MINIO_PORT=443
+MINIO_SECRET_KEY=secret
+MINIO_USE_SSL=true
+MINIO_UNSCANNED_BUCKET=forms-dev-uploaded
+MINIO_SAFE_BUCKET=forms-dev-uploaded
+MINIO_INFECTED_BUCKET=forms-dev-infected
+
+# cognito
+AWS_COGNITO_USERPOOL_ID=eu-central-1_FZDV0j2ZK
+AWS_COGNITO_CLIENT_ID=1pdeai19927kshpgikd6l1ptc6
+AWS_COGNITO_REGION=eu-central-1
+AWS_COGNITO_ACCESS=secret
+AWS_COGNITO_SECRET=secret
+
+# ginis - used to update status of forms past the PROCESSING stage (not needed in local development)
 GINIS_USERNAME=secret
 GINIS_PASSWORD=secret
 GINIS_SSL_HOST=http://172.25.1.195/gordic/ginis/ws/SSL01_BRA/Ssl.svc
 GINIS_GIN_HOST=http://172.25.1.195/gordic/ginis/ws/GIN01_BRA/Gin.svc
 
 # rabbitmq
-RABBIT_MQ_URI=amqp://guest:guest@localhost:5672
+RABBIT_MQ_URI=amqp://guest:guest@localhost:5611
 
 # nases
-API_TOKEN_PRIVATE="banana"
-OBO_TOKEN_PUBLIC="banana"
-NASES_RECIPIENT_ID=banana
-NASES_RECIPIENT_URI=banana
-NASES_SENDER_URI=banana
-SUB_NASES_TECHNICAL_ACCOUNT=banana
+API_TOKEN_PRIVATE="secret"
+OBO_TOKEN_PUBLIC="secret"
+NASES_RECIPIENT_ID=e264cea1-acdc-4db0-8901-275d15b1f48a
+NASES_RECIPIENT_URI=ico://sk/00603481
+NASES_SENDER_URI=ico://sk/83369848
+SUB_NASES_TECHNICAL_ACCOUNT=eba_83369848
 
-# other settings
-PORT=3000
-NODE_ENV=development
+# settings related to virus scanning, update if you run clamav locally
 NEST_CLAMAV_SCANNER=nest-clamav-scanner-url
 NEST_CLAMAV_SCANNER_USERNAME=user
 NEST_CLAMAV_SCANNER_PASSWORD=pass
 NEST_FORMS_BACKEND_USERNAME=user
 NEST_FORMS_BACKEND_PASSWORD=pass
-JWT_SECRET=randomstring
 
+# mailgun settings - optional for local development
+MAILGUN_API_KEY=fake
+MAILGUN_HOST=fake
+MAILGUN_EMAIL_FROM=fake
+MAILGUN_DOMAIN=fake
+
+# Misc
 # Keep both in sync with https://github.com/bratislava/konto.bratislava.sk/ env variables
 #mimetype whitelist
 MIMETYPE_WHITELIST="application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed"
 # max file size 500MB
 MAX_FILE_SIZE=524288000
-
-USER_ACCOUNT_API="https://nest-city-account.bratislava.sk/"
-SLOVENSKO_SK_CONTAINER_URI="https://fix.slovensko-sk-api.bratislava.sk"
-
-FOP_BRATISLAVA_API="https://fop.dev.bratislava.sk"
-
-RABBIT_MQ_USERNAME=""
-RABBIT_MQ_PASSWORD=""
-RABBIT_MQ_PORT=""
-RABBIT_MQ_HOST=""
-
-RABBIT_MQ_GINIS_USERNAME=""
-RABBIT_MQ_GINIS_PASSWORD=""
-RABBIT_MQ_GINIS_PORT=""
-RABBIT_MQ_GINIS_HOST=""
-
 ADMIN_APP_SECRET=""
 
-MAILGUN_API_KEY=""
-MAILGUN_DOMAIN=""
-MAILGUN_HOST=""
-MAILGUN_EMAIL_FROM=""
+### The rest of these settings are only needed for specific forms ###
 
+# used primarily in email/webhook forms flow
 FRONTEND_URL=https://city-account-next.staging.bratislava.sk
 SELF_URL=https://nest-forms-backend.staging.bratislava.sk
+
+# used in signing file urls (i.e. sent in email forms)
+JWT_SECRET=randomstring
 
 # this bucket exists on cdn.bratislava.sk (the prod/staging ones are on s3.bratislava.sk)
 TAX_PDF_DEBUG_BUCKET=forms-tax-debug
@@ -92,16 +96,18 @@ TAX_PDF_DEBUG_BUCKET=forms-tax-debug
 REDIS_USER=default
 REDIS_PASSWORD=""
 REDIS_SERVICE=localhost
-REDIS_PORT=6379
+REDIS_PORT=6311
 TAX_PDF_JOB_CONCURRENCY=2
 TAX_PDF_JOB_TIMEOUT=30000
 
+# used for forms sent to sharepoint tables / powerapps automation after they are sent to NASES (najomne byvanie)
 SHAREPOINT_CLIENT_ID=banana
 SHAREPOINT_CLIENT_SECRET=banana
 SHAREPOINT_TENANT_ID=banana
 SHAREPOINT_DOMAIN=banana
 SHAREPOINT_URL=banana
 
+# OLO has their own SMTP server, which is used for their email forms
 OLO_SMTP_USERNAME=banana
 OLO_SMTP_PASSWORD=banana
 OLO_FRONTEND_URL=https://www.olo.sk

--- a/nest-forms-backend/docker-compose.yml
+++ b/nest-forms-backend/docker-compose.yml
@@ -1,3 +1,6 @@
+# Should be run alongside local npm run start:dev
+# Ports are set to match .env.example and not to conflict with other konto.bratislava.sk services
+
 version: '3.8'
 services:
   postgres:
@@ -6,19 +9,17 @@ services:
       POSTGRES_USER: forms
       POSTGRES_PASSWORD: password
       POSTGRES_DB: forms
-      PGPORT: 5432
-    expose:
-      - '5432'
+      PGPORT: 54321
     ports:
-      - '127.0.0.1:5432:5432'
+      - '127.0.0.1:54321:54321'
 
   rabbitmq:
     image: heidiks/rabbitmq-delayed-message-exchange:latest
     container_name: 'rabbitmq'
     restart: always
     ports:
-      - 5672:5672
-      - 15672:15672
+      - 5611:5672
+      - 15611:15672
     volumes:
       - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
       - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq
@@ -28,4 +29,4 @@ services:
     container_name: 'tax_pdf_redis'
     restart: always
     ports:
-      - 6379:6379
+      - 6311:6379

--- a/nest-forms-backend/package.json
+++ b/nest-forms-backend/package.json
@@ -158,5 +158,9 @@
     "testPathIgnorePatterns": [
       "<rootDir>/nases/__tests__"
     ]
+  },
+  "volta": {
+    "node": "20.9.0",
+    "npm": "10.7.0"
   }
 }


### PR DESCRIPTION
- update docker-compose so that ports don't collide with setups for other projects (planning to do something similar for other nest-* services in this repo as well)
- update .env.example to contain everything needed for sending forms from local dev to fix NASES apart from few secrets, listed on top of the file. Match ports used in docker-compose
- add missing volta config in nest-forms-backend