### PR TITLE
Form status to QUEUED before eid nases send

### DIFF
--- a/nest-forms-backend/src/nases/nases.service.ts
+++ b/nest-forms-backend/src/nases/nases.service.ts
@@ -528,6 +528,14 @@ export default class NasesService {
 
     this.checkAttachments(await this.filesService.areFormAttachmentsReady(id))
 
+    // TODO rework! this is super fragile and QUEUED state was not originally meant for this
+    // just before sending to nases, update form state to QUEUED
+    // if the operation takes long, this prevents repeated sending
+    // sendToNasesAndUpdateState must never throw, and if it does not succeed we update the state back to DRAFT & set NASES_SEND_ERROR
+    await this.formsService.updateForm(id, {
+      state: FormState.QUEUED,
+    })
+
     // Send to nases
     const isSent = await this.nasesConsumerService.sendToNasesAndUpdateState(
       jwt,


### PR DESCRIPTION
We no longer do SENDING_TO_NASES. That allows users to resend while the form is still in flight to NASES. The assumption/oversight was that this operation would either complete or fail quickly, but it's not always the case. We're always sending to nases with the same uuid so we can only send once (this is good, prevents duplicates) - but if the person resends during an in-flight request they may get failed sending on the sunsequent attempt which overwrites the state in db to DRAFT & NASES_SEND_ERROR - and end them stuck in this state forever despite the form being already successful from the initial attempt.

Setting to queued is not super nice, but it prevents resends and displays correctly in FE. The assumption with this change is that we need to rework these states either way.