### PR TITLE
1850 Generate form summary from persisted `formSummary` from DB in sent forms

### DIFF
--- a/forms-shared/src/signer/signerData.ts
+++ b/forms-shared/src/signer/signerData.ts
@@ -15,6 +15,8 @@ import { buildSlovenskoSkXml } from '../slovensko-sk/xmlBuilder'
 import { getSchemaXsd } from '../slovensko-sk/file-templates/schemaXsd'
 import { getHtmlSbXslt } from '../slovensko-sk/file-templates/htmlSbXslt'
 import { createFormSignatureId } from './signatureId'
+import { getFormSummary } from '../summary/summary'
+import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 export type GetSignerDataParams<
   FormDefinition extends FormDefinitionSlovenskoSk = FormDefinitionSlovenskoSk,
@@ -75,10 +77,15 @@ const getSlovenskoSkGenericXmls = async (
 ) => {
   const { formDefinition, formData, validatorRegistry, serverFiles } = params
 
+  const formSummary = getFormSummary({
+    formDefinition,
+    formDataJson: formData,
+    validatorRegistry: testValidatorRegistry,
+  })
   const xmlObject = await generateSlovenskoSkXmlObject({
     formDefinition,
     formData,
-    validatorRegistry,
+    formSummary,
     serverFiles,
   })
   const xdcXMLData = buildSlovenskoSkXml(xmlObject, { headless: false, pretty: false })

--- a/forms-shared/src/signer/signerData.ts
+++ b/forms-shared/src/signer/signerData.ts
@@ -16,7 +16,6 @@ import { getSchemaXsd } from '../slovensko-sk/file-templates/schemaXsd'
 import { getHtmlSbXslt } from '../slovensko-sk/file-templates/htmlSbXslt'
 import { createFormSignatureId } from './signatureId'
 import { getFormSummary } from '../summary/summary'
-import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 
 export type GetSignerDataParams<
   FormDefinition extends FormDefinitionSlovenskoSk = FormDefinitionSlovenskoSk,
@@ -24,6 +23,7 @@ export type GetSignerDataParams<
   formDefinition: FormDefinition
   formId: string
   formData: TaxFormData
+  jsonVersion: string
   validatorRegistry: BaRjsfValidatorRegistry
   serverFiles?: FormsBackendFile[]
 }
