### PR TITLE
Comment on related PRs and Issues after release

### DIFF
--- a/.github/workflows/comment-after-release.yml
+++ b/.github/workflows/comment-after-release.yml
@@ -1,0 +1,18 @@
+name: Release Comments
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Release Commenter
+        uses: apexskier/github-release-commenter@v1.3.6
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-template: |
+            This issue has been resolved in release {release_link} 🎉


### PR DESCRIPTION
Uses existing action - https://github.com/marketplace/actions/release-commenter

The code seems concise enough to toy with if we decide we need more - https://github.com/apexskier/github-release-commenter/blob/main/src/index.ts

GH token is automatically provided by github, when running in CI, so I'm being lazy and want to test "in production" instead of locally - that is, did not run this yet, but if you're ok with it I'd merge and see what it does.