### PR TITLE
Feat/change data in tsb forms

### DIFF
--- a/forms-shared/src/definitions/formDefinitionTypes.ts
+++ b/forms-shared/src/definitions/formDefinitionTypes.ts
@@ -68,6 +68,10 @@ export type FormDefinitionEmail = FormDefinitionBase & {
     sendJsonDataAttachmentInTechnicalMail?: boolean
     extractEmail: (formData: GenericObjectType) => string | undefined
     extractName?: (formData: GenericObjectType) => string | undefined
+    /**
+     * If undefined, the default value from the email template is used.
+     */
+    technicalEmailSubject?: string
   }
 }
 

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -426,7 +426,7 @@ export const formDefinitions: FormDefinition[] = [
     jsonVersion: '1.0.0',
     schema: objednavkaInformativnehoZakresuSieti,
     termsAndConditions: generalTermsAndConditions,
-    messageSubjectDefault: '',
+    messageSubjectDefault: 'Objednávka informatívneho zákresu sietí',
     allowSendingUnauthenticatedUsers: true,
     exampleFormNotRequired: true,
     email: {
@@ -448,7 +448,7 @@ export const formDefinitions: FormDefinition[] = [
     jsonVersion: '1.0.0',
     schema: objednavkaVytyceniaPodzemnychVedeniVerejnehoOsvetlenia,
     termsAndConditions: generalTermsAndConditions,
-    messageSubjectDefault: '',
+    messageSubjectDefault: 'Objednávka vytýčenia podzemných vedení verejného osvetlenia',
     allowSendingUnauthenticatedUsers: true,
     exampleFormNotRequired: true,
     email: {
@@ -470,7 +470,7 @@ export const formDefinitions: FormDefinition[] = [
     jsonVersion: '1.0.0',
     schema: ziadostOStanoviskoKProjektovejDokumentacii,
     termsAndConditions: generalTermsAndConditions,
-    messageSubjectDefault: '',
+    messageSubjectDefault: 'Žiadosť o stanovisko k projektovej dokumentácii',
     allowSendingUnauthenticatedUsers: true,
     exampleFormNotRequired: true,
     email: {
@@ -492,7 +492,7 @@ export const formDefinitions: FormDefinition[] = [
     jsonVersion: '1.0.0',
     schema: ziadostOUmiestnenieInehoZariadeniaNaStoziarVerejnehoOsvetlenia,
     termsAndConditions: generalTermsAndConditions,
-    messageSubjectDefault: '',
+    messageSubjectDefault: 'Žiadosť o umiestnenie iného zariadenia na stožiar verejného osvetlenia',
     allowSendingUnauthenticatedUsers: true,
     exampleFormNotRequired: true,
     email: {

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -430,7 +430,7 @@ export const formDefinitions: FormDefinition[] = [
     allowSendingUnauthenticatedUsers: true,
     exampleFormNotRequired: true,
     email: {
-      address: { prod: 'wf@tsb.sk', test: 'inovacie.bratislava@gmail.com' },
+      address: { prod: 'wf-izs@tsb.sk', test: 'inovacie.bratislava@gmail.com' },
       fromAddress: { prod: 'konto@bratislava.sk', test: 'konto@bratislava.sk' },
       extractEmail: objednavkaInformativnehoZakresuSietiExtractEmail,
       extractName: objednavkaInformativnehoZakresuSietiExtractName,
@@ -452,7 +452,7 @@ export const formDefinitions: FormDefinition[] = [
     allowSendingUnauthenticatedUsers: true,
     exampleFormNotRequired: true,
     email: {
-      address: { prod: 'wf@tsb.sk', test: 'inovacie.bratislava@gmail.com' },
+      address: { prod: 'wf-vs@tsb.sk', test: 'inovacie.bratislava@gmail.com' },
       fromAddress: { prod: 'konto@bratislava.sk', test: 'konto@bratislava.sk' },
       extractEmail: objednavkaVytyceniaPodzemnychVedeniVerejnehoOsvetleniaExtractEmail,
       extractName: objednavkaVytyceniaPodzemnychVedeniVerejnehoOsvetleniaExtractName,
@@ -474,7 +474,7 @@ export const formDefinitions: FormDefinition[] = [
     allowSendingUnauthenticatedUsers: true,
     exampleFormNotRequired: true,
     email: {
-      address: { prod: 'wf@tsb.sk', test: 'inovacie.bratislava@gmail.com' },
+      address: { prod: 'wf-oskpd@tsb.sk', test: 'inovacie.bratislava@gmail.com' },
       fromAddress: { prod: 'konto@bratislava.sk', test: 'konto@bratislava.sk' },
       extractEmail: ziadostOStanoviskoKProjektovejDokumentaciiExtractEmail,
       extractName: ziadostOStanoviskoKProjektovejDokumentaciiExtractName,
@@ -496,7 +496,7 @@ export const formDefinitions: FormDefinition[] = [
     allowSendingUnauthenticatedUsers: true,
     exampleFormNotRequired: true,
     email: {
-      address: { prod: 'wf@tsb.sk', test: 'inovacie.bratislava@gmail.com' },
+      address: { prod: 'wf-ouz@bratislava.sk', test: 'inovacie.bratislava@gmail.com' },
       fromAddress: { prod: 'konto@bratislava.sk', test: 'konto@bratislava.sk' },
       extractEmail: ziadostOUmiestnenieInehoZariadeniaNaStoziarVerejnehoOsvetleniaExtractEmail,
       extractName: ziadostOUmiestnenieInehoZariadeniaNaStoziarVerejnehoOsvetleniaExtractName,

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -438,6 +438,7 @@ export const formDefinitions: FormDefinition[] = [
       userResponseTemplate: MailgunTemplateEnum.TSB_SENT_SUCCESS,
       newSubmissionTemplate: MailgunTemplateEnum.TSB_NEW_SUBMISSION,
       sendJsonDataAttachmentInTechnicalMail: true,
+      technicalEmailSubject: 'tsb-objednavka-informativneho-zakresu-sieti',
     },
   },
   {
@@ -459,6 +460,7 @@ export const formDefinitions: FormDefinition[] = [
       userResponseTemplate: MailgunTemplateEnum.TSB_SENT_SUCCESS,
       newSubmissionTemplate: MailgunTemplateEnum.TSB_NEW_SUBMISSION,
       sendJsonDataAttachmentInTechnicalMail: true,
+      technicalEmailSubject: 'tsb-objednavka-vytycenia-podzemnych-vedeni-verejneho-osvetlenia',
     },
   },
   {
@@ -480,6 +482,7 @@ export const formDefinitions: FormDefinition[] = [
       userResponseTemplate: MailgunTemplateEnum.TSB_SENT_SUCCESS,
       newSubmissionTemplate: MailgunTemplateEnum.TSB_NEW_SUBMISSION,
       sendJsonDataAttachmentInTechnicalMail: true,
+      technicalEmailSubject: 'tsb-ziadost-o-stanovisko-k-projektovej-dokumentacii',
     },
   },
   {
@@ -501,6 +504,8 @@ export const formDefinitions: FormDefinition[] = [
       userResponseTemplate: MailgunTemplateEnum.TSB_SENT_SUCCESS,
       newSubmissionTemplate: MailgunTemplateEnum.TSB_NEW_SUBMISSION,
       sendJsonDataAttachmentInTechnicalMail: true,
+      technicalEmailSubject:
+        'tsb-ziadost-o-umiestnenie-ineho-zariadenia-na-stoziar-verejneho-osvetlenia',
     },
   },
   {

--- a/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/__test__/email-forms.subservice.spec.ts
@@ -252,6 +252,7 @@ describe('EmailFormsSubservice', () => {
             content: expect.any(Buffer),
           }),
         ]),
+        subject: undefined,
       })
 
       // Should send confirmation email to user
@@ -325,6 +326,7 @@ describe('EmailFormsSubservice', () => {
         }),
         emailFrom: mockFormDefinitionWithSendOloEmail.email.fromAddress?.prod,
         attachments: undefined,
+        subject: undefined,
       })
 
       // Should send confirmation email to user using sendOloEmail
@@ -555,6 +557,7 @@ describe('EmailFormsSubservice', () => {
             content: expect.any(Buffer),
           }),
         ]),
+        subject: undefined,
       })
     })
 
@@ -573,6 +576,7 @@ describe('EmailFormsSubservice', () => {
         data: expect.anything(),
         emailFrom: expect.anything(),
         attachments: undefined,
+        subject: undefined,
       })
     })
 
@@ -591,6 +595,7 @@ describe('EmailFormsSubservice', () => {
         data: expect.anything(),
         emailFrom: expect.anything(),
         attachments: undefined,
+        subject: undefined,
       })
 
       // Restore original value
@@ -618,6 +623,7 @@ describe('EmailFormsSubservice', () => {
         }),
         emailFrom: 'department@bratislava.sk',
         attachments: expect.any(Array),
+        subject: undefined,
       })
     })
 
