### PR TITLE
Minor cleanup in strapi configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,5 @@ services:
       - '5432'
     ports:
       - '127.0.0.1:5432:5432'
-
-volumes:
-  postgres:
+    volumes:
+      - ./postgres:/var/lib/postgresql/data

--- a/strapi/.gitignore
+++ b/strapi/.gitignore
@@ -113,3 +113,4 @@ exports
 build
 .strapi-updater.json
 dist
+.strapi

--- a/strapi/config/middlewares.ts
+++ b/strapi/config/middlewares.ts
@@ -1,4 +1,4 @@
-module.exports = [
+export default [
   'strapi::logger',
   'strapi::errors',
   {

--- a/strapi/config/server.ts
+++ b/strapi/config/server.ts
@@ -1,6 +1,6 @@
 export default ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1338),
+  port: env.int('PORT', 1337),
   app: {
     keys: env.array('APP_KEYS'),
   },


### PR DESCRIPTION
- set the postgres volume locally - before, it was accessible globally and therefore overwritten by other strapi local instances
- minor cleanup