### PR TITLE
Feat: import taxes with their payments

### DIFF
--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -235,6 +235,9 @@ export class AdminService {
       }),
     )
 
+    // Add the payments for these added taxes to database
+    await this.updatePaymentsFromNorisWithData(norisData)
+
     return { birthNumbers: birthNumbersResult }
   }
 
@@ -346,14 +349,20 @@ export class AdminService {
   }
 
   async updatePaymentsFromNoris(norisRequest: NorisRequestGeneral) {
-    let created = 0
-    let alreadyCreated = 0
     const norisPaymentData: Partial<NorisPaymentsDto>[] =
       norisRequest.type === 'fromToDate'
         ? await this.norisService.getPaymentDataFromNoris(norisRequest.data)
         : await this.norisService.getPaymentDataFromNorisByVariableSymbols(
             norisRequest.data,
           )
+    return this.updatePaymentsFromNorisWithData(norisPaymentData)
+  }
+
+  async updatePaymentsFromNorisWithData(
+    norisPaymentData: Partial<NorisPaymentsDto>[],
+  ) {
+    let created = 0
+    let alreadyCreated = 0
     const taxesDataMap = await this.getTaxesDataMap(norisPaymentData)
 
     // Get all tax IDs from taxesDataMap

--- a/nest-tax-backend/src/noris/noris.dto.ts
+++ b/nest-tax-backend/src/noris/noris.dto.ts
@@ -101,23 +101,13 @@ export interface NorisTaxPayersDto {
   drazba_dedic_od: string
   drazba_dedic_do: string
   uzivatelsky_atribut: string
+  uhrazeno: string
+  zbyva_uhradit: string
 }
 
 export interface NorisPaymentsDto {
   variabilny_symbol: string
-  suma_mena: string
-  datum_storno: Date | null
-  stav_dokladu: string
-  pohladavka: string
-  datum_posledni_platby: Date
   uhrazeno: string
   zbyva_uhradit: string
-  datum_odvolania: Date
-  druh_dokladu: string
-  spis_sluzba_datum: Date
-  rok_podkladu: number
-  spis_sluzba_stav: string
-  typ_dokladu: string
-  typ_podkladu: string
   specificky_symbol: string
 }

--- a/nest-tax-backend/src/noris/noris.queries.ts
+++ b/nest-tax-backend/src/noris/noris.queries.ts
@@ -10,7 +10,19 @@ SELECT
     lcs.dane21_doklad.datum_dorucenia, 
     lcs.dane21_doklad.datum_platnosti, 
     */
-   lcs.dane21_doklad.variabilny_symbol, 
+    lcs.dane21_doklad.variabilny_symbol, 
+    (case 
+        when isnull(lcs.dane21_druh_dokladu.generovat_pohladavku,'')='A' then view_doklad_saldo.uhrazeno 
+        else 0 end 
+    ) uhrazeno,
+    (case 
+        when isnull(lcs.dane21_druh_dokladu.generovat_pohladavku,'')='A' then (
+            case 
+                when dane21_doklad.stav_dokladu='S' then 0 
+                else view_doklad_saldo.zbyva_uhradit 
+            end)
+        else 0 
+    end ) zbyva_uhradit,
     /* 
     lcs.fn21_dec2string(lcs.dane21_doklad.suma_mena, 2) suma_mena, 
     lcs.fn21_dec2string(ABS(lcs.dane21_doklad.suma_mena), 2) AS abs_suma, 
@@ -563,13 +575,6 @@ ORDER BY
 export const queryPaymentsFromNoris = `
 SELECT 
         dane21_doklad.variabilny_symbol as variabilny_symbol,
-        lcs.dane21_druh_dokladu.posta,
-        lcs.dane21_priznanie.podnikatel,
-        dane21_doklad.suma_mena,
-        dane21_doklad.datum_storno,
-        dane21_doklad.stav_dokladu,
-        dane21_doklad.pohladavka pohladavka,
-        view_doklad_saldo.datum_posledni_platby datum_posledni_platby,
         (case 
             when isnull(lcs.dane21_druh_dokladu.generovat_pohladavku,'')='A' then view_doklad_saldo.uhrazeno 
             else 0 end 
@@ -582,16 +587,6 @@ SELECT
                 end)
             else 0 
         end ) zbyva_uhradit,
-        dane21_doklad.datum_odvolania,
-        dane21_doklad.druh_dokladu,
-        dane21_doklad.spis_sluzba_datum,
-        dane21_doklad.rok_podkladu,
-        dane21_doklad.spis_sluzba_stav,
-        lcs.dane21_druh_dokladu.typ_dokladu,
-        (case 
-            when vpodklad.riadne_priznanie IS null then 'Riadne' 
-            else 'Dodatočné' 
-        end) typ_podkladu,
         dane21_doklad.specificky_symbol specificky_symbol
     FROM 
         (SELECT


### PR DESCRIPTION
When importing taxes from Noris, import their payments right away so there won't be a delay where the tax could be marked as unpaid, even if it is already paid.

The noris queries were tested and are working correctly, the removed SELECT fields were not used anywhere in the code, so they are not necessary to be selected. It was important for `NorisPaymentsDto` to be a subset of `NorisTaxPayersDto`, so after selecting the taxes (including their payments), we can only call the function which adds the payments into database.