### PR TITLE
Fix: Correct handling of errors thrown before logging middleware is called.

### DIFF
--- a/nest-forms-backend/src/utils/filters/error.filter.ts
+++ b/nest-forms-backend/src/utils/filters/error.filter.ts
@@ -29,22 +29,8 @@ export class ErrorFilter implements ExceptionFilter {
     } else {
       const logger = new LineLoggerSubservice(ErrorFilter.name)
 
-      const responseJson = {
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-        message,
-      }
-
-      logger.error({
-        errorType: name,
-        message,
-        response: responseJson,
-        stack: stack,
-      })
-
-      response.json(responseJson)
+      logger.error(exception)
     }
-
-
   }
 }
 
@@ -74,17 +60,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
       }
     } else {
       const logger = new LineLoggerSubservice(HttpExceptionFilter.name)
-      logger.error({
-        errorName: exception.name,
-        errorType: 'HttpException',
-        message: exception.message,
-        response:
-          typeof exceptionResponse === 'object'
-            ? JSON.stringify(exceptionResponse)
-            : exceptionResponse,
-        stack: exception.stack,
-      })
-      response.json(exceptionResponse)
+
+      logger.error(exception)
     }
   }
 }

--- a/nest-forms-backend/src/utils/filters/error.filter.ts
+++ b/nest-forms-backend/src/utils/filters/error.filter.ts
@@ -19,7 +19,7 @@ export class ErrorFilter implements ExceptionFilter {
 
     response.status(HttpStatus.INTERNAL_SERVER_ERROR)
 
-    if (response.get('middlewareUsed')) {
+    if (response.locals.middlewareUsed) {
       response.json({
         statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
         '$Symbol-errorType': name,
@@ -58,7 +58,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
 
     response.status(status)
 
-    if (response.get('middlewareUsed')) {
+    if (response.locals.middlewareUsed) {
       if (typeof exceptionResponse === 'object') {
         response.json({
           ...symbolKeysToStrings(exceptionResponse),

--- a/nest-forms-backend/src/utils/middlewares/logger.service.ts
+++ b/nest-forms-backend/src/utils/middlewares/logger.service.ts
@@ -7,15 +7,15 @@ import { LineLoggerSubservice } from '../subservices/line-logger.subservice'
 @Injectable()
 export default class AppLoggerMiddleware implements NestMiddleware {
   use(request: Request, response: Response, next: NextFunction): void {
-    response.set('middlewareUsed', 'true')
     const { method, originalUrl, body, ip, userAgent, userId } =
       this.extractRequestData(request)
     const startAt = process.hrtime()
     const { statusMessage, statusCode } = response
 
+    response.locals.middlewareUsed = 'true'
     const { send } = response
     response.send = (exitData: string | object | Buffer | Array<any>) => {
-      response.set('middlewareUsed', undefined)
+      response.locals.middlewareUsed = undefined
       const { responseData, logData, returnExitData } = this.parseExitData(
         response,
         exitData,

--- a/nest-forms-backend/src/utils/middlewares/logger.service.ts
+++ b/nest-forms-backend/src/utils/middlewares/logger.service.ts
@@ -7,6 +7,7 @@ import { LineLoggerSubservice } from '../subservices/line-logger.subservice'
 @Injectable()
 export default class AppLoggerMiddleware implements NestMiddleware {
   use(request: Request, response: Response, next: NextFunction): void {
+    response.set('middlewareUsed', 'true')
     const { method, originalUrl, body, ip, userAgent, userId } =
       this.extractRequestData(request)
     const startAt = process.hrtime()
@@ -14,6 +15,7 @@ export default class AppLoggerMiddleware implements NestMiddleware {
 
     const { send } = response
     response.send = (exitData: string | object | Buffer | Array<any>) => {
+      response.set('middlewareUsed', undefined)
       const { responseData, logData, returnExitData } = this.parseExitData(
         response,
         exitData,


### PR DESCRIPTION
### Problem:
Our current logging system relies on middleware that intercepts errors, separates log data from the response, and logs it appropriately. The middleware achieves this by modifying the `response.send` function, ensuring that log data is not included in the response sent back to the client.
However, an issue arises when an error is thrown **before the middleware is executed**, which happens at the earlier stages of the request lifecycle. In such cases:
1. No log data is collected or recorded.
2. Portions of raw log data may unintentionally be included in the response to the client.


### Solution:
This PR introduces a flag (`middlewareUsed`) in the `response` object to indicate whether the middleware has been executed. The error-handling filters check for the presence of this flag before merging log data into the response:
- If the flag is **present** (middleware executed), logging and response behaviors proceed as usual.
- If the flag is **absent** (middleware not reached), the filter avoids merging all log data into the client response. Instead:
    - Log data is logged separately.
    - A clean error message is sent in the response.

This ensures that even when errors occur before the middleware runs, logs are created and response does not contain any log data. 

This approach provides fewer details in logs. I do not yet know if this can be fixed and may look into it further if required.

### Reference
[Request lifecycle summary](https://docs.nestjs.com/faq/request-lifecycle#summary) can be found here.