@@ -75,16 +75,17 @@ const formatTitleForObjectId = (title: string): string => {
 const getSlovenskoSkGenericXmls = async (
   params: GetSignerDataParams<FormDefinitionSlovenskoSkGeneric>,
 ) => {
-  const { formDefinition, formData, validatorRegistry, serverFiles } = params
+  const { formDefinition, formData, jsonVersion, serverFiles, validatorRegistry } = params
 
   const formSummary = getFormSummary({
     formDefinition,
     formDataJson: formData,
-    validatorRegistry: testValidatorRegistry,
+    validatorRegistry,
   })
   const xmlObject = await generateSlovenskoSkXmlObject({
     formDefinition,
     formData,
+    jsonVersion,
     formSummary,
     serverFiles,
   })

--- a/forms-shared/src/signer/signerData.ts
+++ b/forms-shared/src/signer/signerData.ts
@@ -75,12 +75,12 @@ const getSlovenskoSkGenericXmls = async (
 ) => {
   const { formDefinition, formData, validatorRegistry, serverFiles } = params
 
-  const xmlObject = await generateSlovenskoSkXmlObject(
+  const xmlObject = await generateSlovenskoSkXmlObject({
     formDefinition,
     formData,
     validatorRegistry,
     serverFiles,
-  )
+  })
   const xdcXMLData = buildSlovenskoSkXml(xmlObject, { headless: false, pretty: false })
   const xdcUsedXSD = getSchemaXsd(formDefinition)
   const xdcUsedXSLT = getHtmlSbXslt(formDefinition)

--- a/forms-shared/src/slovensko-sk/generateXml.ts
+++ b/forms-shared/src/slovensko-sk/generateXml.ts
@@ -39,24 +39,31 @@ export function getEmptySlovenskoSkXmlObject(formDefinition: FormDefinitionSlove
   })
 }
 
+type GenerateSlovenskoSkXmlObjectParams = {
+  formDefinition: FormDefinitionSlovenskoSk
+  formData: GenericObjectType
+  validatorRegistry: BaRjsfValidatorRegistry
+  serverFiles?: FormsBackendFile[]
+}
+
 /**
  * Generates a Slovensko SK XML object that can be built with "xml2js" to create a valid XML.
  */
-export async function generateSlovenskoSkXmlObject(
-  formDefinition: FormDefinitionSlovenskoSk,
-  formData: GenericObjectType,
-  validatorRegistry: BaRjsfValidatorRegistry,
-  serverFiles?: FormsBackendFile[],
-) {
+export async function generateSlovenskoSkXmlObject({
+  formDefinition,
+  formData,
+  validatorRegistry,
+  serverFiles,
+}: GenerateSlovenskoSkXmlObjectParams) {
   return getSlovenskoSkXmlObjectBase(formDefinition, {
     JsonVersion: formDefinition.jsonVersion,
     Json: JSON.stringify(formData),
-    Summary: await renderSlovenskoXmlSummary(
+    Summary: await renderSlovenskoXmlSummary({
       formDefinition,
       formData,
       validatorRegistry,
       serverFiles,
-    ),
+    }),
     TermsAndConditions: removeMarkdown(formDefinition.termsAndConditions),
   })
 }

--- a/forms-shared/src/slovensko-sk/generateXml.ts
+++ b/forms-shared/src/slovensko-sk/generateXml.ts
@@ -43,6 +43,7 @@ type GenerateSlovenskoSkXmlObjectParams = {
   formDefinition: FormDefinitionSlovenskoSk
   formSummary: FormSummary
   formData: GenericObjectType
+  jsonVersion: string
   serverFiles?: FormsBackendFile[]
 }
 
@@ -53,10 +54,11 @@ export async function generateSlovenskoSkXmlObject({
   formDefinition,
   formSummary,
   formData,
+  jsonVersion,
   serverFiles,
 }: GenerateSlovenskoSkXmlObjectParams) {
   return getSlovenskoSkXmlObjectBase(formDefinition, {
-    JsonVersion: formDefinition.jsonVersion,
+    JsonVersion: jsonVersion,
     Json: JSON.stringify(formData),
     Summary: await renderSlovenskoXmlSummary({
       formSummary,

--- a/forms-shared/src/slovensko-sk/generateXml.ts
+++ b/forms-shared/src/slovensko-sk/generateXml.ts
@@ -4,7 +4,7 @@ import { renderSlovenskoXmlSummary } from './renderXmlSummary'
 import removeMarkdown from 'remove-markdown'
 import { FormsBackendFile } from '../form-files/serverFilesTypes'
 import { getSlovenskoSkXmlns } from './urls'
-import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
+import { FormSummary } from '../summary/summary'
 
 function getSlovenskoSkXmlObjectBase(
   formDefinition: FormDefinitionSlovenskoSk,
@@ -41,8 +41,8 @@ export function getEmptySlovenskoSkXmlObject(formDefinition: FormDefinitionSlove
 
 type GenerateSlovenskoSkXmlObjectParams = {
   formDefinition: FormDefinitionSlovenskoSk
+  formSummary: FormSummary
   formData: GenericObjectType
-  validatorRegistry: BaRjsfValidatorRegistry
   serverFiles?: FormsBackendFile[]
 }
 
@@ -51,19 +51,17 @@ type GenerateSlovenskoSkXmlObjectParams = {
  */
 export async function generateSlovenskoSkXmlObject({
   formDefinition,
+  formSummary,
   formData,
-  validatorRegistry,
   serverFiles,
 }: GenerateSlovenskoSkXmlObjectParams) {
   return getSlovenskoSkXmlObjectBase(formDefinition, {
     JsonVersion: formDefinition.jsonVersion,
     Json: JSON.stringify(formData),
     Summary: await renderSlovenskoXmlSummary({
-      formDefinition,
-      formData,
-      validatorRegistry,
+      formSummary,
       serverFiles,
     }),
-    TermsAndConditions: removeMarkdown(formDefinition.termsAndConditions),
+    TermsAndConditions: removeMarkdown(formSummary.termsAndConditions),
   })
 }

--- a/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
+++ b/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
@@ -10,9 +10,8 @@ import {
   SummaryStringValueRendererProps,
 } from '../summary-renderer/SummaryRenderer'
 import { SummaryJsonForm } from '../summary-json/summaryJsonTypes'
-import { validateSummary } from '../summary-renderer/validateSummary'
 import { FormDefinition } from '../definitions/formDefinitionTypes'
-import { GenericObjectType, ValidationData } from '@rjsf/utils'
+import { GenericObjectType } from '@rjsf/utils'
 import { renderToString } from 'react-dom/server'
 import { getSummaryJsonNode } from '../summary-json/getSummaryJsonNode'
 import { Parser } from 'xml2js'
@@ -24,7 +23,6 @@ import { FileInfoSummary } from '../form-files/fileStatus'
 type SlovenskoSkSummaryXmlProps = {
   summaryJson: SummaryJsonForm
   fileInfos: Record<string, FileInfoSummary>
-  validationData: ValidationData<GenericObjectType>
 }
 
 type CustomElement<P = {}> = DetailedHTMLProps<HTMLAttributes<HTMLElement> & P, HTMLElement>
@@ -95,16 +93,11 @@ const ArrayItemRenderer = ({ arrayItem, children }: SummaryArrayItemRendererProp
   )
 }
 
-export const SlovenskoSkSummaryXml = ({
-  summaryJson,
-  validationData,
-  fileInfos,
-}: SlovenskoSkSummaryXmlProps) => {
+export const SlovenskoSkSummaryXml = ({ summaryJson, fileInfos }: SlovenskoSkSummaryXmlProps) => {
   return (
     <SummaryRenderer
       summaryJson={summaryJson}
       fileInfos={fileInfos}
-      validationData={validationData}
       renderForm={FormRenderer}
       renderStep={StepRenderer}
       renderField={FieldRenderer}
@@ -149,19 +142,9 @@ export async function renderSlovenskoXmlSummary(
 ) {
   const summaryJson = getSummaryJsonNode(formDefinition.schema, formData, validatorRegistry)
   const fileInfos = mergeClientAndServerFilesSummary([], serverFiles)
-  const { validationData } = validateSummary(
-    formDefinition.schema,
-    formData,
-    fileInfos,
-    validatorRegistry,
-  )
 
   const stringXml = renderToString(
-    <SlovenskoSkSummaryXml
-      summaryJson={summaryJson}
-      fileInfos={fileInfos}
-      validationData={validationData}
-    />,
+    <SlovenskoSkSummaryXml summaryJson={summaryJson} fileInfos={fileInfos} />,
   )
 
   return await parser.parseStringPromise(stringXml)

--- a/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
+++ b/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
@@ -140,7 +140,11 @@ export async function renderSlovenskoXmlSummary(
   validatorRegistry: BaRjsfValidatorRegistry,
   serverFiles?: FormsBackendFile[],
 ) {
-  const summaryJson = getSummaryJsonNode(formDefinition.schema, formData, validatorRegistry)
+  const summaryJson = getSummaryJsonNode({
+    schema: formDefinition.schema,
+    formData,
+    validatorRegistry,
+  })
   const fileInfos = mergeClientAndServerFilesSummary([], serverFiles)
 
   const stringXml = renderToString(

--- a/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
+++ b/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
@@ -134,12 +134,19 @@ const parser = new Parser({
   ],
 })
 
-export async function renderSlovenskoXmlSummary(
-  formDefinition: FormDefinition,
-  formData: GenericObjectType,
-  validatorRegistry: BaRjsfValidatorRegistry,
-  serverFiles?: FormsBackendFile[],
-) {
+type RenderSlovenskoXmlSummaryParams = {
+  formDefinition: FormDefinition
+  formData: GenericObjectType
+  validatorRegistry: BaRjsfValidatorRegistry
+  serverFiles?: FormsBackendFile[]
+}
+
+export async function renderSlovenskoXmlSummary({
+  formDefinition,
+  formData,
+  validatorRegistry,
+  serverFiles,
+}: RenderSlovenskoXmlSummaryParams) {
   const summaryJson = getSummaryJsonNode({
     schema: formDefinition.schema,
     formData,

--- a/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
+++ b/forms-shared/src/slovensko-sk/renderXmlSummary.tsx
@@ -9,19 +9,15 @@ import {
   SummaryStepRendererProps,
   SummaryStringValueRendererProps,
 } from '../summary-renderer/SummaryRenderer'
-import { SummaryJsonForm } from '../summary-json/summaryJsonTypes'
-import { FormDefinition } from '../definitions/formDefinitionTypes'
-import { GenericObjectType } from '@rjsf/utils'
 import { renderToString } from 'react-dom/server'
-import { getSummaryJsonNode } from '../summary-json/getSummaryJsonNode'
 import { Parser } from 'xml2js'
 import { FormsBackendFile } from '../form-files/serverFilesTypes'
 import { mergeClientAndServerFilesSummary } from '../form-files/mergeClientAndServerFiles'
-import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 import { FileInfoSummary } from '../form-files/fileStatus'
+import { FormSummary } from '../summary/summary'
 
 type SlovenskoSkSummaryXmlProps = {
-  summaryJson: SummaryJsonForm
+  formSummary: FormSummary
   fileInfos: Record<string, FileInfoSummary>
 }
 
@@ -93,7 +89,10 @@ const ArrayItemRenderer = ({ arrayItem, children }: SummaryArrayItemRendererProp
   )
 }
 
-export const SlovenskoSkSummaryXml = ({ summaryJson, fileInfos }: SlovenskoSkSummaryXmlProps) => {
+export const SlovenskoSkSummaryXml = ({
+  formSummary: { summaryJson },
+  fileInfos,
+}: SlovenskoSkSummaryXmlProps) => {
   return (
     <SummaryRenderer
       summaryJson={summaryJson}
@@ -135,27 +134,18 @@ const parser = new Parser({
 })
 
 type RenderSlovenskoXmlSummaryParams = {
-  formDefinition: FormDefinition
-  formData: GenericObjectType
-  validatorRegistry: BaRjsfValidatorRegistry
+  formSummary: FormSummary
   serverFiles?: FormsBackendFile[]
 }
 
 export async function renderSlovenskoXmlSummary({
-  formDefinition,
-  formData,
-  validatorRegistry,
+  formSummary,
   serverFiles,
 }: RenderSlovenskoXmlSummaryParams) {
-  const summaryJson = getSummaryJsonNode({
-    schema: formDefinition.schema,
-    formData,
-    validatorRegistry,
-  })
   const fileInfos = mergeClientAndServerFilesSummary([], serverFiles)
 
   const stringXml = renderToString(
-    <SlovenskoSkSummaryXml summaryJson={summaryJson} fileInfos={fileInfos} />,
+    <SlovenskoSkSummaryXml formSummary={formSummary} fileInfos={fileInfos} />,
   )
 
   return await parser.parseStringPromise(stringXml)

--- a/forms-shared/src/summary-email/SummaryEmail.tsx
+++ b/forms-shared/src/summary-email/SummaryEmail.tsx
@@ -14,13 +14,11 @@ import {
 } from '../summary-renderer/SummaryRenderer'
 import { SummaryJsonForm } from '../summary-json/summaryJsonTypes'
 import { FileIdInfoMap } from './renderSummaryEmail'
-import { GenericObjectType, ValidationData } from '@rjsf/utils'
 import { FileInfoSummary } from '../form-files/fileStatus'
 
 type SummaryEmailProps = {
   summaryJson: SummaryJsonForm
   fileInfos: Record<string, FileInfoSummary>
-  validationData: ValidationData<GenericObjectType>
   fileIdInfoMap: FileIdInfoMap
   withHtmlBodyTags: boolean
 }
@@ -142,7 +140,6 @@ const ArrayItemRenderer = ({ arrayItem, children, isLast }: SummaryArrayItemRend
 export const SummaryEmail = ({
   summaryJson,
   fileInfos,
-  validationData,
   fileIdInfoMap,
   withHtmlBodyTags,
 }: SummaryEmailProps) => {
@@ -151,7 +148,6 @@ export const SummaryEmail = ({
       <SummaryRenderer
         summaryJson={summaryJson}
         fileInfos={fileInfos}
-        validationData={validationData}
         renderForm={FormRenderer}
         renderStep={StepRenderer}
         renderField={FieldRenderer}

--- a/forms-shared/src/summary-email/SummaryEmail.tsx
+++ b/forms-shared/src/summary-email/SummaryEmail.tsx
@@ -12,12 +12,12 @@ import {
   SummaryStepRendererProps,
   SummaryStringValueRendererProps,
 } from '../summary-renderer/SummaryRenderer'
-import { SummaryJsonForm } from '../summary-json/summaryJsonTypes'
 import { FileIdInfoMap } from './renderSummaryEmail'
 import { FileInfoSummary } from '../form-files/fileStatus'
+import { FormSummary } from '../summary/summary'
 
 type SummaryEmailProps = {
-  summaryJson: SummaryJsonForm
+  formSummary: FormSummary
   fileInfos: Record<string, FileInfoSummary>
   fileIdInfoMap: FileIdInfoMap
   withHtmlBodyTags: boolean
@@ -138,7 +138,7 @@ const ArrayItemRenderer = ({ arrayItem, children, isLast }: SummaryArrayItemRend
 )
 
 export const SummaryEmail = ({
-  summaryJson,
+  formSummary: { summaryJson },
   fileInfos,
   fileIdInfoMap,
   withHtmlBodyTags,

--- a/forms-shared/src/summary-email/renderSummaryEmail.tsx
+++ b/forms-shared/src/summary-email/renderSummaryEmail.tsx
@@ -27,7 +27,11 @@ export const renderSummaryEmail = async ({
   serverFiles,
   withHtmlBodyTags = false,
 }: RenderSummaryEmailPayload) => {
-  const summaryJson = getSummaryJsonNode(formDefinition.schema, formData, validatorRegistry)
+  const summaryJson = getSummaryJsonNode({
+    schema: formDefinition.schema,
+    formData,
+    validatorRegistry,
+  })
   const fileInfos = mergeClientAndServerFilesSummary([], serverFiles)
 
   return render(

--- a/forms-shared/src/summary-email/renderSummaryEmail.tsx
+++ b/forms-shared/src/summary-email/renderSummaryEmail.tsx
@@ -1,18 +1,15 @@
 import React from 'react'
-import { GenericObjectType } from '@rjsf/utils'
-import { getSummaryJsonNode } from '../summary-json/getSummaryJsonNode'
 import { FormsBackendFile } from '../form-files/serverFilesTypes'
 import { mergeClientAndServerFilesSummary } from '../form-files/mergeClientAndServerFiles'
 import { render } from '@react-email/components'
 import { SummaryEmail } from './SummaryEmail'
-import { FormDefinition } from '../definitions/formDefinitionTypes'
 import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
+import { FormSummary } from '../summary/summary'
 
 export type FileIdInfoMap = Record<string, { url: string; fileName: string }>
 
 export type RenderSummaryEmailPayload = {
-  formDefinition: FormDefinition
-  formData: GenericObjectType
+  formSummary: FormSummary
   fileIdInfoMap: FileIdInfoMap
   validatorRegistry: BaRjsfValidatorRegistry
   serverFiles?: FormsBackendFile[]
@@ -20,23 +17,16 @@ export type RenderSummaryEmailPayload = {
 }
 
 export const renderSummaryEmail = async ({
-  formDefinition,
-  formData,
+  formSummary,
   fileIdInfoMap,
-  validatorRegistry,
   serverFiles,
   withHtmlBodyTags = false,
 }: RenderSummaryEmailPayload) => {
-  const summaryJson = getSummaryJsonNode({
-    schema: formDefinition.schema,
-    formData,
-    validatorRegistry,
-  })
   const fileInfos = mergeClientAndServerFilesSummary([], serverFiles)
 
   return render(
     <SummaryEmail
-      summaryJson={summaryJson}
+      formSummary={formSummary}
       fileInfos={fileInfos}
       fileIdInfoMap={fileIdInfoMap}
       withHtmlBodyTags={withHtmlBodyTags}

--- a/forms-shared/src/summary-email/renderSummaryEmail.tsx
+++ b/forms-shared/src/summary-email/renderSummaryEmail.tsx
@@ -3,7 +3,6 @@ import { GenericObjectType } from '@rjsf/utils'
 import { getSummaryJsonNode } from '../summary-json/getSummaryJsonNode'
 import { FormsBackendFile } from '../form-files/serverFilesTypes'
 import { mergeClientAndServerFilesSummary } from '../form-files/mergeClientAndServerFiles'
-import { validateSummary } from '../summary-renderer/validateSummary'
 import { render } from '@react-email/components'
 import { SummaryEmail } from './SummaryEmail'
 import { FormDefinition } from '../definitions/formDefinitionTypes'
@@ -30,18 +29,11 @@ export const renderSummaryEmail = async ({
 }: RenderSummaryEmailPayload) => {
   const summaryJson = getSummaryJsonNode(formDefinition.schema, formData, validatorRegistry)
   const fileInfos = mergeClientAndServerFilesSummary([], serverFiles)
-  const { validationData } = validateSummary(
-    formDefinition.schema,
-    formData,
-    fileInfos,
-    validatorRegistry,
-  )
 
   return render(
     <SummaryEmail
       summaryJson={summaryJson}
       fileInfos={fileInfos}
-      validationData={validationData}
       fileIdInfoMap={fileIdInfoMap}
       withHtmlBodyTags={withHtmlBodyTags}
     ></SummaryEmail>,

--- a/forms-shared/src/summary-json/getSummaryJson.tsx
+++ b/forms-shared/src/summary-json/getSummaryJson.tsx
@@ -14,6 +14,12 @@ import {
 import { SummaryXmlForm, SummaryXmlFormTag } from './SummaryXmlForm'
 import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
+export type GetSummaryJsonParams = {
+  schema: RJSFSchema
+  formData: GenericObjectType
+  validatorRegistry: BaRjsfValidatorRegistry
+}
+
 const allowedChildren: Record<SummaryXmlFormTag, SummaryXmlFormTag[]> = {
   [SummaryXmlFormTag.Form]: [SummaryXmlFormTag.Step],
   [SummaryXmlFormTag.Step]: [SummaryXmlFormTag.Field, SummaryXmlFormTag.Array],
@@ -143,15 +149,15 @@ function parseXml(domParserInstance: DOMParser, xmlString: string) {
 /**
  * Renders the summary form and parses the XML into a JSON object.
  */
-export const getSummaryJson = (
-  schema: RJSFSchema,
-  data: GenericObjectType,
-  domParserInstance: DOMParser,
-  validatorRegistry: BaRjsfValidatorRegistry,
-) => {
+export const getSummaryJson = ({
+  schema,
+  formData,
+  domParserInstance,
+  validatorRegistry,
+}: GetSummaryJsonParams & { domParserInstance: DOMParser }) => {
   // eslint-disable-next-line testing-library/render-result-naming-convention
   const renderedString = renderToString(
-    <SummaryXmlForm schema={schema} formData={data} validatorRegistry={validatorRegistry} />,
+    <SummaryXmlForm schema={schema} formData={formData} validatorRegistry={validatorRegistry} />,
   )
 
   return parseXml(domParserInstance, renderedString)

--- a/forms-shared/src/summary-json/getSummaryJsonBrowser.ts
+++ b/forms-shared/src/summary-json/getSummaryJsonBrowser.ts
@@ -1,18 +1,15 @@
-import { GenericObjectType, RJSFSchema } from '@rjsf/utils'
-
-import { getSummaryJson } from './getSummaryJson'
-import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
+import { getSummaryJson, GetSummaryJsonParams } from './getSummaryJson'
 
 /**
  * Browser implementation of `getSummaryJson`. It cannot be used in Node.js environment, because
  * `window.DOMParser` is not available there.
  */
-export const getSummaryJsonBrowser = (
-  schema: RJSFSchema,
-  data: GenericObjectType,
-  validatorRegistry: BaRjsfValidatorRegistry,
-) => {
+export const getSummaryJsonBrowser = ({
+  schema,
+  formData,
+  validatorRegistry,
+}: GetSummaryJsonParams) => {
   const domParserInstance = new window.DOMParser()
 
-  return getSummaryJson(schema, data, domParserInstance, validatorRegistry)
+  return getSummaryJson({ schema, formData, domParserInstance, validatorRegistry })
 }

--- a/forms-shared/src/summary-json/getSummaryJsonNode.ts
+++ b/forms-shared/src/summary-json/getSummaryJsonNode.ts
@@ -1,8 +1,6 @@
-import { GenericObjectType, RJSFSchema } from '@rjsf/utils'
 import jsdom from 'jsdom'
 
-import { getSummaryJson } from './getSummaryJson'
-import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
+import { getSummaryJson, GetSummaryJsonParams } from './getSummaryJson'
 
 /**
  * Node.js implementation of `getSummaryJson`. Instead of `window.DOMParser` (which is not available
@@ -10,13 +8,13 @@ import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
  * `jsdom` is huge - https://bundlephobia.com/package/jsdom, therefore it must never be included in
  * the client bundle.
  */
-export const getSummaryJsonNode = (
-  schema: RJSFSchema,
-  data: GenericObjectType,
-  validatorRegistry: BaRjsfValidatorRegistry,
-) => {
+export const getSummaryJsonNode = ({
+  schema,
+  formData,
+  validatorRegistry,
+}: GetSummaryJsonParams) => {
   const jsDomInstance = new jsdom.JSDOM()
   const domParserInstance = new jsDomInstance.window.DOMParser()
 
-  return getSummaryJson(schema, data, domParserInstance, validatorRegistry)
+  return getSummaryJson({ schema, formData, domParserInstance, validatorRegistry })
 }

--- a/forms-shared/src/summary-pdf/SummaryPdf.tsx
+++ b/forms-shared/src/summary-pdf/SummaryPdf.tsx
@@ -9,21 +9,17 @@ import {
   SummaryStepRendererProps,
   SummaryStringValueRendererProps,
 } from '../summary-renderer/SummaryRenderer'
-import { SummaryJsonForm } from '../summary-json/summaryJsonTypes'
 import Markdown from 'react-markdown'
 import cx from 'classnames'
-import { FormDefinition } from '../definitions/formDefinitionTypes'
 import { GenericObjectType, ValidationData } from '@rjsf/utils'
-import { renderFormAdditionalInfo } from '../string-templates/renderTemplate'
 import { FileInfoSummary } from '../form-files/fileStatus'
+import { FormSummary } from '../summary/summary'
 
 type SummaryPdfProps = {
-  formDefinition: FormDefinition
+  formSummary: FormSummary
   cssToInject: string
-  formData: GenericObjectType
-  summaryJson: SummaryJsonForm
   fileInfos: Record<string, FileInfoSummary>
-  validationData: ValidationData<GenericObjectType>
+  validationData?: ValidationData<GenericObjectType>
 }
 
 const FormRenderer = ({ form, children }: SummaryFormRendererProps) => (
@@ -143,12 +139,7 @@ const SummaryMarkdown = ({ className, children }: { className: string; children:
   )
 }
 
-const AdditionalInfo = ({
-  formDefinition,
-  formData,
-}: Pick<SummaryPdfProps, 'formDefinition' | 'formData'>) => {
-  const additionalInfo = renderFormAdditionalInfo(formDefinition, formData)
-
+const AdditionalInfo = ({ additionalInfo }: { additionalInfo: string | null }) => {
   if (!additionalInfo) {
     return null
   }
@@ -161,24 +152,20 @@ const AdditionalInfo = ({
   )
 }
 
-const TermsAndConditions = ({ formDefinition }: Pick<SummaryPdfProps, 'formDefinition'>) => {
+const TermsAndConditions = ({ termsAndConditions }: { termsAndConditions: string }) => {
   return (
     <div className="flex flex-col gap-4">
       <h2 className="text-xl font-semibold">Ochrana osobných údajov</h2>
-      <SummaryMarkdown className="rounded-xl bg-gray-50 p-6">
-        {formDefinition.termsAndConditions}
-      </SummaryMarkdown>
+      <SummaryMarkdown className="rounded-xl bg-gray-50 p-6">{termsAndConditions}</SummaryMarkdown>
     </div>
   )
 }
 
 export const SummaryPdf = ({
-  formDefinition,
+  formSummary: { summaryJson, additionalInfo, termsAndConditions },
   cssToInject,
-  summaryJson,
   fileInfos,
   validationData,
-  formData,
 }: SummaryPdfProps) => {
   return (
     <html>
@@ -202,8 +189,8 @@ export const SummaryPdf = ({
             renderNoneValue={NoneValueRenderer}
             renderInvalidValue={InvalidValueRenderer}
           />
-          <AdditionalInfo formDefinition={formDefinition} formData={formData} />
-          <TermsAndConditions formDefinition={formDefinition} />
+          <AdditionalInfo additionalInfo={additionalInfo} />
+          <TermsAndConditions termsAndConditions={termsAndConditions} />
         </div>
       </body>
     </html>

--- a/forms-shared/src/summary-pdf/renderSummaryPdf.tsx
+++ b/forms-shared/src/summary-pdf/renderSummaryPdf.tsx
@@ -1,26 +1,22 @@
 import React from 'react'
 import type { Browser } from 'playwright'
-import { GenericObjectType } from '@rjsf/utils'
-import { getSummaryJsonNode } from '../summary-json/getSummaryJsonNode'
 import { renderToString } from 'react-dom/server'
 import { SummaryPdf } from './SummaryPdf'
 import { FormsBackendFile } from '../form-files/serverFilesTypes'
 import { ClientFileInfo } from '../form-files/fileStatus'
 import { mergeClientAndServerFilesSummary } from '../form-files/mergeClientAndServerFiles'
-import { validateSummary } from '../summary-renderer/validateSummary'
 import summaryPdfCss from '../generated-assets/summaryPdfCss'
-import { FormDefinition } from '../definitions/formDefinitionTypes'
-import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
+import { FormSummary } from '../summary/summary'
+import { GenericObjectType, ValidationData } from '@rjsf/utils'
 
 export type RenderSummaryPdfPayload = {
-  formDefinition: FormDefinition
-  formData: GenericObjectType
+  formSummary: FormSummary
+  validationData?: ValidationData<GenericObjectType>
   /**
    * Playwright must be installed and managed by the consumer of this function (e.g. in Docker) to run correctly, and is
    * only a peer dependency of this package.
    */
   launchBrowser: () => Promise<Browser>
-  validatorRegistry: BaRjsfValidatorRegistry
   serverFiles?: FormsBackendFile[]
   clientFiles?: ClientFileInfo[]
 }
@@ -29,35 +25,20 @@ export type RenderSummaryPdfPayload = {
  * Renders a summary PDF from the given JSON schema, UI schema and data.
  */
 export const renderSummaryPdf = async ({
-  formDefinition,
-  formData,
+  formSummary,
+  validationData,
   launchBrowser,
-  validatorRegistry,
   clientFiles,
   serverFiles,
 }: RenderSummaryPdfPayload) => {
-  const summaryJson = getSummaryJsonNode({
-    schema: formDefinition.schema,
-    formData,
-    validatorRegistry,
-  })
-
   const fileInfos = mergeClientAndServerFilesSummary(clientFiles, serverFiles)
-  const { validationData } = validateSummary(
-    formDefinition.schema,
-    formData,
-    fileInfos,
-    validatorRegistry,
-  )
 
   const renderedString = renderToString(
     <SummaryPdf
-      formDefinition={formDefinition}
-      cssToInject={summaryPdfCss.toString()}
-      summaryJson={summaryJson}
-      fileInfos={fileInfos}
+      formSummary={formSummary}
       validationData={validationData}
-      formData={formData}
+      cssToInject={summaryPdfCss.toString()}
+      fileInfos={fileInfos}
     ></SummaryPdf>,
   )
   const browser = await launchBrowser()

--- a/forms-shared/src/summary-pdf/renderSummaryPdf.tsx
+++ b/forms-shared/src/summary-pdf/renderSummaryPdf.tsx
@@ -36,7 +36,11 @@ export const renderSummaryPdf = async ({
   clientFiles,
   serverFiles,
 }: RenderSummaryPdfPayload) => {
-  const summaryJson = getSummaryJsonNode(formDefinition.schema, formData, validatorRegistry)
+  const summaryJson = getSummaryJsonNode({
+    schema: formDefinition.schema,
+    formData,
+    validatorRegistry,
+  })
 
   const fileInfos = mergeClientAndServerFilesSummary(clientFiles, serverFiles)
   const { validationData } = validateSummary(

--- a/forms-shared/src/summary-renderer/SummaryRenderer.tsx
+++ b/forms-shared/src/summary-renderer/SummaryRenderer.tsx
@@ -84,6 +84,9 @@ type DisplayValueRendererProps = {
 type SummaryRendererProps = {
   summaryJson: SummaryJsonForm
   fileInfos: Record<string, FileInfoSummary>
+  /**
+   * Required only for summaries that display validation errors (FE app, PDF).
+   */
   validationData?: ValidationData<GenericObjectType>
   renderForm: (props: SummaryFormRendererProps) => ReactNode
   renderStep: (props: SummaryStepRendererProps) => ReactNode

--- a/forms-shared/src/summary-renderer/validateSummary.ts
+++ b/forms-shared/src/summary-renderer/validateSummary.ts
@@ -6,6 +6,13 @@ import { baGetDefaultFormStateStable } from '../form-utils/defaultFormState'
 import { validateBaFileUuid } from '../form-utils/ajvFormats'
 import { BaRjsfValidatorRegistry } from '../form-utils/validatorRegistry'
 
+type ValidateSummaryParams = {
+  schema: RJSFSchema
+  formData: GenericObjectType
+  fileInfos: Record<string, FileInfoSummary>
+  validatorRegistry: BaRjsfValidatorRegistry
+}
+
 export type ValidatedSummary = {
   hasErrors: boolean
   validationData: ValidationData<GenericObjectType>
@@ -19,12 +26,12 @@ export type ValidatedSummary = {
  * to traverse the form data for specific values. In this case, we extract the files we need to give a special attention
  * in summary.
  */
-export const validateSummary = (
-  schema: RJSFSchema,
-  formData: GenericObjectType,
-  fileInfos: Record<string, FileInfoSummary>,
-  validatorRegistry: BaRjsfValidatorRegistry,
-): ValidatedSummary => {
+export const validateSummary = ({
+  schema,
+  formData,
+  fileInfos,
+  validatorRegistry,
+}: ValidateSummaryParams): ValidatedSummary => {
   // When displaying summary, all the default data must be present to get correct error schema for each field, e.g. when
   // we have schema like this:
   //  - `wrapper` (object, required)

--- a/forms-shared/src/summary/summary.ts
+++ b/forms-shared/src/summary/summary.ts
@@ -11,12 +11,22 @@ export interface FormSummary {
   termsAndConditions: string
 }
 
-export const getFormSummary = (
-  formDefinition: FormDefinition,
-  formDataJson: GenericObjectType,
-  validatorRegistry: BaRjsfValidatorRegistry,
-): FormSummary => {
-  const summaryJson = getSummaryJsonNode(formDefinition.schema, formDataJson, validatorRegistry)
+type GetFormSummaryParams = {
+  formDefinition: FormDefinition
+  formDataJson: GenericObjectType
+  validatorRegistry: BaRjsfValidatorRegistry
+}
+
+export const getFormSummary = ({
+  formDefinition,
+  formDataJson,
+  validatorRegistry,
+}: GetFormSummaryParams): FormSummary => {
+  const summaryJson = getSummaryJsonNode({
+    schema: formDefinition.schema,
+    formData: formDataJson,
+    validatorRegistry,
+  })
   const additionalInfo = renderFormAdditionalInfo(formDefinition, formDataJson)
   const termsAndConditions = formDefinition.termsAndConditions
 

--- a/forms-shared/tests/signer/signerData.ts
+++ b/forms-shared/tests/signer/signerData.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterAll, vi } from 'vitest'
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs'
 import { isSlovenskoSkFormDefinition } from '../../src/definitions/formDefinitionTypes'
 import { getSignerData } from '../../src/signer/signerData'
@@ -20,6 +20,7 @@ describe('signerData', () => {
           const signerData = await getSignerData({
             formDefinition,
             formId: '123e4567-e89b-12d3-a456-426614174000',
+            jsonVersion: formDefinition.jsonVersion,
             formData: exampleForm.formData,
             validatorRegistry: testValidatorRegistry,
             serverFiles: exampleForm.serverFiles,

--- a/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
+++ b/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
@@ -58,6 +58,7 @@ describe('slovenskoSkForm', () => {
           const xmlObject = await generateSlovenskoSkXmlObject({
             formDefinition,
             formSummary,
+            jsonVersion: formDefinition.jsonVersion,
             formData: exampleForm.formData,
             serverFiles: exampleForm.serverFiles,
           })

--- a/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
+++ b/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll } from 'vitest'
+import { beforeAll, describe, expect, test } from 'vitest'
 import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs'
 import { generateSlovenskoSkXmlObject } from '../../src/slovensko-sk/generateXml'
 import { isSlovenskoSkFormDefinition } from '../../src/definitions/formDefinitionTypes'
@@ -49,12 +49,12 @@ describe('slovenskoSkForm', () => {
       describe(`${exampleForm.name}`, () => {
         let xmlString: string
         beforeAll(async () => {
-          const xmlObject = await generateSlovenskoSkXmlObject(
+          const xmlObject = await generateSlovenskoSkXmlObject({
             formDefinition,
-            exampleForm.formData,
-            testValidatorRegistry,
-            exampleForm.serverFiles,
-          )
+            formData: exampleForm.formData,
+            validatorRegistry: testValidatorRegistry,
+            serverFiles: exampleForm.serverFiles,
+          })
           xmlString = buildSlovenskoSkXml(xmlObject, { headless: false, pretty: true })
         })
 

--- a/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
+++ b/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
@@ -16,6 +16,7 @@ import { extractJsonFromSlovenskoSkXml } from '../../src/slovensko-sk/extractJso
 import { buildSlovenskoSkXml } from '../../src/slovensko-sk/xmlBuilder'
 import { screenshotTestTimeout } from '../../test-utils/consts'
 import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
+import { getFormSummary } from '../../src/summary/summary'
 
 describe('slovenskoSkForm', () => {
   formDefinitions.filter(isSlovenskoSkFormDefinition).forEach((formDefinition) => {
@@ -49,10 +50,15 @@ describe('slovenskoSkForm', () => {
       describe(`${exampleForm.name}`, () => {
         let xmlString: string
         beforeAll(async () => {
+          const formSummary = getFormSummary({
+            formDefinition,
+            formDataJson: exampleForm.formData,
+            validatorRegistry: testValidatorRegistry,
+          })
           const xmlObject = await generateSlovenskoSkXmlObject({
             formDefinition,
+            formSummary,
             formData: exampleForm.formData,
-            validatorRegistry: testValidatorRegistry,
             serverFiles: exampleForm.serverFiles,
           })
           xmlString = buildSlovenskoSkXml(xmlObject, { headless: false, pretty: true })

--- a/forms-shared/tests/summary-email/renderSummaryEmail.ts
+++ b/forms-shared/tests/summary-email/renderSummaryEmail.ts
@@ -6,6 +6,7 @@ import { mapValues } from 'lodash'
 import { screenshotTestTimeout } from '../../test-utils/consts'
 import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 import { toMatchImageSnapshot } from 'jest-image-snapshot'
+import { getFormSummary } from '../../src/summary/summary'
 
 expect.extend({ toMatchImageSnapshot })
 
@@ -25,9 +26,13 @@ describe('renderSummaryEmail', () => {
           fileName: `${id}.pdf`,
         }))
 
-        emailHtml = await renderSummaryEmail({
+        const formSummary = getFormSummary({
           formDefinition,
-          formData: exampleForm.formData,
+          formDataJson: exampleForm.formData,
+          validatorRegistry: testValidatorRegistry,
+        })
+        emailHtml = await renderSummaryEmail({
+          formSummary,
           serverFiles: exampleForm.serverFiles,
           fileIdInfoMap,
           validatorRegistry: testValidatorRegistry,

--- a/forms-shared/tests/summary-json/getSummaryJson.ts
+++ b/forms-shared/tests/summary-json/getSummaryJson.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs'
 import { getSummaryJsonNode } from '../../src/summary-json/getSummaryJsonNode'
 import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
@@ -6,11 +6,11 @@ import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 describe('getSummaryJson', () => {
   getExampleFormPairs().forEach(({ formDefinition, exampleForm }) => {
     test(`${exampleForm.name} summary JSON should match snapshot`, () => {
-      const result = getSummaryJsonNode(
-        formDefinition.schema,
-        exampleForm.formData,
-        testValidatorRegistry,
-      )
+      const result = getSummaryJsonNode({
+        schema: formDefinition.schema,
+        formData: exampleForm.formData,
+        validatorRegistry: testValidatorRegistry,
+      })
       expect(result).toMatchSnapshot()
     })
   })

--- a/forms-shared/tests/summary-pdf/renderSummaryPdf.ts
+++ b/forms-shared/tests/summary-pdf/renderSummaryPdf.ts
@@ -33,12 +33,12 @@ describe('getSummaryJson', () => {
           exampleForm.clientFiles,
           exampleForm.serverFiles,
         )
-        const { validationData } = validateSummary(
-          formDefinition.schema,
-          exampleForm.formData,
+        const { validationData } = validateSummary({
+          schema: formDefinition.schema,
+          formData: exampleForm.formData,
           fileInfos,
-          testValidatorRegistry,
-        )
+          validatorRegistry: testValidatorRegistry,
+        })
 
         const pdfBuffer = await renderSummaryPdf({
           formSummary,

--- a/forms-shared/tests/summary-pdf/renderSummaryPdf.ts
+++ b/forms-shared/tests/summary-pdf/renderSummaryPdf.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll } from 'vitest'
+import { describe, test } from 'vitest'
 import { getExampleFormPairs } from '../../src/example-forms/getExampleFormPairs'
 import { filterConsole } from '../../test-utils/filterConsole'
 import { renderSummaryPdf } from '../../src/summary-pdf/renderSummaryPdf'
@@ -6,6 +6,9 @@ import { launchPlaywrightTest } from '../../test-utils/launchPlaywright'
 import { expectPdfToMatchSnapshot } from '../../test-utils/expectPdfToMatchSnapshot'
 import { screenshotTestTimeout } from '../../test-utils/consts'
 import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
+import { getFormSummary } from '../../src/summary/summary'
+import { validateSummary } from '../../src/summary-renderer/validateSummary'
+import { mergeClientAndServerFilesSummary } from '../../src/form-files/mergeClientAndServerFiles'
 
 describe('getSummaryJson', () => {
   getExampleFormPairs().forEach(({ formDefinition, exampleForm }) => {
@@ -21,12 +24,28 @@ describe('getSummaryJson', () => {
             ),
         )
 
-        const pdfBuffer = await renderSummaryPdf({
+        const formSummary = getFormSummary({
           formDefinition,
-          formData: exampleForm.formData,
-          launchBrowser: launchPlaywrightTest,
-          serverFiles: exampleForm.serverFiles,
+          formDataJson: exampleForm.formData,
           validatorRegistry: testValidatorRegistry,
+        })
+        const fileInfos = mergeClientAndServerFilesSummary(
+          exampleForm.clientFiles,
+          exampleForm.serverFiles,
+        )
+        const { validationData } = validateSummary(
+          formDefinition.schema,
+          exampleForm.formData,
+          fileInfos,
+          testValidatorRegistry,
+        )
+
+        const pdfBuffer = await renderSummaryPdf({
+          formSummary,
+          validationData,
+          launchBrowser: launchPlaywrightTest,
+          clientFiles: exampleForm.clientFiles,
+          serverFiles: exampleForm.serverFiles,
         })
 
         await expectPdfToMatchSnapshot(pdfBuffer)

--- a/forms-shared/tests/summary-renderer/validateSummary.ts
+++ b/forms-shared/tests/summary-renderer/validateSummary.ts
@@ -25,12 +25,12 @@ describe('validateSummary', () => {
     ])
 
     test('should validate successfully when required field is provided', () => {
-      const result = validateSummary(
+      const result = validateSummary({
         schema,
-        { requiredInput: 'some value' },
-        {},
-        testValidatorRegistry,
-      )
+        formData: { requiredInput: 'some value' },
+        fileInfos: {},
+        validatorRegistry: testValidatorRegistry,
+      })
 
       expect(result.hasErrors).toBe(false)
       expect(checkPathForErrors('root_requiredInput', result.validationData.errorSchema)).toBe(
@@ -43,7 +43,12 @@ describe('validateSummary', () => {
     })
 
     test('should report errors for missing required field', () => {
-      const result = validateSummary(schema, {}, {}, testValidatorRegistry)
+      const result = validateSummary({
+        schema,
+        formData: {},
+        fileInfos: {},
+        validatorRegistry: testValidatorRegistry,
+      })
 
       expect(result.hasErrors).toBe(true)
       expect(checkPathForErrors('root_requiredInput', result.validationData.errorSchema)).toBe(true)
@@ -58,18 +63,18 @@ describe('validateSummary', () => {
     const { schema } = object('wrapper', {}, {}, [fileUpload('file', { title: 'File' }, {})])
 
     test('should validate successfully for valid file status', () => {
-      const result = validateSummary(
+      const result = validateSummary({
         schema,
-        { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' },
-        {
+        formData: { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' },
+        fileInfos: {
           'e37359e2-2547-42a9-82d6-d40054f17da0': {
             id: 'e37359e2-2547-42a9-82d6-d40054f17da0',
             statusType: FileStatusType.ScanDone,
             fileName: '',
           },
         },
-        testValidatorRegistry,
-      )
+        validatorRegistry: testValidatorRegistry,
+      })
 
       expect(result.hasErrors).toBe(false)
       expect(checkPathForErrors('root_file', result.validationData.errorSchema)).toBe(false)
@@ -81,18 +86,18 @@ describe('validateSummary', () => {
     })
 
     test('should report errors for files with errors', () => {
-      const result = validateSummary(
+      const result = validateSummary({
         schema,
-        { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' },
-        {
+        formData: { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' },
+        fileInfos: {
           'e37359e2-2547-42a9-82d6-d40054f17da0': {
             id: 'e37359e2-2547-42a9-82d6-d40054f17da0',
             statusType: FileStatusType.UploadServerError,
             fileName: '',
           },
         },
-        testValidatorRegistry,
-      )
+        validatorRegistry: testValidatorRegistry,
+      })
 
       expect(result.hasErrors).toBe(true)
       expect(checkPathForErrors('root_file', result.validationData.errorSchema)).toBe(true)
@@ -104,12 +109,12 @@ describe('validateSummary', () => {
     })
 
     test('should report errors for missing file information', () => {
-      const result = validateSummary(
+      const result = validateSummary({
         schema,
-        { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' },
-        {},
-        testValidatorRegistry,
-      )
+        formData: { file: 'e37359e2-2547-42a9-82d6-d40054f17da0' },
+        fileInfos: {},
+        validatorRegistry: testValidatorRegistry,
+      })
 
       expect(result.hasErrors).toBe(true)
       expect(checkPathForErrors('root_file', result.validationData.errorSchema)).toBe(true)
@@ -124,16 +129,16 @@ describe('validateSummary', () => {
     ])
 
     test('should handle multiple file upload scenario', () => {
-      const result = validateSummary(
+      const result = validateSummary({
         schema,
-        {
+        formData: {
           files: [
             'e37359e2-2547-42a9-82d6-d40054f17da0',
             'b3d0cd96-d255-4bfb-8b1a-56a185d467f3',
             '7459535f-96c2-47ed-bf32-55143e52a4ea', // File missing in fileInfos
           ],
         },
-        {
+        fileInfos: {
           'e37359e2-2547-42a9-82d6-d40054f17da0': {
             id: 'e37359e2-2547-42a9-82d6-d40054f17da0',
             statusType: FileStatusType.ScanDone,
@@ -151,8 +156,8 @@ describe('validateSummary', () => {
             fileName: '',
           },
         },
-        testValidatorRegistry,
-      )
+        validatorRegistry: testValidatorRegistry,
+      })
 
       expect(result.hasErrors).toBe(true)
       expect(checkPathForErrors('root_files', result.validationData.errorSchema)).toBe(true)

--- a/nest-forms-backend/src/convert/convert.service.ts
+++ b/nest-forms-backend/src/convert/convert.service.ts
@@ -278,12 +278,12 @@ export default class ConvertService {
           clientFiles,
           form.files,
         )
-        const { validationData } = validateSummary(
-          formDefinition.schema,
-          jsonForm,
+        const { validationData } = validateSummary({
+          schema: formDefinition.schema,
+          formData: jsonForm,
           fileInfos,
-          this.formValidatorRegistryService.getRegistry(),
-        )
+          validatorRegistry: this.formValidatorRegistryService.getRegistry(),
+        })
         pdfBuffer = await renderSummaryPdf({
           formSummary,
           validationData,

--- a/nest-forms-backend/src/convert/convert.service.ts
+++ b/nest-forms-backend/src/convert/convert.service.ts
@@ -102,6 +102,7 @@ export default class ConvertService {
     return generateSlovenskoSkXmlObject({
       formDefinition: formDefinitionPatched,
       formSummary,
+      jsonVersion: form.jsonVersion,
       formData: formDataJson,
       serverFiles: formWithFiles.files,
     })

--- a/nest-forms-backend/src/convert/convert.service.ts
+++ b/nest-forms-backend/src/convert/convert.service.ts
@@ -85,6 +85,8 @@ export default class ConvertService {
       ? patchConvertServiceTaxFormDefinition(formDefinition)
       : formDefinition
 
+    // Forms that are not sent have their summary generated on the fly. For sent forms the summary is stored in the database.
+    // Sent forms cannot contain `clientFiles` and don't render errors (it is not possible to send form with errors).
     const formSummary =
       form.state === FormState.DRAFT
         ? getFormSummary({
@@ -268,6 +270,8 @@ export default class ConvertService {
 
     let pdfBuffer: Buffer
     try {
+      // Forms that are not sent have their summary generated on the fly. For sent forms the summary is stored in the database.
+      // Sent forms cannot contain `clientFiles` and don't render errors (it is not possible to send form with errors).
       if (form.state === FormState.DRAFT) {
         const formSummary = getFormSummary({
           formDefinition,

--- a/nest-forms-backend/src/convert/convert.service.ts
+++ b/nest-forms-backend/src/convert/convert.service.ts
@@ -78,14 +78,14 @@ export default class ConvertService {
       },
     })) as FormWithFiles
 
-    return generateSlovenskoSkXmlObject(
-      isSlovenskoSkTaxFormDefinition(formDefinition)
+    return generateSlovenskoSkXmlObject({
+      formDefinition: isSlovenskoSkTaxFormDefinition(formDefinition)
         ? patchConvertServiceTaxFormDefinition(formDefinition)
         : formDefinition,
-      formDataJson,
-      this.formValidatorRegistryService.getRegistry(),
-      formWithFiles.files,
-    )
+      formData: formDataJson,
+      validatorRegistry: this.formValidatorRegistryService.getRegistry(),
+      serverFiles: formWithFiles.files,
+    })
   }
 
   /**

--- a/nest-forms-backend/src/forms/forms.errors.enum.ts
+++ b/nest-forms-backend/src/forms/forms.errors.enum.ts
@@ -8,6 +8,7 @@ export enum FormsErrorsEnum {
   FORM_DEFINITION_NOT_FOUND = 'FORM_DEFINITION_NOT_FOUND',
   FORM_DEFINITION_NOT_SUPPORTED_TYPE = 'FORM_DEFINITION_NOT_SUPPORTED_TYPE',
   EMPTY_FORM_DATA = 'EMPTY_FORM_DATA',
+  EMPTY_FORM_SUMMARY = 'EMPTY_FORM_SUMMARY',
 }
 
 export enum FormsErrorsResponseEnum {
@@ -20,4 +21,5 @@ export enum FormsErrorsResponseEnum {
   FORM_DEFINITION_NOT_FOUND = 'Form definition was not found for given slug.',
   FORM_DEFINITION_NOT_SUPPORTED_TYPE = 'Got unsupported type of FormDefinition.',
   EMPTY_FORM_DATA = 'Form data is empty.',
+  EMPTY_FORM_SUMMARY = 'Form summary is empty.',
 }

--- a/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
@@ -86,6 +86,7 @@ describe('EmailFormsSubservice', () => {
         formDataJson: {},
         files: [],
         email: 'test@example.com',
+        formSummary: {},
       }
       const mockFormDefinition = {
         type: 'Email',
@@ -134,6 +135,7 @@ describe('EmailFormsSubservice', () => {
         },
         files: [],
         email: null,
+        formSummary: {},
       }
       const mockFormDefinition = {
         type: 'Email',

--- a/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
@@ -135,7 +135,7 @@ export default class EmailFormsSubservice {
     if (userConfirmationEmail) {
       // Generate confirmation pdf and send to user.
       const file = await this.convertService.generatePdf(
-        jsonDataExtraDataOmitted,
+        form.formDataJson,
         form.id,
         formDefinition,
       )

--- a/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
@@ -3,7 +3,6 @@ import { ConfigService } from '@nestjs/config'
 import { FormError, FormState } from '@prisma/client'
 import { FormDefinitionType } from 'forms-shared/definitions/formDefinitionTypes'
 import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinitionBySlug'
-import { omitExtraData } from 'forms-shared/form-utils/omitExtraData'
 import { renderSummaryEmail } from 'forms-shared/summary-email/renderSummaryEmail'
 
 import ConvertService from '../../convert/convert.service'
@@ -99,11 +98,12 @@ export default class EmailFormsSubservice {
       )
     }
 
-    const jsonDataExtraDataOmitted = omitExtraData(
-      formDefinition.schema,
-      form.formDataJson,
-      this.formValidatorRegistryService.getRegistry(),
-    )
+    if (form.formSummary == null) {
+      throw this.throwerErrorGuard.UnprocessableEntityException(
+        FormsErrorsEnum.EMPTY_FORM_SUMMARY,
+        FormsErrorsResponseEnum.EMPTY_FORM_SUMMARY,
+      )
+    }
 
     const jwtSecret = this.configService.getOrThrow<string>('JWT_SECRET')
     const selfUrl = this.configService.getOrThrow<string>('SELF_URL')
@@ -118,8 +118,7 @@ export default class EmailFormsSubservice {
           firstName: null,
           slug: formDefinition.slug,
           htmlData: await renderSummaryEmail({
-            formDefinition,
-            formData: jsonDataExtraDataOmitted,
+            formSummary: form.formSummary,
             serverFiles: form.files,
             fileIdInfoMap: getFileIdsToInfoMap(form, jwtSecret, selfUrl),
             validatorRegistry: this.formValidatorRegistryService.getRegistry(),

--- a/nest-forms-backend/src/nases/nases.service.spec.ts
+++ b/nest-forms-backend/src/nases/nases.service.spec.ts
@@ -543,11 +543,12 @@ describe('NasesService', () => {
       )
 
       expect(result).toEqual(mockSummary)
-      expect(getFormSummary).toHaveBeenCalledWith(
-        mockFormDefinition,
-        mockForm.formDataJson,
-        service['formValidatorRegistryService'].getRegistry(),
-      )
+      expect(getFormSummary).toHaveBeenCalledWith({
+        formDefinition: mockFormDefinition,
+        formDataJson: mockForm.formDataJson,
+        validatorRegistry:
+          service['formValidatorRegistryService'].getRegistry(),
+      })
     })
 
     it('should throw InternalServerError when getFormSummary fails', () => {

--- a/nest-forms-backend/src/nases/nases.service.ts
+++ b/nest-forms-backend/src/nases/nases.service.ts
@@ -287,11 +287,11 @@ export default class NasesService {
     }
 
     try {
-      return getFormSummary(
+      return getFormSummary({
         formDefinition,
-        form.formDataJson,
-        this.formValidatorRegistryService.getRegistry(),
-      )
+        formDataJson: form.formDataJson,
+        validatorRegistry: this.formValidatorRegistryService.getRegistry(),
+      })
     } catch (error) {
       this.logger.error(
         `Error while generating form summary for form definition ${formDefinition.slug}, formId: ${form.id}, error: ${error}`,

--- a/nest-forms-backend/src/signer/signer.service.ts
+++ b/nest-forms-backend/src/signer/signer.service.ts
@@ -81,6 +81,7 @@ export default class SignerService {
       formDefinition,
       formId: data.formId,
       formData: data.formDataJson,
+      jsonVersion: form.jsonVersion,
       validatorRegistry: this.formValidatorRegistryService.getRegistry(),
       serverFiles: files,
     })

--- a/next/components/forms/steps/Summary/SummaryDetails.tsx
+++ b/next/components/forms/steps/Summary/SummaryDetails.tsx
@@ -154,7 +154,7 @@ const SummaryDetails = () => {
       return initialSummaryJson
     }
 
-    return getSummaryJsonBrowser(schema, formData, validatorRegistry)
+    return getSummaryJsonBrowser({ schema, formData, validatorRegistry })
   }, [isSSR, initialSummaryJson, schema, formData, validatorRegistry])
 
   if (!summaryJson) {

--- a/next/components/forms/steps/Summary/useFormSummary.tsx
+++ b/next/components/forms/steps/Summary/useFormSummary.tsx
@@ -67,7 +67,7 @@ const useGetContext = () => {
         throw new Error('getValidatedSummary should never be called on a form step')
       }
 
-      return memoizedValidateSummary(schema, formData, fileInfos, validatorRegistry)
+      return memoizedValidateSummary({ schema, formData, fileInfos, validatorRegistry })
     },
     [formData, schema, fileInfos, currentStepIndex, validatorRegistry],
   )

--- a/next/components/forms/useFormState.tsx
+++ b/next/components/forms/useFormState.tsx
@@ -153,7 +153,7 @@ const useGetContext = () => {
     const fileInfos = mergeClientAndServerFilesSummary(clientFiles, serverFiles)
     const {
       validationData: { errorSchema },
-    } = validateSummary(schema, pickedPropertiesData, fileInfos, validatorRegistry)
+    } = validateSummary({ schema, formData: pickedPropertiesData, fileInfos, validatorRegistry })
     const keysWithErrors = Object.keys(errorSchema)
     const stepIndexesWithoutErrors = evaluatedSchemas
       .map((value, index) => {

--- a/next/frontend/utils/getInitialSummaryJson.ts
+++ b/next/frontend/utils/getInitialSummaryJson.ts
@@ -20,5 +20,5 @@ export const getInitialSummaryJson = (
     return null
   }
 
-  return getSummaryJsonNode(formDefinition.schema, formData, validatorRegistry)
+  return getSummaryJsonNode({ schema: formDefinition.schema, formData, validatorRegistry })
 }


### PR DESCRIPTION
This change https://github.com/bratislava/konto.bratislava.sk/pull/2079 generated `formSummary` when form is sent. It wasn't used until now. In this PR we use persisted `formSummary` for sent forms which allows us to change JSON schema (and bump versions whenever we want = versioning). Without this, the summary (PDF, email) will be still generated on the fly. This assures that the summary will be generate once (during send) and the will be stable 100%. E.g. when when remove some field and we download PDF for form that contained the field, it will still be in summary.

Also, previously we validated the form data for sent form (naturally they contained 0 errors and they weren't displayed - as XML summery renderer doesn't support showing them anyway). This was changed to only accept validation data only for FE form and PDF (only drafts).