### PR TITLE
Fix summary update when sending form through eID

### DIFF
--- a/nest-forms-backend/src/nases/nases.service.ts
+++ b/nest-forms-backend/src/nases/nases.service.ts
@@ -560,23 +560,27 @@ export default class NasesService {
 
     this.checkAttachments(await this.filesService.areFormAttachmentsReady(id))
 
-    // TODO rework! this is super fragile and QUEUED state was not originally meant for this
-    // just before sending to nases, update form state to QUEUED
-    // if the operation takes long, this prevents repeated sending
-    // sendToNasesAndUpdateState must never throw, and if it does not succeed we update the state back to DRAFT & set NASES_SEND_ERROR
-    await this.formsService.updateForm(id, {
-      state: FormState.QUEUED,
-    })
-
-    // Send to nases
-    let isSent = false
-
     const shouldBumpJsonVersion =
       !this.versioningEnabled ||
       versionCompareBumpDuringSend({
         currentVersion: form.jsonVersion,
         latestVersion: formDefinition.jsonVersion,
       })
+
+    // TODO rework! this is super fragile and QUEUED state was not originally meant for this
+    // just before sending to nases, update form state to QUEUED
+    // if the operation takes long, this prevents repeated sending
+    // sendToNasesAndUpdateState must never throw, and if it does not succeed we update the state back to DRAFT & set NASES_SEND_ERROR
+    await this.formsService.updateForm(id, {
+      state: FormState.QUEUED,
+      formSummary,
+      ...(shouldBumpJsonVersion
+        ? { jsonVersion: formDefinition.jsonVersion }
+        : undefined),
+    })
+
+    // Send to nases
+    let isSent = false
 
     try {
       isSent = await this.nasesConsumerService.sendToNasesAndUpdateState(
@@ -585,12 +589,6 @@ export default class NasesService {
         data,
         formDefinition,
         user.sub,
-        {
-          formSummary,
-          ...(shouldBumpJsonVersion
-            ? { jsonVersion: formDefinition.jsonVersion }
-            : undefined),
-        },
       )
     } catch (error) {
       this.logger.error(`Error sending form to nases: ${error}`)


### PR DESCRIPTION
I attached `formSummary` after it is send (which fails becaue XML/PDF generation is missing `formSummary`). Now it is added to form before the send.