### PR TITLE
Do not error if magproxy returns empty object instead of array

### DIFF
--- a/nest-city-account/.eslintrc
+++ b/nest-city-account/.eslintrc
@@ -35,5 +35,13 @@
   },
   "ignorePatterns": [
     "src/generated-clients/**/*"
+  ],
+  "overrides": [
+    {
+      "files": ["**/*.spec.ts"],
+      "rules": {
+        "@typescript-eslint/dot-notation": "off" // to test private methods
+      }
+    }
   ]
 }

--- a/nest-city-account/src/user-verification/utils/subservice/__tests__/verification.subservice.spec.ts
+++ b/nest-city-account/src/user-verification/utils/subservice/__tests__/verification.subservice.spec.ts
@@ -1,0 +1,160 @@
+import { createMock } from '@golevelup/ts-jest'
+import { HttpStatus } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+
+import { MagproxyService } from '../../../../magproxy/magproxy.service'
+import { PhysicalEntityService } from '../../../../physical-entity/physical-entity.service'
+import { RfoIdentityListElement } from '../../../../rfo-by-birthnumber/dtos/rfoSchema'
+import ThrowerErrorGuard, {
+  ErrorMessengerGuard,
+} from '../../../../utils/guards/errors.guard'
+import { VerificationErrorsEnum } from '../../../verification.errors.enum'
+import { DatabaseSubserviceUser } from '../database.subservice'
+import { VerificationSubservice } from '../verification.subservice'
+
+const IDENTITY_CARD = 'Občiansky preukaz'
+
+describe('VerificationSubservice', () => {
+  let service: VerificationSubservice
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VerificationSubservice,
+        ErrorMessengerGuard,
+        ThrowerErrorGuard,
+        { provide: MagproxyService, useValue: createMock<MagproxyService>() },
+        {
+          provide: DatabaseSubserviceUser,
+          useValue: createMock<DatabaseSubserviceUser>(),
+        },
+        {
+          provide: PhysicalEntityService,
+          useValue: createMock<PhysicalEntityService>(),
+        },
+      ],
+    }).compile()
+
+    service = module.get<VerificationSubservice>(VerificationSubservice)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  describe('checkIdentityCard', () => {
+    it('should return ok if identity card is in RFO', () => {
+      const identityCard = '1234567890'
+      const rfoData: RfoIdentityListElement = {
+        doklady: [
+          {
+            druhDokladuKod: 111,
+            druhDokladu: IDENTITY_CARD,
+            jednoznacnyIdentifikator: 'INVALID',
+            udrzitela: true,
+          },
+          {
+            druhDokladuKod: 111,
+            druhDokladu: IDENTITY_CARD,
+            jednoznacnyIdentifikator: '1234567890',
+            udrzitela: true,
+          },
+        ],
+      }
+      const result = service['checkIdentityCard'](rfoData, identityCard)
+      expect(result).toEqual({
+        statusCode: 200,
+        status: 'OK',
+        message: { message: 'ok' },
+      })
+    })
+
+    it('should return error if identity card is not in RFO', () => {
+      const identityCard = '1234567890'
+      const rfoData: RfoIdentityListElement = {
+        doklady: [
+          {
+            druhDokladuKod: 111,
+            druhDokladu: IDENTITY_CARD,
+            jednoznacnyIdentifikator: 'INVALID',
+            udrzitela: true,
+          },
+          {
+            druhDokladuKod: 111,
+            druhDokladu: IDENTITY_CARD,
+            jednoznacnyIdentifikator: 'INVALID',
+            udrzitela: true,
+          },
+        ],
+      }
+      const result = service['checkIdentityCard'](rfoData, identityCard)
+      expect(result).toEqual(
+        expect.objectContaining({
+          statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+          status: 'CustomError',
+          errorName:
+            VerificationErrorsEnum.BIRTH_NUMBER_AND_IDENTITY_CARD_INCONSISTENCY,
+        }),
+      )
+    })
+
+    it('should return error if RFO returned empty object for identity cards', () => {
+      const identityCard = '1234567890'
+      const rfoData: RfoIdentityListElement = {
+        doklady: {},
+      } as RfoIdentityListElement // This can happen, sometimes it returns empty object instead of empty array
+      const result = service['checkIdentityCard'](rfoData, identityCard)
+      expect(result).toEqual(
+        expect.objectContaining({
+          statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+          status: 'CustomError',
+          errorName:
+            VerificationErrorsEnum.BIRTH_NUMBER_AND_IDENTITY_CARD_INCONSISTENCY,
+        }),
+      )
+    })
+
+    it('should return error if RFO returned empty array for identity cards', () => {
+      const identityCard = '1234567890'
+      const rfoData: RfoIdentityListElement = { doklady: [] }
+      const result = service['checkIdentityCard'](rfoData, identityCard)
+      expect(result).toEqual(
+        expect.objectContaining({
+          statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+          status: 'CustomError',
+          errorName:
+            VerificationErrorsEnum.BIRTH_NUMBER_AND_IDENTITY_CARD_INCONSISTENCY,
+        }),
+      )
+    })
+
+    it('should return error if the person died', () => {
+      const identityCard = '1234567890'
+      const rfoData: RfoIdentityListElement = {
+        doklady: [
+          {
+            druhDokladuKod: 111,
+            druhDokladu: IDENTITY_CARD,
+            jednoznacnyIdentifikator: '1234567890',
+            udrzitela: true,
+          },
+          {
+            druhDokladuKod: 111,
+            druhDokladu: IDENTITY_CARD,
+            jednoznacnyIdentifikator: 'INVALID',
+            udrzitela: true,
+          },
+        ],
+        datumUmrtia: '2021-01-01',
+      }
+      const result = service['checkIdentityCard'](rfoData, identityCard)
+      expect(result).toEqual(
+        expect.objectContaining({
+          statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+          status: 'CustomError',
+          errorName: VerificationErrorsEnum.DEAD_PERSON,
+        }),
+      )
+    })
+  })
+})

