### PR TITLE
Endpoint for changing delivery methods in tax backend

### DIFF
--- a/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
+++ b/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
@@ -3,10 +3,12 @@ import { Test, TestingModule } from '@nestjs/testing'
 
 import { BloomreachService } from '../../bloomreach/bloomreach.service'
 import { NorisService } from '../../noris/noris.service'
+import { DeliveryMethod, IsInCityAccount } from '../../noris/noris.types'
 import { PrismaService } from '../../prisma/prisma.service'
 import { CityAccountSubservice } from '../../utils/subservices/cityaccount.subservice'
 import { QrCodeSubservice } from '../../utils/subservices/qrcode.subservice'
 import { AdminService } from '../admin.service'
+import { RequestUpdateNorisDeliveryMethodsData } from '../dtos/requests.dto'
 
 describe('TasksService', () => {
   let service: AdminService
@@ -36,39 +38,170 @@ describe('TasksService', () => {
     expect(service).toBeDefined()
   })
 
-  describe('createTaxPayers', () => {
-    it('should correctly check in database and add new', async () => {
-      service['prismaService'].taxPayer.findMany = jest
-        .fn()
-        .mockResolvedValue([
-          { birthNumber: '000000/0001' },
-          { birthNumber: '000000/0002' },
-        ])
+  // eslint-disable-next-line no-secrets/no-secrets
+  describe('updateDeliveryMethodsInNoris', () => {
+    const mockDate1 = '2024-01-01'
+    const mockDate2 = '2024-01-02'
 
-      const spy = jest
-        .spyOn(service, 'loadDataFromNoris')
-        .mockResolvedValue({ birthNumbers: ['000000/0003', '000000/0004'] })
+    it('should correctly group and update delivery methods', async () => {
+      const mockData: RequestUpdateNorisDeliveryMethodsData = {
+        '123456/789': { deliveryMethod: DeliveryMethod.EDESK },
+        '234567/890': { deliveryMethod: DeliveryMethod.EDESK },
+        '345678/901': { deliveryMethod: DeliveryMethod.POSTAL },
+        '345678/902': { deliveryMethod: DeliveryMethod.POSTAL },
+        '456789/0123': {
+          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+          date: mockDate1,
+        },
+        '456789/0103': {
+          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+          date: mockDate2,
+        },
+      }
 
-      const result = await service.createTaxPayers([
-        '000000/0001',
-        '000000/0002',
-        '000000/0003',
-        '000000/0004',
-        '000000/0005',
-      ])
-
-      expect(result).toEqual({
-        birthNumbers: [
-          '000000/0001',
-          '000000/0002',
-          '000000/0003',
-          '000000/0004',
-        ],
+      await service.updateDeliveryMethodsInNoris({
+        data: mockData,
       })
-      expect(spy).toHaveBeenCalledWith({
-        birthNumbers: ['000000/0003', '000000/0004', '000000/0005'],
-        year: new Date().getFullYear(),
+
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledTimes(4)
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledWith({
+        birthNumbers: ['123456/789', '234567/890'],
+        inCityAccount: IsInCityAccount.YES,
+        deliveryMethod: DeliveryMethod.EDESK,
+        date: null,
       })
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledWith({
+        birthNumbers: ['345678/901', '345678/902'],
+        inCityAccount: IsInCityAccount.YES,
+        deliveryMethod: DeliveryMethod.POSTAL,
+        date: null,
+      })
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledWith({
+        birthNumbers: ['456789/0123'],
+        inCityAccount: IsInCityAccount.YES,
+        deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+        date: mockDate1,
+      })
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledWith({
+        birthNumbers: ['456789/0103'],
+        inCityAccount: IsInCityAccount.YES,
+        deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+        date: mockDate2,
+      })
+    })
+
+    it('should skip empty groups', async () => {
+      const mockData: RequestUpdateNorisDeliveryMethodsData = {
+        '001234/567': { deliveryMethod: DeliveryMethod.EDESK },
+        '000123/890': { deliveryMethod: DeliveryMethod.EDESK },
+      }
+
+      await service.updateDeliveryMethodsInNoris({
+        data: mockData,
+      })
+
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledTimes(1)
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledWith({
+        birthNumbers: ['001234/567', '000123/890'],
+        inCityAccount: IsInCityAccount.YES,
+        deliveryMethod: DeliveryMethod.EDESK,
+        date: null,
+      })
+    })
+
+    it('should handle empty input data', async () => {
+      await service.updateDeliveryMethodsInNoris({ data: {} })
+
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should handle invalid delivery methods', async () => {
+      const mockData: RequestUpdateNorisDeliveryMethodsData = {
+        '012345/678': { deliveryMethod: 'INVALID' as DeliveryMethod.POSTAL }, // Just to make TS happy
+        '123456/789': { deliveryMethod: DeliveryMethod.EDESK },
+      }
+
+      await service.updateDeliveryMethodsInNoris({
+        data: mockData,
+      })
+
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledTimes(1)
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledWith({
+        birthNumbers: ['123456/789'],
+        inCityAccount: IsInCityAccount.YES,
+        deliveryMethod: DeliveryMethod.EDESK,
+        date: null,
+      })
+    })
+
+    it('should propagate errors from norisService', async () => {
+      const mockError = new Error('Update failed')
+      jest
+        .spyOn(service['norisService'], 'updateDeliveryMethods')
+        .mockRejectedValueOnce(mockError)
+
+      const mockData: RequestUpdateNorisDeliveryMethodsData = {
+        '000123/456': { deliveryMethod: DeliveryMethod.EDESK },
+      }
+
+      await expect(
+        service.updateDeliveryMethodsInNoris({
+          data: mockData,
+        }),
+      ).rejects.toThrow(mockError)
+    })
+  })
+
+  describe('removeDeliveryMethodsFromNoris', () => {
+    it('should call updateDeliveryMethods with correct parameters', async () => {
+      const birthNumber = '123456/789'
+
+      await service.removeDeliveryMethodsFromNoris(birthNumber)
+
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledTimes(1)
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).toHaveBeenCalledWith({
+        birthNumbers: [birthNumber],
+        inCityAccount: IsInCityAccount.NO,
+        deliveryMethod: null,
+        date: null,
+      })
+    })
+
+    it('should propagate errors from norisService', async () => {
+      const birthNumber = '123456/789'
+      const mockError = new Error('Update failed')
+
+      jest
+        .spyOn(service['norisService'], 'updateDeliveryMethods')
+        .mockRejectedValueOnce(mockError)
+
+      await expect(
+        service.removeDeliveryMethodsFromNoris(birthNumber),
+      ).rejects.toThrow(mockError)
     })
   })
 })

--- a/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
+++ b/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
@@ -169,6 +169,32 @@ describe('TasksService', () => {
         }),
       ).rejects.toThrow(mockError)
     })
+
+    it('should throw if date is missing for CITY_ACCOUNT', async () => {
+      const mockData: RequestUpdateNorisDeliveryMethodsData = {
+        '123456/789': { deliveryMethod: DeliveryMethod.EDESK },
+        '234567/890': { deliveryMethod: DeliveryMethod.EDESK },
+        '345678/901': { deliveryMethod: DeliveryMethod.POSTAL },
+        '345678/902': { deliveryMethod: DeliveryMethod.POSTAL },
+        '456789/0123': {
+          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+          date: undefined,
+        },
+        '456789/0103': {
+          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+          date: mockDate2,
+        },
+      } as unknown as RequestUpdateNorisDeliveryMethodsData
+
+      await expect(
+        service.updateDeliveryMethodsInNoris({
+          data: mockData,
+        }),
+      ).rejects.toThrow()
+      expect(
+        service['norisService'].updateDeliveryMethods,
+      ).not.toHaveBeenCalled()
+    })
   })
 
   describe('removeDeliveryMethodsFromNoris', () => {

--- a/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
+++ b/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
@@ -38,7 +38,6 @@ describe('TasksService', () => {
     expect(service).toBeDefined()
   })
 
-  // eslint-disable-next-line no-secrets/no-secrets
   describe('updateDeliveryMethodsInNoris', () => {
     const mockDate1 = '2024-01-01'
     const mockDate2 = '2024-01-02'

--- a/nest-tax-backend/src/admin/admin.controller.ts
+++ b/nest-tax-backend/src/admin/admin.controller.ts
@@ -87,7 +87,7 @@ export class AdminController {
   })
   @ApiResponse({
     status: 200,
-    description: 'Records succesfully updated in Noris',
+    description: 'Records successfully updated in Noris',
   })
   @UseGuards(AdminGuard)
   @Post('update-delivery-methods-in-noris')
@@ -105,7 +105,7 @@ export class AdminController {
   })
   @ApiResponse({
     status: 200,
-    description: 'Records succesfully updated in Noris',
+    description: 'Records successfully updated in Noris',
   })
   @UseGuards(AdminGuard)
   @Post('remove-delivery-methods-from-noris/:birthNumber')

--- a/nest-tax-backend/src/admin/admin.controller.ts
+++ b/nest-tax-backend/src/admin/admin.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common'
 import {
   ApiOperation,
   ApiResponse,
@@ -9,9 +16,9 @@ import { AdminGuard } from 'src/auth/guards/admin.guard'
 
 import { AdminService } from './admin.service'
 import {
-  CreateBirthNumbersRequestDto,
   RequestPostNorisLoadDataDto,
   RequestPostNorisPaymentDataLoadDto,
+  RequestUpdateNorisDeliveryMethodsDto,
 } from './dtos/requests.dto'
 import { CreateBirthNumbersResponseDto } from './dtos/responses.dto'
 
@@ -76,21 +83,35 @@ export class AdminController {
 
   @HttpCode(200)
   @ApiOperation({
-    summary: 'Creates tax payers for birth numbers',
-    description:
-      'For a list of birth numbers this tries to create tax payers in the database, by taking data from NORIS.',
+    summary: 'Update delivery methods for given birth numbers and date.',
   })
   @ApiResponse({
     status: 200,
-    description:
-      'Returns birth numbers of created tax payers which were possible (were in Noris)',
-    type: CreateBirthNumbersResponseDto,
+    description: 'Records succesfully updated in Noris',
   })
   @UseGuards(AdminGuard)
-  @Post('create-tax-payers')
-  async createTaxPayersFromBirthNumbers(
-    @Body() data: CreateBirthNumbersRequestDto,
-  ): Promise<CreateBirthNumbersResponseDto> {
-    return this.adminService.createTaxPayers(data.birthNumbers)
+  @Post('update-delivery-methods-in-noris')
+  async updateDeliveryMethodsInNoris(
+    @Body() data: RequestUpdateNorisDeliveryMethodsDto,
+  ): Promise<void> {
+    return this.adminService.updateDeliveryMethodsInNoris(data)
+  }
+
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Remove delivery methods for given birth number.',
+    description:
+      'Used when deactivating user from city account, to mark that this user does not have delivery methods anymore.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Records succesfully updated in Noris',
+  })
+  @UseGuards(AdminGuard)
+  @Post('remove-delivery-methods-from-noris/:birthNumber')
+  async removeDeliveryMethodsFromNoris(
+    @Param('birthNumber') birthNumber: string,
+  ): Promise<void> {
+    return this.adminService.removeDeliveryMethodsFromNoris(birthNumber)
   }
 }

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -465,6 +465,15 @@ export class AdminService {
 
     Object.entries(data).forEach(([birthNumber, methodInfo]) => {
       if (methodInfo.deliveryMethod in deliveryGroups) {
+        if (
+          methodInfo.deliveryMethod === DeliveryMethod.CITY_ACCOUNT &&
+          !methodInfo.date
+        ) {
+          // We must enforce that the date is present for CITY_ACCOUNT delivery method.
+          throw new Error(
+            `ERROR - Status-500: Date must be provided for birth number ${birthNumber} when delivery method is CITY_ACCOUNT`,
+          )
+        }
         deliveryGroups[methodInfo.deliveryMethod].push({
           birthNumber: addSlashToBirthNumber(birthNumber),
           date:

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -5,12 +5,15 @@ import currency from 'currency.js'
 import { BloomreachService } from '../bloomreach/bloomreach.service'
 import { NorisPaymentsDto, NorisTaxPayersDto } from '../noris/noris.dto'
 import { NorisService } from '../noris/noris.service'
+import { DeliveryMethod, IsInCityAccount } from '../noris/noris.types'
 import { PrismaService } from '../prisma/prisma.service'
+import { addSlashToBirthNumber } from '../utils/functions/birthNumber'
 import { CityAccountSubservice } from '../utils/subservices/cityaccount.subservice'
 import { QrCodeSubservice } from '../utils/subservices/qrcode.subservice'
 import {
   NorisRequestGeneral,
   RequestPostNorisLoadDataDto,
+  RequestUpdateNorisDeliveryMethodsDto,
 } from './dtos/requests.dto'
 import { CreateBirthNumbersResponseDto } from './dtos/responses.dto'
 import { taxDetail } from './utils/tax-detail.helper'
@@ -445,42 +448,68 @@ export class AdminService {
     }
   }
 
-  /**
-   * Adds birth numbers to the taxpayer table in the database from Noris. The birth numbers must include a slash.
-   *
-   * First, the function checks which birth numbers are already in the database. Then, it attempts to add the remaining birth numbers from Noris.
-   *
-   * @param {string[]} birthNumbers - A list of birth numbers in the format with a slash, which should be added from Noris to the taxpayer table if they are not already present.
-   * @returns {string[]} A list of birth numbers that were either already in the taxpayer table or were successfully added from Noris.
-   */
-  async createTaxPayers(
-    birthNumbers: string[],
-  ): Promise<CreateBirthNumbersResponseDto> {
-    const birthNumbersResult: string[] = []
-    const taxPayersAlreadyInDb = await this.prismaService.taxPayer.findMany({
-      select: {
-        birthNumber: true,
-      },
-      where: {
-        birthNumber: {
-          in: birthNumbers,
-        },
-      },
-    })
-    birthNumbersResult.push(
-      ...taxPayersAlreadyInDb.map(
-        (birthNumberRow) => birthNumberRow.birthNumber,
-      ),
-    )
+  async updateDeliveryMethodsInNoris({
+    data,
+  }: RequestUpdateNorisDeliveryMethodsDto) {
+    /**
+     * TODO - concurrency (if someone somehow changes his delivery method during its updating in Noris)
+     */
+    const deliveryGroups: Record<
+      DeliveryMethod,
+      { birthNumber: string; date: string | null }[]
+    > = {
+      [DeliveryMethod.EDESK]: [],
+      [DeliveryMethod.CITY_ACCOUNT]: [],
+      [DeliveryMethod.POSTAL]: [],
+    }
 
-    const birthNumbersCreatedFromNoris = await this.loadDataFromNoris({
-      birthNumbers: birthNumbers.filter(
-        (item) => !birthNumbersResult.includes(item),
-      ),
-      year: new Date().getFullYear(),
+    Object.entries(data).forEach(([birthNumber, methodInfo]) => {
+      if (methodInfo.deliveryMethod in deliveryGroups) {
+        deliveryGroups[methodInfo.deliveryMethod].push({
+          birthNumber: addSlashToBirthNumber(birthNumber),
+          date:
+            methodInfo.deliveryMethod === DeliveryMethod.CITY_ACCOUNT
+              ? methodInfo.date
+              : null,
+        })
+      }
     })
-    birthNumbersResult.push(...birthNumbersCreatedFromNoris.birthNumbers)
 
-    return { birthNumbers: [...new Set(birthNumbersResult)] }
+    const updates = Object.entries(deliveryGroups)
+      .filter(
+        ([deliveryMethod, birthNumbers]) =>
+          birthNumbers.length > 0 &&
+          deliveryMethod !== DeliveryMethod.CITY_ACCOUNT,
+      )
+      .map(([deliveryMethod, birthNumbers]) =>
+        this.norisService.updateDeliveryMethods({
+          birthNumbers: birthNumbers.map((item) => item.birthNumber),
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: deliveryMethod as DeliveryMethod,
+          date: null, // date of confirmation of delivery method should be set only for city account notification
+        }),
+      )
+
+    deliveryGroups[DeliveryMethod.CITY_ACCOUNT].forEach((item) => {
+      updates.push(
+        this.norisService.updateDeliveryMethods({
+          birthNumbers: [item.birthNumber],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+          date: item.date,
+        }),
+      )
+    })
+
+    await Promise.all(updates)
+  }
+
+  async removeDeliveryMethodsFromNoris(birthNumber: string): Promise<void> {
+    await this.norisService.updateDeliveryMethods({
+      birthNumbers: [addSlashToBirthNumber(birthNumber)],
+      inCityAccount: IsInCityAccount.NO,
+      deliveryMethod: null,
+      date: null,
+    })
   }
 }

--- a/nest-tax-backend/src/admin/dtos/requests.dto.ts
+++ b/nest-tax-backend/src/admin/dtos/requests.dto.ts
@@ -77,11 +77,16 @@ export type RequestUpdateNorisDeliveryMethodsData = {
 
 export class RequestUpdateNorisDeliveryMethodsDto {
   @ApiProperty({
-    description: 'The new delivery methods for the birth numbers',
+    description:
+      'The new delivery methods for the birth numbers. For city account notification, date must be provided.',
     example: {
-      '010366/4554': DeliveryMethod.EDESK,
-      '010366/554': DeliveryMethod.EDESK,
-      '017766/2244': DeliveryMethod.POSTAL,
+      '010366/4554': { deliveryMethod: DeliveryMethod.EDESK },
+      '010366/554': { deliveryMethod: DeliveryMethod.EDESK },
+      '017766/2244': { deliveryMethod: DeliveryMethod.POSTAL },
+      '022176/2244': {
+        deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+        date: '2024-01-01',
+      },
     },
   })
   @IsObject()

--- a/nest-tax-backend/src/admin/dtos/requests.dto.ts
+++ b/nest-tax-backend/src/admin/dtos/requests.dto.ts
@@ -1,4 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger'
+import { IsObject } from 'class-validator'
+
+import { DeliveryMethod } from '../../noris/noris.types'
 
 export class RequestPostNorisLoadDataDto {
   @ApiProperty({
@@ -64,6 +67,25 @@ export class RequestPostNorisPaymentDataLoadByVariableSymbolsDto {
     isArray: true,
   })
   variableSymbols: string[]
+}
+
+export type RequestUpdateNorisDeliveryMethodsData = {
+  [key: string]:
+    | { deliveryMethod: DeliveryMethod.CITY_ACCOUNT; date: string }
+    | { deliveryMethod: DeliveryMethod.EDESK | DeliveryMethod.POSTAL }
+}
+
+export class RequestUpdateNorisDeliveryMethodsDto {
+  @ApiProperty({
+    description: 'The new delivery methods for the birth numbers',
+    example: {
+      '010366/4554': DeliveryMethod.EDESK,
+      '010366/554': DeliveryMethod.EDESK,
+      '017766/2244': DeliveryMethod.POSTAL,
+    },
+  })
+  @IsObject()
+  data: RequestUpdateNorisDeliveryMethodsData
 }
 
 export type NorisRequestGeneral =

--- a/nest-tax-backend/src/admin/dtos/requests.dto.ts
+++ b/nest-tax-backend/src/admin/dtos/requests.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger'
-import { IsObject } from 'class-validator'
+import { IsObject, ValidateNested } from 'class-validator'
 
 import { DeliveryMethod } from '../../noris/noris.types'
 
@@ -88,8 +88,38 @@ export class RequestUpdateNorisDeliveryMethodsDto {
         date: '2024-01-01',
       },
     },
+    type: 'object',
+    additionalProperties: {
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            deliveryMethod: {
+              type: 'string',
+              enum: [DeliveryMethod.CITY_ACCOUNT],
+            },
+            date: {
+              type: 'string',
+              format: 'date',
+            },
+          },
+          required: ['deliveryMethod', 'date'],
+        },
+        {
+          type: 'object',
+          properties: {
+            deliveryMethod: {
+              type: 'string',
+              enum: [DeliveryMethod.EDESK, DeliveryMethod.POSTAL],
+            },
+          },
+          required: ['deliveryMethod'],
+        },
+      ],
+    },
   })
   @IsObject()
+  @ValidateNested()
   data: RequestUpdateNorisDeliveryMethodsData
 }
 

--- a/nest-tax-backend/src/auth/guards/cognito.guard.ts
+++ b/nest-tax-backend/src/auth/guards/cognito.guard.ts
@@ -8,6 +8,7 @@ import {
   Configuration,
   UsersManipulationApi,
 } from '../../generated-clients/nest-city-account'
+import { addSlashToBirthNumber } from '../../utils/functions/birthNumber'
 
 export const BratislavaUser = createParamDecorator(
   async (data: string, ctx: ExecutionContext) => {
@@ -26,10 +27,9 @@ export const BratislavaUser = createParamDecorator(
     const user = userRequest.data
 
     if (user.birthNumber) {
-      let birthNumberWithSlash: string = user.birthNumber
-      if (!birthNumberWithSlash.includes('/')) {
-        birthNumberWithSlash = `${birthNumberWithSlash.slice(0, 6)}/${birthNumberWithSlash.slice(6)}`
-      }
+      const birthNumberWithSlash: string = addSlashToBirthNumber(
+        user.birthNumber,
+      )
       return { ...user, birthNumber: birthNumberWithSlash }
     }
 

--- a/nest-tax-backend/src/noris/noris.queries.ts
+++ b/nest-tax-backend/src/noris/noris.queries.ts
@@ -645,3 +645,18 @@ SELECT
         AND lcs.dane21_priznanie.podnikatel = 'N'
         {%VARIABLE_SYMBOLS%}
 `
+
+export const setDeliveryMethodsForUser = `
+    UPDATE lcs.uda_21_organizacia_mag
+    SET
+        dkba_stav = @dkba_stav,
+        dkba_datum_suhlasu = @dkba_datum_suhlasu,
+        dkba_sposob_dorucovania = @dkba_sposob_dorucovania
+    WHERE
+        cislo_subjektu IN (
+            SELECT DISTINCT subjekt
+            FROM lcs.dane21_priznanie
+            WHERE podnikatel = 'N' 
+            AND rodne_cislo IN (@birth_numbers)
+        )
+`

--- a/nest-tax-backend/src/noris/noris.service.ts
+++ b/nest-tax-backend/src/noris/noris.service.ts
@@ -178,13 +178,19 @@ export class NorisService {
       )
       request.input('dkba_sposob_dorucovania', data.deliveryMethod)
 
-      const queryWithBirthNumbers = setDeliveryMethodsForUser.replaceAll(
+      const birthNumberPlaceholders = data.birthNumbers
+        .map((_, index) => `@birthnumber${index}`)
+        .join(',')
+      data.birthNumbers.forEach((birthNumber, index) => {
+        request.input(`birthnumber${index}`, birthNumber)
+      })
+      const queryWithPlaceholders = setDeliveryMethodsForUser.replaceAll(
         '@birth_numbers',
-        data.birthNumbers.map((bn) => `'${bn}'`).join(','),
+        birthNumberPlaceholders,
       )
 
       // Execute the query
-      await request.query(queryWithBirthNumbers)
+      await request.query(queryWithPlaceholders)
     } catch (error) {
       throw new Error(
         `Failed to update delivery methods: ${(error as Error).message}`,

--- a/nest-tax-backend/src/noris/noris.types.ts
+++ b/nest-tax-backend/src/noris/noris.types.ts
@@ -1,0 +1,17 @@
+export enum IsInCityAccount {
+  YES = 'A',
+  NO = 'N',
+}
+
+export enum DeliveryMethod {
+  EDESK = 'E', // edesk
+  CITY_ACCOUNT = 'O', // city account notification
+  POSTAL = 'P', // postal
+}
+
+export interface UpdateNorisDeliveryMethods {
+  birthNumbers: string[]
+  inCityAccount: IsInCityAccount
+  deliveryMethod: DeliveryMethod | null
+  date: string | null
+}

--- a/nest-tax-backend/src/utils/functions/__test__/birthNumber.spec.ts
+++ b/nest-tax-backend/src/utils/functions/__test__/birthNumber.spec.ts
@@ -12,4 +12,14 @@ describe('addSlashToBirthNumber', () => {
   it('should work on birth number with length 9', () => {
     expect(addSlashToBirthNumber('123456789')).toBe('123456/789')
   })
+
+  it('should throw if the format is wrong', () => {
+    expect(() => addSlashToBirthNumber('12345678901')).toThrow()
+    expect(() => addSlashToBirthNumber('abcdef')).toThrow()
+    expect(() => addSlashToBirthNumber('123456/11a')).toThrow()
+    expect(() => addSlashToBirthNumber('12345611a')).toThrow()
+    expect(() => addSlashToBirthNumber('123456/11')).toThrow()
+    expect(() => addSlashToBirthNumber('12456/1155')).toThrow()
+    expect(() => addSlashToBirthNumber('12345611')).toThrow()
+  })
 })

--- a/nest-tax-backend/src/utils/functions/__test__/birthNumber.spec.ts
+++ b/nest-tax-backend/src/utils/functions/__test__/birthNumber.spec.ts
@@ -1,0 +1,15 @@
+import { addSlashToBirthNumber } from '../birthNumber'
+
+describe('addSlashToBirthNumber', () => {
+  it('should add slash to birth number', () => {
+    expect(addSlashToBirthNumber('1234567890')).toBe('123456/7890')
+  })
+
+  it('should not add slash to birth number that already contains it', () => {
+    expect(addSlashToBirthNumber('123456/7890')).toBe('123456/7890')
+  })
+
+  it('should work on birth number with length 9', () => {
+    expect(addSlashToBirthNumber('123456789')).toBe('123456/789')
+  })
+})

--- a/nest-tax-backend/src/utils/functions/birthNumber.ts
+++ b/nest-tax-backend/src/utils/functions/birthNumber.ts
@@ -1,4 +1,10 @@
 export function addSlashToBirthNumber(birthNumber: string): string {
+  const birthNumberRegex = /^\d{6}\/?\d{3,4}$/
+  if (!birthNumberRegex.test(birthNumber)) {
+    throw new Error(
+      `ERROR - Status-500: Invalid birth number passed to addSlashToBirthNumber ${birthNumber}`,
+    )
+  }
   return birthNumber.includes('/')
     ? birthNumber
     : `${birthNumber.slice(0, 6)}/${birthNumber.slice(6)}`

--- a/nest-tax-backend/src/utils/functions/birthNumber.ts
+++ b/nest-tax-backend/src/utils/functions/birthNumber.ts
@@ -1,0 +1,5 @@
+export function addSlashToBirthNumber(birthNumber: string): string {
+  return birthNumber.includes('/')
+    ? birthNumber
+    : `${birthNumber.slice(0, 6)}/${birthNumber.slice(6)}`
+}

--- a/nest-tax-backend/src/utils/subservices/cityaccount.subservice.ts
+++ b/nest-tax-backend/src/utils/subservices/cityaccount.subservice.ts
@@ -6,6 +6,7 @@ import {
   Configuration,
   ResponseUserByBirthNumberDto,
 } from '../../generated-clients/nest-city-account'
+import { addSlashToBirthNumber } from '../functions/birthNumber'
 
 @Injectable()
 export class CityAccountSubservice {
@@ -71,9 +72,7 @@ export class CityAccountSubservice {
 
     const result: Record<string, ResponseUserByBirthNumberDto> = {}
     Object.keys(userDataResult.data.users).forEach((birthNumber) => {
-      const modifiedKey = birthNumber.includes('/')
-        ? birthNumber
-        : `${birthNumber.slice(0, 6)}/${birthNumber.slice(6)}`
+      const modifiedKey = addSlashToBirthNumber(birthNumber)
       result[modifiedKey] = userDataResult.data.users[birthNumber]
     })
 


### PR DESCRIPTION
Creates two endpoints in tax backend for modifying delivery methods for users in Noris.
1. First is for updating delivery methods for users which have city account, that is setting if they want to receive tax notification by Edesk, Post, or directly via city account.
2. Second is for removing delivery methods for given user, used when an account is deactivated, to set their delivery methods to default value (and mark that this person does not have an city account anymore)

Also this PR removes the `create-tax-payers` endpoint, which is not used anymore.

A small detail is moving the logic of adding slashes to birth numbers to separate function `addSlashToBirthNumber`.

This has been tested locally, with the non-production Noris `cvicna_magistrat`.