### PR TITLE
Fix responseCode in logs, when an error was thrown.

### DIFF
--- a/nest-tax-backend/src/utils/middlewares/logger.ts
+++ b/nest-tax-backend/src/utils/middlewares/logger.ts
@@ -10,7 +10,6 @@ export default class AppLoggerMiddleware implements NestMiddleware {
     const { method, originalUrl, body, ip, userAgent, userId } =
       this.extractRequestData(request)
     const startAt = process.hrtime()
-    const { statusMessage, statusCode } = response
     response.locals.middlewareUsed = 'true'
 
     const { send } = response
@@ -22,14 +21,14 @@ export default class AppLoggerMiddleware implements NestMiddleware {
         exitData,
       )
 
-      const logger = new LineLoggerSubservice(statusMessage)
+      const logger = new LineLoggerSubservice(response.statusMessage)
 
       const diff = process.hrtime(startAt)
       const responseTime = diff[0] * 1e3 + diff[1] * 1e-6
       const logObj: Record<string, string | number> = {
         method,
         originalUrl,
-        statusCode,
+        statusCode: response.statusCode,
         responseTime,
         userAgent,
         ip,


### PR DESCRIPTION
Use response `statusCode` and `statusMessage` after the rest of the request pipeline has run, so that updated values are used.