### PR TITLE
Fake GINIS data while ssl endpoint does not work

### DIFF
--- a/next/frontend/utils/ginis.ts
+++ b/next/frontend/utils/ginis.ts
@@ -35,3 +35,38 @@ export const modifyGinisDataForSchemaSlug = (
     ownerPhone: '',
   }
 }
+
+// temp workaround while GINIS API endpoints don't work as expected
+export const getFakeGinisData = (schemaSlug: string): GinisDocumentDetailResponseDto => {
+  const prefilteredData = {
+    id: '',
+    dossierId: '',
+    documentHistory: [],
+    ownerName: '',
+    ownerEmail: '',
+    ownerPhone: '',
+  }
+  if (
+    ['stanovisko-k-investicnemu-zameru', 'zavazne-stanovisko-k-investicnej-cinnosti'].includes(
+      schemaSlug,
+    )
+  ) {
+    return {
+      ...prefilteredData,
+      ownerEmail: 'usmernovanievystavby@bratislava.sk',
+      ownerName: '',
+      ownerPhone: '',
+    }
+  }
+  // taxes want to share the contact for referents (as far as we know)
+  if (schemaSlug === 'priznanie-k-dani-z-nehnutelnosti') {
+    return prefilteredData
+  }
+  // we don't have any direction for other schemas, but we have a few complaints, so playing it safe until the details page is fixed
+  return {
+    ...prefilteredData,
+    ownerEmail: 'info@bratislava.sk',
+    ownerName: '',
+    ownerPhone: '',
+  }
+}

--- a/next/pages/moje-ziadosti/[ziadost].tsx
+++ b/next/pages/moje-ziadosti/[ziadost].tsx
@@ -3,7 +3,7 @@ import { GetFormResponseDto, GinisDocumentDetailResponseDto } from '@clients/ope
 import MyApplicationDetails from 'components/forms/segments/AccountSections/MyApplicationsSection/MyApplicationDetails'
 import AccountPageLayout from 'components/layouts/AccountPageLayout'
 import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinitionBySlug'
-import { modifyGinisDataForSchemaSlug } from 'frontend/utils/ginis'
+import { getFakeGinisData } from 'frontend/utils/ginis'
 import logger from 'frontend/utils/logger'
 
 import { SsrAuthProviderHOC } from '../../components/logic/SsrAuthContext'
@@ -31,11 +31,12 @@ export const getServerSideProps = amplifyGetServerSideProps<AccountMyApplication
       })
       myApplicationDetailsData = response?.data // getApplicationDetailsData(ctx.query.ziadost) || null
       if (myApplicationDetailsData.ginisDocumentId) {
-        const ginisRequest = await formsApi.ginisControllerGetGinisDocumentByFormId(id, {
-          accessToken: 'always',
-          accessTokenSsrGetFn: getAccessToken,
-        })
-        myApplicationGinisData = ginisRequest?.data
+        // TODO commented out while GINIS API endpoints don't work as expected
+        // const ginisRequest = await formsApi.ginisControllerGetGinisDocumentByFormId(id, {
+        //   accessToken: 'always',
+        //   accessTokenSsrGetFn: getAccessToken,
+        // })
+        myApplicationGinisData = getFakeGinisData(myApplicationDetailsData.formDefinitionSlug)
       }
     } catch (error) {
       logger.error(error)
@@ -53,10 +54,7 @@ export const getServerSideProps = amplifyGetServerSideProps<AccountMyApplication
       props: {
         formDefinitionTitle: formDefinition.title,
         myApplicationDetailsData,
-        myApplicationGinisData: modifyGinisDataForSchemaSlug(
-          myApplicationGinisData,
-          myApplicationDetailsData.formDefinitionSlug,
-        ),
+        myApplicationGinisData,
         ...(await slovakServerSideTranslations()),
       },
     }


### PR DESCRIPTION
Show at least something while we do not have ginis `ssl` ("spisová služba") endpoint. Without it we can load neither the id/dossierId data, or the `gin` service owner info, which requires owner id from `ssl` service.

