### PR TITLE
Fix: Import payments even for taxes from past years

### DIFF
--- a/nest-tax-backend/src/admin/dtos/requests.dto.ts
+++ b/nest-tax-backend/src/admin/dtos/requests.dto.ts
@@ -52,10 +52,12 @@ export class RequestPostNorisPaymentDataLoadDto {
 
 export class RequestPostNorisPaymentDataLoadByVariableSymbolsDto {
   @ApiProperty({
-    description: 'Year of tax',
-    default: 2022,
+    description:
+      'Years of taxes for which it should find payments. Used for more effective querying.',
+    default: [2022, 2023],
+    type: [Number],
   })
-  year: number
+  years: number[]
 
   @ApiProperty({
     description: 'Variable symbols which should be checked.',

--- a/nest-tax-backend/src/noris/noris.queries.ts
+++ b/nest-tax-backend/src/noris/noris.queries.ts
@@ -599,8 +599,8 @@ SELECT
         FROM
             lcs.dane21_doklad
         WHERE
-            lcs.dane21_doklad.rok_podkladu = {%YEAR%}
-            AND lcs.dane21_doklad.rok_podkladu = {%YEAR%}
+            lcs.dane21_doklad.rok_podkladu {%YEARS%}
+            AND lcs.dane21_doklad.rok_podkladu {%YEARS%}
         ) as dane21_doklad
     JOIN 
         (SELECT 

--- a/nest-tax-backend/src/noris/noris.service.ts
+++ b/nest-tax-backend/src/noris/noris.service.ts
@@ -98,7 +98,7 @@ export class NorisService {
             ${overpayments}
         )`,
         )
-        .replaceAll('{%YEAR%}', data.year.toString())
+        .replaceAll('{%YEARS%}', `= ${data.year.toString()}`)
         .replaceAll('{%VARIABLE_SYMBOLS%}', ''),
     )
     connection.close()
@@ -134,9 +134,15 @@ export class NorisService {
     })
     variableSymbols = `(${variableSymbols.slice(0, -1)})`
 
+    if (data.years.length === 0) {
+      throw new Error(
+        'ERROR - Status-500: Years are empty in payment data import from Noris request.',
+      )
+    }
+
     const norisData = await connection.query(
       queryPaymentsFromNoris
-        .replaceAll('{%YEAR%}', data.year.toString())
+        .replaceAll('{%YEARS%}', `IN (${data.years.join(',')})`)
         .replaceAll(
           '{%VARIABLE_SYMBOLS%}',
           `AND dane21_doklad.variabilny_symbol IN ${variableSymbols}`,

--- a/nest-tax-backend/src/tasks/tasks.service.ts
+++ b/nest-tax-backend/src/tasks/tasks.service.ts
@@ -19,19 +19,22 @@ export class TasksService {
 
   @Cron(CronExpression.EVERY_10_MINUTES)
   async updatePaymentsFromNoris() {
-    const year = new Date().getFullYear()
-
-    let variableSymbolsDb: { variableSymbol: string; id: number }[] = []
+    let variableSymbolsDb: {
+      variableSymbol: string
+      id: number
+      year: number
+    }[] = []
     try {
       variableSymbolsDb = await this.prismaService.$transaction(
         async (prisma) => {
           await prisma.$executeRaw`SET LOCAL statement_timeout = '120000'`
 
-          return prisma.$queryRaw<{ variableSymbol: string; id: number }[]>`
-          SELECT t."variableSymbol", t."id"
+          return prisma.$queryRaw<
+            { variableSymbol: string; id: number; year: number }[]
+          >`
+          SELECT t."variableSymbol", t."id", t."year"
           FROM "Tax" t
           LEFT JOIN "TaxPayment" tp ON t."id" = tp."taxId" AND tp.status = 'SUCCESS'
-          WHERE t.year = ${year}
           GROUP BY t."id", t."variableSymbol", t."lastCheckedPayments"
           HAVING COALESCE(SUM(tp."amount"), 0) < t."amount"
           ORDER BY t."lastCheckedPayments" ASC
@@ -49,7 +52,6 @@ export class TasksService {
       }
       this.logger.error('Failed to fetch variable symbols from database', {
         error: error instanceof Error ? error.message : 'Unknown error',
-        year,
       })
       throw error
     }
@@ -57,10 +59,14 @@ export class TasksService {
     if (variableSymbolsDb.length === 0) return
 
     const data = {
-      year,
       variableSymbols: variableSymbolsDb.map(
         (variableSymbolDb) => variableSymbolDb.variableSymbol,
       ),
+      years: [
+        ...new Set(
+          variableSymbolsDb.map((variableSymbolDb) => variableSymbolDb.year),
+        ),
+      ],
     }
 
     this.logger.log(


### PR DESCRIPTION
Fixes the automatic task which imports payments for taxes, so it will import payments even for taxes from past years (basically all unpaid).

The first query was tested on production database, duration of it running was almost the same as the query before. Noris queries were tested on staging Noris, they work, however `years[]` must not be empty.