--- a/nest-city-account/src/user-verification/utils/subservice/__tests__/verification.subservice.spec.ts
+++ b/nest-city-account/src/user-verification/utils/subservice/__tests__/verification.subservice.spec.ts
@@ -44,7 +44,7 @@ describe('VerificationSubservice', () => {
 
   describe('checkIdentityCard', () => {
     it('should return ok if identity card is in RFO', () => {
-      const identityCard = '1234567890'
+      const identityCard = 'AB123456'
       const rfoData: RfoIdentityListElement = {
         doklady: [
           {
@@ -56,7 +56,33 @@ describe('VerificationSubservice', () => {
           {
             druhDokladuKod: 111,
             druhDokladu: IDENTITY_CARD,
-            jednoznacnyIdentifikator: '1234567890',
+            jednoznacnyIdentifikator: 'AB123456',
+            udrzitela: true,
+          },
+        ],
+      }
+      const result = service['checkIdentityCard'](rfoData, identityCard)
+      expect(result).toEqual({
+        statusCode: 200,
+        status: 'OK',
+        message: { message: 'ok' },
+      })
+    })
+
+    it('should return ok if identity card is in RFO in another format', () => {
+      const identityCard = 'AB123456'
+      const rfoData: RfoIdentityListElement = {
+        doklady: [
+          {
+            druhDokladuKod: 111,
+            druhDokladu: IDENTITY_CARD,
+            jednoznacnyIdentifikator: 'INVALID',
+            udrzitela: true,
+          },
+          {
+            druhDokladuKod: 111,
+            druhDokladu: IDENTITY_CARD,
+            jednoznacnyIdentifikator: '123456 AB',
             udrzitela: true,
           },
         ],
@@ -70,7 +96,7 @@ describe('VerificationSubservice', () => {
     })
 
     it('should return error if identity card is not in RFO', () => {
-      const identityCard = '1234567890'
+      const identityCard = 'AB123456'
       const rfoData: RfoIdentityListElement = {
         doklady: [
           {
@@ -99,7 +125,7 @@ describe('VerificationSubservice', () => {
     })
 
     it('should return error if RFO returned empty object for identity cards', () => {
-      const identityCard = '1234567890'
+      const identityCard = 'AB123456'
       const rfoData: RfoIdentityListElement = {
         doklady: {},
       } as RfoIdentityListElement // This can happen, sometimes it returns empty object instead of empty array
@@ -115,7 +141,7 @@ describe('VerificationSubservice', () => {
     })
 
     it('should return error if RFO returned empty array for identity cards', () => {
-      const identityCard = '1234567890'
+      const identityCard = 'AB123456'
       const rfoData: RfoIdentityListElement = { doklady: [] }
       const result = service['checkIdentityCard'](rfoData, identityCard)
       expect(result).toEqual(
@@ -128,14 +154,14 @@ describe('VerificationSubservice', () => {
       )
     })
 
-    it('should return error if the person died', () => {
-      const identityCard = '1234567890'
+    it('should return error if the person is dead', () => {
+      const identityCard = 'AB123456'
       const rfoData: RfoIdentityListElement = {
         doklady: [
           {
             druhDokladuKod: 111,
             druhDokladu: IDENTITY_CARD,
-            jednoznacnyIdentifikator: '1234567890',
+            jednoznacnyIdentifikator: 'AB123456',
             udrzitela: true,
           },
           {

--- a/nest-city-account/src/user-verification/utils/subservice/verification.subservice.ts
+++ b/nest-city-account/src/user-verification/utils/subservice/verification.subservice.ts
@@ -34,7 +34,7 @@ export class VerificationSubservice {
     if (rfoData.datumUmrtia && rfoData.datumUmrtia !== 'unknown' && rfoData.datumUmrtia !== '') {
       return this.errorMessengerGuard.rfoDeadPerson()
     }
-    if (!rfoData.doklady) {
+    if (!rfoData.doklady || Object.keys(rfoData.doklady).length === 0) {
       return this.errorMessengerGuard.birthNumberICInconsistency()
     }
     for (const document of rfoData.doklady) {


### PR DESCRIPTION
If a person has record in RFO, but has do identity cards, magproxy returns `{}` instead of `[]`, thus the iteration errors.