@@ -652,6 +658,7 @@ describe('EmailFormsSubservice', () => {
         }),
         emailFrom: 'from-olo@bratislava.sk',
         attachments: undefined,
+        subject: undefined,
       })
       expect(oloMailerService.sendEmail).toHaveBeenNthCalledWith(2, {
         data: expect.objectContaining({
@@ -659,6 +666,27 @@ describe('EmailFormsSubservice', () => {
         }),
         emailFrom: 'from-olo@bratislava.sk',
         attachments: expect.any(Array),
+      })
+    })
+
+    it('should use subject from the form definition if there is one', async () => {
+      const formDefinitionWithSubject = {
+        ...mockFormDefinitionWithSendEmail,
+        email: {
+          ...mockFormDefinitionWithSendEmail.email,
+          technicalEmailSubject: 'Test technical Subject',
+        },
+      }
+      jest
+        .spyOn(getFormDefinitionBySlug, 'getFormDefinitionBySlug')
+        .mockReturnValue(formDefinitionWithSubject)
+      await service.sendEmailForm(formId, userEmail, userFirstName)
+
+      expect(mailgunService.sendEmail).toHaveBeenNthCalledWith(1, {
+        data: expect.anything(),
+        emailFrom: expect.anything(),
+        attachments: expect.anything(),
+        subject: 'Test technical Subject',
       })
     })
   })

