### PR TITLE
Use JSON endpoint to fetch Slovensko.sk metadata

### DIFF
--- a/forms-shared/Dockerfile
+++ b/forms-shared/Dockerfile
@@ -59,6 +59,12 @@ RUN wget https://github.com/Saxonica/Saxon-HE/raw/main/12/Java/SaxonHE12-5J.zip 
 
 ENV SAXON_JAR=/opt/saxon/saxon-he-12.5.jar
 
+# Download the Slovensko.sk metadata file
+RUN mkdir -p /opt/slovensko-metadata
+RUN wget -O /opt/slovensko-metadata/mef.json https://www.slovensko.sk/static/eForm/datasetexport/json/mef.json
+
+ENV SLOVENSKO_SK_METADATA_PATH=/opt/slovensko-metadata/mef.json
+
 RUN npx playwright install chromium --with-deps
 # COPY needs to be after Playwright installation to make it more cache friendly.
 COPY . ./

--- a/forms-shared/test-utils/fetchSlovenskoSkFormMetadata.ts
+++ b/forms-shared/test-utils/fetchSlovenskoSkFormMetadata.ts
@@ -1,67 +1,49 @@
-import { JSDOM } from 'jsdom'
-import { parseStringPromise } from 'xml2js'
 import { FormDefinitionSlovenskoSk } from '../src/definitions/formDefinitionTypes'
 
