### PR TITLE
Fix: do not open many connections when updating delivery methods

### DIFF
--- a/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
+++ b/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
@@ -66,39 +66,35 @@ describe('TasksService', () => {
 
       expect(
         service['norisService'].updateDeliveryMethods,
-      ).toHaveBeenCalledTimes(4)
+      ).toHaveBeenCalledTimes(1)
       expect(
         service['norisService'].updateDeliveryMethods,
-      ).toHaveBeenCalledWith({
-        birthNumbers: ['123456/789', '234567/890'],
-        inCityAccount: IsInCityAccount.YES,
-        deliveryMethod: DeliveryMethod.EDESK,
-        date: null,
-      })
-      expect(
-        service['norisService'].updateDeliveryMethods,
-      ).toHaveBeenCalledWith({
-        birthNumbers: ['345678/901', '345678/902'],
-        inCityAccount: IsInCityAccount.YES,
-        deliveryMethod: DeliveryMethod.POSTAL,
-        date: null,
-      })
-      expect(
-        service['norisService'].updateDeliveryMethods,
-      ).toHaveBeenCalledWith({
-        birthNumbers: ['456789/0123'],
-        inCityAccount: IsInCityAccount.YES,
-        deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
-        date: mockDate1,
-      })
-      expect(
-        service['norisService'].updateDeliveryMethods,
-      ).toHaveBeenCalledWith({
-        birthNumbers: ['456789/0103'],
-        inCityAccount: IsInCityAccount.YES,
-        deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
-        date: mockDate2,
-      })
+      ).toHaveBeenCalledWith([
+        {
+          birthNumbers: ['123456/789', '234567/890'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.EDESK,
+          date: null,
+        },
+        {
+          birthNumbers: ['345678/901', '345678/902'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.POSTAL,
+          date: null,
+        },
+        {
+          birthNumbers: ['456789/0123'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+          date: mockDate1,
+        },
+        {
+          birthNumbers: ['456789/0103'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+          date: mockDate2,
+        },
+      ])
     })
 
     it('should skip empty groups', async () => {
@@ -116,12 +112,14 @@ describe('TasksService', () => {
       ).toHaveBeenCalledTimes(1)
       expect(
         service['norisService'].updateDeliveryMethods,
-      ).toHaveBeenCalledWith({
-        birthNumbers: ['001234/567', '000123/890'],
-        inCityAccount: IsInCityAccount.YES,
-        deliveryMethod: DeliveryMethod.EDESK,
-        date: null,
-      })
+      ).toHaveBeenCalledWith([
+        {
+          birthNumbers: ['001234/567', '000123/890'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.EDESK,
+          date: null,
+        },
+      ])
     })
 
     it('should handle empty input data', async () => {
@@ -147,12 +145,14 @@ describe('TasksService', () => {
       ).toHaveBeenCalledTimes(1)
       expect(
         service['norisService'].updateDeliveryMethods,
-      ).toHaveBeenCalledWith({
-        birthNumbers: ['123456/789'],
-        inCityAccount: IsInCityAccount.YES,
-        deliveryMethod: DeliveryMethod.EDESK,
-        date: null,
-      })
+      ).toHaveBeenCalledWith([
+        {
+          birthNumbers: ['123456/789'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.EDESK,
+          date: null,
+        },
+      ])
     })
 
     it('should propagate errors from norisService', async () => {
@@ -210,12 +210,14 @@ describe('TasksService', () => {
       ).toHaveBeenCalledTimes(1)
       expect(
         service['norisService'].updateDeliveryMethods,
-      ).toHaveBeenCalledWith({
-        birthNumbers: [birthNumber],
-        inCityAccount: IsInCityAccount.NO,
-        deliveryMethod: null,
-        date: null,
-      })
+      ).toHaveBeenCalledWith([
+        {
+          birthNumbers: [birthNumber],
+          inCityAccount: IsInCityAccount.NO,
+          deliveryMethod: null,
+          date: null,
+        },
+      ])
     })
 
     it('should propagate errors from norisService', async () => {

--- a/nest-tax-backend/src/noris/__tests__/noris.service.spec.ts
+++ b/nest-tax-backend/src/noris/__tests__/noris.service.spec.ts
@@ -1,0 +1,121 @@
+import { createMock } from '@golevelup/ts-jest'
+import { ConfigService } from '@nestjs/config'
+import { Test, TestingModule } from '@nestjs/testing'
+import * as mssql from 'mssql'
+
+import ThrowerErrorGuard from '../../utils/guards/errors.guard'
+import { NorisService } from '../noris.service'
+import { DeliveryMethod, IsInCityAccount } from '../noris.types'
+
+const mockConnection = {
+  close: jest.fn(),
+}
+
+const mockRequest = {
+  query: jest.fn(),
+  input: jest.fn(),
+}
+
+jest.mock('mssql', () => ({
+  connect: jest.fn().mockImplementation(() => mockConnection),
+  Request: jest.fn().mockImplementation(() => mockRequest),
+}))
+
+describe('NorisService', () => {
+  let service: NorisService
+
+  beforeAll(() => {
+    process.env = {
+      ...process.env,
+      MSSQL_HOST: 'mock-host',
+      MSSQL_DB: 'mock-db',
+      MSSQL_USERNAME: 'mock-username',
+      MSSQL_PASSWORD: 'mock-password',
+    }
+  })
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NorisService,
+        { provide: ConfigService, useValue: createMock<ConfigService>() },
+        ThrowerErrorGuard,
+      ],
+    }).compile()
+
+    service = module.get<NorisService>(NorisService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  describe('updateDeliveryMethods', () => {
+    it('should call for each data', async () => {
+      const requestSpy = jest.spyOn(mssql, 'Request')
+      const querySpy = jest.spyOn(mockRequest, 'query')
+      const closeSpy = jest.spyOn(mockConnection, 'close')
+
+      await service.updateDeliveryMethods([
+        {
+          birthNumbers: ['003322/4455', '003322/4456'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.POSTAL,
+          date: null,
+        },
+        {
+          birthNumbers: ['003322/4455', '003322/4456'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.EDESK,
+          date: null,
+        },
+        {
+          birthNumbers: ['003322/4455', '003322/4456'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+          date: '2024-01-01',
+        },
+      ])
+
+      expect(requestSpy).toHaveBeenCalledTimes(3)
+      expect(querySpy).toHaveBeenCalledTimes(3)
+      expect(closeSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw if something throws', async () => {
+      jest.spyOn(mssql, 'Request').mockImplementation(() => {
+        throw new Error('mock-error')
+      })
+      const querySpy = jest.spyOn(mockRequest, 'query')
+      const closeSpy = jest.spyOn(mockConnection, 'close')
+
+      await expect(
+        service.updateDeliveryMethods([
+          {
+            birthNumbers: ['003322/4455', '003322/4456'],
+            inCityAccount: IsInCityAccount.YES,
+            deliveryMethod: DeliveryMethod.POSTAL,
+            date: null,
+          },
+          {
+            birthNumbers: ['003322/4455', '003322/4456'],
+            inCityAccount: IsInCityAccount.YES,
+            deliveryMethod: DeliveryMethod.EDESK,
+            date: null,
+          },
+          {
+            birthNumbers: ['003322/4455', '003322/4456'],
+            inCityAccount: IsInCityAccount.YES,
+            deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+            date: '2024-01-01',
+          },
+        ]),
+      ).rejects.toThrow()
+
+      expect(querySpy).not.toHaveBeenCalled()
+      expect(closeSpy).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Instead of one connection for each update of delivery method create just one connection and perform multiple Requests on it.