--- a/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
+++ b/nest-forms-backend/src/nases-consumer/subservices/email-forms.subservice.ts
@@ -303,6 +303,7 @@ export default class EmailFormsSubservice {
       attachments: formDefinition.email.sendJsonDataAttachmentInTechnicalMail
         ? this.createJsonAttachment(formDefinition, form.formDataJson)
         : undefined,
+      subject: formDefinition.email.technicalEmailSubject,
     })
 
     // Determine user email address for confirmation

--- a/nest-forms-backend/src/utils/global-services/mailer/mailer.interface.ts
+++ b/nest-forms-backend/src/utils/global-services/mailer/mailer.interface.ts
@@ -5,6 +5,7 @@ import { SendEmailInputDto } from '../../global-dtos/mailgun.dto'
 export type MailerSendEmailParams = {
   data: SendEmailInputDto
   emailFrom?: string
+  subject?: string
   attachments?: { filename: string; content: Buffer | Readable }[]
 }
 

--- a/nest-forms-backend/src/utils/global-services/mailer/mailgun.constants.ts
+++ b/nest-forms-backend/src/utils/global-services/mailer/mailgun.constants.ts
@@ -187,9 +187,9 @@ export const MAILGUN_CONFIG = {
     template: 'tsb-form-send',
     subject: 'TSB: Nové podanie',
     variables: {
-      applicationName: {
+      slug: {
         type: MailgunConfigVariableType.PARAMETER,
-        value: '{{messageSubject}}',
+        value: '{{slug}}',
       },
       htmlData: {
         type: MailgunConfigVariableType.PARAMETER,
@@ -204,11 +204,6 @@ export const MAILGUN_CONFIG = {
       applicationName: {
         type: MailgunConfigVariableType.PARAMETER,
         value: '{{messageSubject}}',
-      },
-      feHost: {
-        type: MailgunConfigVariableType.STRING,
-        value:
-          'https://bratislava.sk/mesto-bratislava/technicke-siete-bratislava',
       },
       firstName: {
         type: MailgunConfigVariableType.PARAMETER,

--- a/nest-forms-backend/src/utils/global-services/mailer/mailgun.service.ts
+++ b/nest-forms-backend/src/utils/global-services/mailer/mailgun.service.ts
@@ -36,7 +36,7 @@ export default class MailgunService implements Mailer {
   }
 
   async sendEmail(params: MailerSendEmailParams): Promise<void> {
-    const { data, emailFrom, attachments } = params
+    const { data, emailFrom, attachments, subject } = params
     const mailgunAttachments = attachments?.map((attachment) => ({
       data: attachment.content,
       filename: attachment.filename,
@@ -48,7 +48,7 @@ export default class MailgunService implements Mailer {
           from: emailFrom ?? process.env.MAILGUN_EMAIL_FROM!,
           to: data.to,
           template: MAILGUN_CONFIG[data.template].template,
-          subject: MAILGUN_CONFIG[data.template].subject,
+          subject: subject ?? MAILGUN_CONFIG[data.template].subject,
           'h:X-Mailgun-Variables': JSON.stringify(
             MailgunHelper.createEmailVariables(data),
           ),

--- a/nest-forms-backend/src/utils/global-services/mailer/olo-mailer.service.ts
+++ b/nest-forms-backend/src/utils/global-services/mailer/olo-mailer.service.ts
@@ -46,7 +46,7 @@ export default class OloMailerService implements Mailer {
    * @param attachments Optional array of attachments to be sent with the email.
    */
   async sendEmail(params: MailerSendEmailParams): Promise<void> {
-    const { data, emailFrom, attachments } = params
+    const { data, emailFrom, attachments, subject } = params
     try {
       const mailBody = await this.mailgunHelper.getFilledTemplate(
         MAILGUN_CONFIG[data.template].template,
@@ -55,7 +55,7 @@ export default class OloMailerService implements Mailer {
       await this.oloTransporter.sendMail({
         from: `OLO <${emailFrom}>`,
         to: data.to,
-        subject: MAILGUN_CONFIG[data.template].subject,
+        subject: subject ?? MAILGUN_CONFIG[data.template].subject,
         // eslint-disable-next-line xss/no-mixed-html
         html: mailBody,
         attachments,


### PR DESCRIPTION
- Uses slug as email subject in technical email for tsb
- Sends each form to different email in TSB
- adds a default name of submission as the form name for TSB
- Instead of submission name use slug as the form indentifier in technical email for TSB