-interface SlovenskoSkMetadataXml {
-  'meta:metadata': {
-    $: {
-      'xmlns:attachment': string
-      'xmlns:manifest': string
-      'xmlns:attachmentfile': string
-      'xmlns:xs': string
-      'xmlns:setting': string
-      'xmlns:content': string
-      'xmlns:dc': string
-      'xmlns:presentation': string
-      'xmlns:data': string
-      'xmlns:meta': string
-    }
-    'dc:title': string[]
-    'dc:identifier': string[]
-    'dc:description': string[]
-    'dc:creator': string[]
-    'dc:publisher': string[]
-    'meta:version': string[]
-    'meta:validDateFrom': string[]
-    'meta:inForceFrom': string[]
-    'meta:inForceTo'?: string[]
-  }
+export interface SlovenskoSkMetadataJson {
+  XSDtargetNamespace: string
+  title: string
+  identifier: string
+  shortIdentifier: string
+  eformURI: string
+  eformPartsURI: string
+  description: string
+  creator: string
+  publisherURI: string
+  publisherUpvsURI: string
+  language: string | null
+  version: string
+  validDateFrom: string
+  validDateTo: string | null
+  inForceFrom: string
+  inForceTo: string | null
+  changeDate: string
 }
 
-const getSlovenskoSkUrl = (formDefinition: FormDefinitionSlovenskoSk) => {
-  const versionRegex = /^\d+\.\d+$/
-  if (!versionRegex.test(formDefinition.pospVersion)) {
-    throw new Error(
-      'Invalid pospVersion format. Expected format: "x.y" where x and y are integers.',
-    )
-  }
-  const [vh, vl] = formDefinition.pospVersion.split('.').map(Number)
-
-  return `https://formulare.slovensko.sk/_layouts/eFLCM/DetailVzoruEFormulara.aspx?vid=${formDefinition.pospID}&vh=${vh}&vl=${vl}`
-}
-
-/**
- * Fetches the form metadata XML and converts it to JSON, e.g.:
- * https://formulare.slovensko.sk/_layouts/eFLCM/DetailVzoruEFormulara.aspx?vid=00603481.predzahradky&vh=1&vl=0
- */
-export async function fetchSlovenskoSkFormMetadata(formDefintion: FormDefinitionSlovenskoSk) {
-  const url = getSlovenskoSkUrl(formDefintion)
+export async function fetchSlovenskoSkMetadata() {
+  const url = 'https://www.slovensko.sk/static/eForm/datasetexport/json/mef.json'
   const response = await fetch(url)
   if (!response.ok) {
-    throw new Error(`Failed to fetch the URL: ${response.statusText}`)
+    throw new Error(`Failed to fetch metadata: ${response.statusText}`)
   }
-  const htmlText = await response.text()
 
-  const dom = new JSDOM(htmlText)
-  const document = dom.window.document
+  return (await response.json()) as SlovenskoSkMetadataJson[]
+}
 
-  const textarea = document.querySelector(
-    'textarea#PlaceHolderMain_metadataTextBox',
-  ) as HTMLTextAreaElement
-  if (!textarea) {
-    throw new Error('Textarea with ID "PlaceHolderMain_metadataTextBox" not found')
+export function findSlovenskoSkFormMetadata(
+  allMetadata: SlovenskoSkMetadataJson[],
+  formDefinition: FormDefinitionSlovenskoSk,
+) {
+  const formMetadata = allMetadata.find(
+    (item) =>
+      item.shortIdentifier === formDefinition.pospID && item.version === formDefinition.pospVersion,
+  )
+
+  if (!formMetadata) {
+    throw new Error(
+      `Form metadata not found for ID ${formDefinition.pospID} version ${formDefinition.pospVersion}`,
+    )
   }
-  const xmlContent = textarea.value
-  const parsedXml = (await parseStringPromise(xmlContent)) as SlovenskoSkMetadataXml
-  return parsedXml['meta:metadata']
+
+  return formMetadata
 }

--- a/forms-shared/test-utils/fetchSlovenskoSkFormMetadata.ts
+++ b/forms-shared/test-utils/fetchSlovenskoSkFormMetadata.ts
@@ -1,4 +1,5 @@
 import { FormDefinitionSlovenskoSk } from '../src/definitions/formDefinitionTypes'
+import fs from 'fs/promises'
 
 export interface SlovenskoSkMetadataJson {
   XSDtargetNamespace: string
@@ -21,6 +22,15 @@ export interface SlovenskoSkMetadataJson {
 }
 
 export async function fetchSlovenskoSkMetadata() {
+  const metadataPath = process.env.SLOVENSKO_SK_METADATA_PATH
+
+  // The file download is too slow (the file is large) and makes the test run long, the metadata file is prefetched
+  // in Dockerfile on CI.
+  if (metadataPath) {
+    const fileContent = await fs.readFile(metadataPath, 'utf-8')
+    return JSON.parse(fileContent) as SlovenskoSkMetadataJson[]
+  }
+
   const url = 'https://www.slovensko.sk/static/eForm/datasetexport/json/mef.json'
   const response = await fetch(url)
   if (!response.ok) {

--- a/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
+++ b/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
@@ -11,14 +11,25 @@ import { generatePageScreenshot } from '../../test-utils/generatePageScreenshot'
 import { getSchemaXsd } from '../../src/slovensko-sk/file-templates/schemaXsd'
 import { formDefinitions } from '../../src/definitions/formDefinitions'
 import { validateXml } from '../../src/slovensko-sk/validateXml'
-import { fetchSlovenskoSkFormMetadata } from '../../test-utils/fetchSlovenskoSkFormMetadata'
+import {
+  fetchSlovenskoSkMetadata,
+  findSlovenskoSkFormMetadata,
+  SlovenskoSkMetadataJson,
+} from '../../test-utils/fetchSlovenskoSkFormMetadata'
 import { extractJsonFromSlovenskoSkXml } from '../../src/slovensko-sk/extractJson'
 import { buildSlovenskoSkXml } from '../../src/slovensko-sk/xmlBuilder'
 import { screenshotTestTimeout } from '../../test-utils/consts'
 import { testValidatorRegistry } from '../../test-utils/validatorRegistry'
 import { getFormSummary } from '../../src/summary/summary'
+import { getSlovenskoSkMetaIdentifier } from '../../src/slovensko-sk/urls'
 
 describe('slovenskoSkForm', () => {
+  let slovenskoSkMetadata: SlovenskoSkMetadataJson[]
+
+  beforeAll(async () => {
+    slovenskoSkMetadata = await fetchSlovenskoSkMetadata()
+  }, /* The JSON file is too large to download in the default timeout. */ 30000)
+
   formDefinitions.filter(isSlovenskoSkFormDefinition).forEach((formDefinition) => {
     describe(`${formDefinition.slug}`, () => {
       test('schema XSD should match snapshot', () => {
@@ -29,17 +40,18 @@ describe('slovenskoSkForm', () => {
       test(`should match Slovensko.sk data`, async () => {
         // temp until the test pospid is removed, we don't want to publish this form into production forms
         if (formDefinition.pospID === 'hmba.eforms.bratislava.obec_024') return
-        const metadata = await fetchSlovenskoSkFormMetadata(formDefinition)
 
-        expect(metadata['dc:identifier']).toEqual([
-          `http://data.gov.sk/doc/eform/${formDefinition.pospID}/${formDefinition.pospVersion}`,
-        ])
-        expect(metadata['dc:creator']).toEqual([formDefinition.gestor])
-        expect(metadata['dc:publisher']).toEqual([formDefinition.publisher])
-        expect(metadata['meta:version']).toEqual([formDefinition.pospVersion])
+        const metadata = findSlovenskoSkFormMetadata(slovenskoSkMetadata, formDefinition)
+
+        expect(metadata.XSDtargetNamespace).toContain(formDefinition.pospID)
+        expect(metadata.identifier).toEqual(getSlovenskoSkMetaIdentifier(formDefinition))
+        expect(metadata.shortIdentifier).toEqual(formDefinition.pospID)
+        expect(metadata.creator).toEqual(formDefinition.gestor)
+        expect(metadata.publisherURI).toEqual(formDefinition.publisher)
+        expect(metadata.version).toEqual(formDefinition.pospVersion)
 
         // Change in the future when forms with limited date validity are added
-        const inForceFromDate = new Date(metadata['meta:inForceFrom'][0])
+        const inForceFromDate = new Date(metadata.inForceFrom)
         expect(inForceFromDate.getTime()).toBeLessThanOrEqual(new Date().getTime())
       })
     })

--- a/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
+++ b/forms-shared/tests/slovensko-sk/slovenskoSkForm.ts
@@ -28,7 +28,7 @@ describe('slovenskoSkForm', () => {
 
   beforeAll(async () => {
     slovenskoSkMetadata = await fetchSlovenskoSkMetadata()
-  }, /* The JSON file is too large to download in the default timeout. */ 30000)
+  })
 
   formDefinitions.filter(isSlovenskoSkFormDefinition).forEach((formDefinition) => {
     describe(`${formDefinition.slug}`, () => {


### PR DESCRIPTION
> Dataset elektronických formulárov
> 
> Od februára 2025 je každý deň automatizovane zverejňovaný dataset, ktorý obsahuje zoznam všetkých elektronických formulárov a to v dvoch formátoch:.json, .csv. . Zverejnený je na stránke Národný katalóg otvorených dát ako [Zoznam MEF](https://data.slovensko.sk/datasety/654ddfde-14bd-4237-99ef-cddda467fc40).
> 
> Dátová štruktúra datasetu je popísaná v [Návode na registráciu a správu formulárov v module elektronických formulárov](https://www.slovensko.sk/_img/CMS4/Navody/navod_registracia_eform_ovm.pdf)  v kapitole „Zverejňovanie zoznamu formulárov – dataset“  na strane 36.
> 
> Dataset obsahuje aj URL linky na jednotlivé formuláre na statickom úložisku formulárov. S jeho pomocou je možné automaticky vyskladať odkaz buď na každú súčasť elektronického formulára, napríklad za účelom jeho stiahnutia, alebo na celý .zip súbor. Postup pre vyskladanie odkazu nájdete v [Návode na registráciu a správu formulárov v module elektronických formulárov](https://www.slovensko.sk/_img/CMS4/Navody/navod_registracia_eform_ovm.pdf) v kapitole „7.  Zoznam registrovaných vzorov a funkcie vyhľadávania“ na strane 35.
> 
> Statické úložisko nájdete na adrese http://data.gov.sk/doc/egov/eform/ v zmysle [§32 Vyhlášky č. 78/2020 Z. z.](https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2020/78/20200501#paragraf-32) o štandardoch pre IT VS paragrafu 32.
> 
> Dataset elektronických formulárov môžu používať aj také subjekty, ktoré nie sú integrované na ÚPVS a potrebujú vykonať automatickú detekciu nových elektronických formulárov a ich verzii.

Slovensko.sk started publishing metadata in JSON, therefore we can get rid of this HTML/XML parsing method