### PR TITLE
Endpoint for creating and deleting testing taxes

### DIFF
--- a/nest-tax-backend/src/admin/admin.controller.ts
+++ b/nest-tax-backend/src/admin/admin.controller.ts
@@ -7,6 +7,8 @@ import {
   UseGuards,
 } from '@nestjs/common'
 import {
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiResponse,
   ApiSecurity,
@@ -16,6 +18,8 @@ import { AdminGuard } from 'src/auth/guards/admin.guard'
 
 import { AdminService } from './admin.service'
 import {
+  RequestAdminCreateTestingTaxDto,
+  RequestAdminDeleteTaxDto,
   RequestPostNorisLoadDataDto,
   RequestPostNorisPaymentDataLoadDto,
   RequestUpdateNorisDeliveryMethodsDto,
@@ -113,5 +117,44 @@ export class AdminController {
     @Param('birthNumber') birthNumber: string,
   ): Promise<void> {
     return this.adminService.removeDeliveryMethodsFromNoris(birthNumber)
+  }
+
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Create a testing tax record',
+    description:
+      'Creates a testing tax record with specified details for development and testing purposes',
+  })
+  @ApiOkResponse({
+    description: 'Testing tax record created successfully',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  @UseGuards(AdminGuard)
+  @Post('create-testing-tax')
+  async createTestingTax(
+    @Body() request: RequestAdminCreateTestingTaxDto,
+  ): Promise<void> {
+    await this.adminService.createTestingTax(request)
+  }
+
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Delete a tax record',
+    description: 'Deletes a tax record for a specific birth number and year',
+  })
+  @ApiOkResponse({
+    description: 'Tax record deleted successfully',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error or tax payer not found',
+  })
+  @UseGuards(AdminGuard)
+  @Post('delete-testing-tax')
+  async deleteTestingTax(
+    @Body() request: RequestAdminDeleteTaxDto,
+  ): Promise<void> {
+    await this.adminService.deleteTestingTax(request)
   }
 }

--- a/nest-tax-backend/src/admin/admin.controller.ts
+++ b/nest-tax-backend/src/admin/admin.controller.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/swagger'
 import { AdminGuard } from 'src/auth/guards/admin.guard'
 
+import { NotProductionGuard } from '../auth/guards/not-production.guard'
 import { AdminService } from './admin.service'
 import {
   RequestAdminCreateTestingTaxDto,
@@ -132,6 +133,7 @@ export class AdminController {
     description: 'Internal server error',
   })
   @UseGuards(AdminGuard)
+  @UseGuards(NotProductionGuard)
   @Post('create-testing-tax')
   async createTestingTax(
     @Body() request: RequestAdminCreateTestingTaxDto,
@@ -151,6 +153,7 @@ export class AdminController {
     description: 'Internal server error or tax payer not found',
   })
   @UseGuards(AdminGuard)
+  @UseGuards(NotProductionGuard)
   @Post('delete-testing-tax')
   async deleteTestingTax(
     @Body() request: RequestAdminDeleteTaxDto,

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -619,6 +619,10 @@ export class AdminService {
     )
   }
   
+  /**
+   * Creates a testing tax record with specified details for development and testing purposes.
+   * WARNING! This tax should be removed after testing, with the endpoint `delete-testing-tax`.
+   */
   async createTestingTax({
     year,
     norisData,
@@ -689,7 +693,7 @@ export class AdminService {
             .toFixed(2)
             .replace('.', ','),
 
-          // tax detail fields
+          // tax detail fields - mock only
           det_zaklad_dane_byt: '100,50',
           det_dan_byty_byt: '10,50',
           det_zaklad_dane_nebyt: '200,75',
@@ -789,6 +793,37 @@ export class AdminService {
         'Tax payer not found',
       )
     }
+
+    const tax = await this.prismaService.tax.findUnique({
+      where: {
+        taxPayerId_year: {
+          taxPayerId: taxPayer.id,
+          year,
+        },
+      },
+    })
+    if (!tax) {
+      throw this.throwerErrorGuard.InternalServerErrorException(
+        ErrorsEnum.INTERNAL_SERVER_ERROR,
+        'Tax not found',
+      )
+    }
+
+    await this.prismaService.taxPayment.deleteMany({
+      where: {
+        taxId: tax.id,
+      },
+    })
+    await this.prismaService.taxInstallment.deleteMany({
+      where: {
+        taxId: tax.id,
+      },
+    })
+    await this.prismaService.taxDetail.deleteMany({
+      where: {
+        taxId: tax.id,
+      },
+    })
     await this.prismaService.tax.delete({
       where: {
         taxPayerId_year: {

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -617,7 +617,7 @@ export class AdminService {
       ),
     )
   }
-  
+
   /**
    * Creates a testing tax record with specified details for development and testing purposes.
    * WARNING! This tax should be removed after testing, with the endpoint `delete-testing-tax`.

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from 'node:crypto'
-
 import { Injectable, Logger } from '@nestjs/common'
 import { PaymentStatus, Tax } from '@prisma/client'
 import currency from 'currency.js'
@@ -31,6 +29,7 @@ import {
 } from './dtos/requests.dto'
 import { CreateBirthNumbersResponseDto } from './dtos/responses.dto'
 import { taxDetail } from './utils/tax-detail.helper'
+import { createTestingTaxMock } from './utils/testing-tax-mock'
 
 @Injectable()
 export class AdminService {
@@ -635,147 +634,11 @@ export class AdminService {
       )
     }
 
-    await this.processNorisTaxData(
-      [
-        {
-          ICO_RC: norisData.fakeBirthNumber,
-          subjekt_nazev: norisData.nameSurname,
-          variabilny_symbol: norisData.variabilnySymbol,
-          dan_spolu: norisData.taxTotal,
-          rok: year,
+    // Generate the mock tax record
+    const mockTaxRecord = createTestingTaxMock(norisData, taxEmployee, year)
 
-          // payment data
-          specificky_symbol: '2024100000',
-          uhrazeno: norisData.alreadyPaid,
-          zbyva_uhradit: (
-            parseFloat(norisData.taxTotal.replace(',', '.')) -
-            parseFloat(norisData.alreadyPaid.replace(',', '.'))
-          ).toString(),
-
-          // existing tax employee data to not overwrite
-          vyb_email: taxEmployee.email,
-          cislo_poradace: +taxEmployee.externalId,
-          vyb_id: taxEmployee.id,
-          vyb_nazov: taxEmployee.name,
-          vyb_telefon_prace: taxEmployee.phoneNumber,
-          cislo_konania: randomBytes(4).toString('hex'),
-
-          // mock values for testing
-          subjekt_refer: '123456789',
-          dan_pozemky: '0',
-          dan_stavby_SPOLU: '0',
-          ulica_tb: 'test ulica',
-          ulica_tb_cislo: 'test ulica cislo',
-          psc_ref_tb: 'test psc',
-          psc_naz_tb: 'test psc nazov',
-          stat_nazov_plny: 'test stat',
-          obec_nazev_tb: 'test obec',
-          TXT_UL: 'test ulica txt',
-          TXT_MENO: 'test meno txt',
-
-          // splátky (installments) data
-          TXTSPL1: 'TEST: Daň za rok je splatná do xx.yy',
-          SPL1: norisData.taxTotal,
-          TXTSPL4_1: 'Test splatka1',
-          SPL4_1: (parseFloat(norisData.taxTotal.replace(',', '.')) / 4)
-            .toFixed(2)
-            .replace('.', ','),
-          TXTSPL4_2: 'Test splatka2',
-          SPL4_2: (parseFloat(norisData.taxTotal.replace(',', '.')) / 4)
-            .toFixed(2)
-            .replace('.', ','),
-          TXTSPL4_3: 'Test splatka3',
-          SPL4_3: (parseFloat(norisData.taxTotal.replace(',', '.')) / 4)
-            .toFixed(2)
-            .replace('.', ','),
-          TXTSPL4_4: 'Test splatka4',
-          SPL4_4: (parseFloat(norisData.taxTotal.replace(',', '.')) / 4)
-            .toFixed(2)
-            .replace('.', ','),
-
-          // tax detail fields - mock only
-          det_zaklad_dane_byt: '100,50',
-          det_dan_byty_byt: '10,50',
-          det_zaklad_dane_nebyt: '200,75',
-          det_dan_byty_nebyt: '20,75',
-          det_pozemky_ZAKLAD_A: '300,25',
-          det_pozemky_DAN_A: '30,25',
-          det_pozemky_VYMERA_A: '50',
-          det_pozemky_ZAKLAD_B: '400,75',
-          det_pozemky_DAN_B: '40,75',
-          det_pozemky_VYMERA_B: '60',
-          det_pozemky_ZAKLAD_C: '500,25',
-          det_pozemky_DAN_C: '50,25',
-          det_pozemky_VYMERA_C: '70',
-          det_pozemky_ZAKLAD_D: '600,25',
-          det_pozemky_DAN_D: '60,25',
-          det_pozemky_VYMERA_D: '80',
-          det_pozemky_ZAKLAD_E: '700,25',
-          det_pozemky_DAN_E: '70,25',
-          det_pozemky_VYMERA_E: '90',
-          det_pozemky_ZAKLAD_F: '800,25',
-          det_pozemky_DAN_F: '80,25',
-          det_pozemky_VYMERA_F: '100',
-          det_pozemky_ZAKLAD_G: '900,25',
-          det_pozemky_DAN_G: '90,25',
-          det_pozemky_VYMERA_G: '110',
-          det_pozemky_ZAKLAD_H: '1000,25',
-          det_pozemky_DAN_H: '100,25',
-          det_pozemky_VYMERA_H: '120',
-          det_stavba_ZAKLAD_A: '600,25',
-          det_stavba_DAN_A: '60,25',
-          det_stavba_ZAKLAD_B: '700,75',
-          det_stavba_DAN_B: '70,75',
-          det_stavba_ZAKLAD_C: '800,75',
-          det_stavba_DAN_C: '80,75',
-          det_stavba_ZAKLAD_D: '900,75',
-          det_stavba_DAN_D: '90,75',
-          det_stavba_ZAKLAD_E: '1000,75',
-          det_stavba_DAN_E: '100,75',
-          det_stavba_ZAKLAD_F: '1100,75',
-          det_stavba_DAN_F: '110,75',
-          det_stavba_ZAKLAD_G: '1200,75',
-          det_stavba_DAN_G: '120,75',
-          det_stavba_ZAKLAD_jH: '1300,75',
-          det_stavba_DAN_jH: '130,75',
-          det_stavba_ZAKLAD_jI: '1400,75',
-          det_stavba_DAN_jI: '140,75',
-          det_stavba_ZAKLAD_H: '1500,75',
-          det_stavba_DAN_H: '150,75',
-
-          // additional required fields
-          sposob_dorucenia: 'TEST',
-          cislo_subjektu: 123_456,
-          akt_datum: new Date().toISOString().split('T')[0],
-          dan_stavby: '600,50',
-          dan_stavby_viac: '300,25',
-          dan_byty: norisData.taxTotal,
-          adresa_tp_sidlo: 'test sidlo',
-
-          // envelope data
-          obalka_ulica: 'Testovacia ulica 123',
-          obalka_psc: '85000',
-          obalka_mesto: 'Bratislava',
-          obalka_stat: 'Slovensko',
-
-          // money transfer data
-          pouk_cena_bez_hal: norisData.taxTotal.split(',')[0],
-          pouk_cena_hal: norisData.taxTotal.includes(',')
-            ? norisData.taxTotal.split(',')[1]
-            : '00',
-
-          // user attribute
-          uzivatelsky_atribut: 'Test attribute',
-
-          // user type
-          TYP_USER: 'FO',
-
-          // delivery method
-          delivery_method: norisData.deliveryMethod,
-        },
-      ],
-      year,
-    )
+    // Process the mock data to create the testing tax
+    await this.processNorisTaxData([mockTaxRecord], year)
   }
 
   async deleteTestingTax({

--- a/nest-tax-backend/src/admin/dtos/requests.dto.ts
+++ b/nest-tax-backend/src/admin/dtos/requests.dto.ts
@@ -169,6 +169,14 @@ export class RequestAdminCreateTestingTaxNorisData {
   })
   @IsString()
   alreadyPaid: string
+
+  @ApiProperty({
+    description: 'Date of tax ruling (dátum právoplatnosti)',
+    example: '2024-01-01',
+  })
+  @IsString()
+  @IsOptional()
+  dateTaxRuling: string | null
 }
 
 export class RequestAdminCreateTestingTaxDto {

--- a/nest-tax-backend/src/admin/dtos/requests.dto.ts
+++ b/nest-tax-backend/src/admin/dtos/requests.dto.ts
@@ -150,13 +150,6 @@ export class RequestAdminCreateTestingTaxNorisData {
   fakeBirthNumber: string
 
   @ApiProperty({
-    description: 'Variable symbol for the tax payment',
-    example: '1234567890',
-  })
-  @IsString()
-  variabilnySymbol: string
-
-  @ApiProperty({
     description: 'Full name and surname of the tax payer',
     example: 'John Doe',
   })

--- a/nest-tax-backend/src/admin/dtos/requests.dto.ts
+++ b/nest-tax-backend/src/admin/dtos/requests.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger'
-import { IsObject, ValidateNested } from 'class-validator'
+import {
+  IsEnum,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator'
 
 import { DeliveryMethod } from '../../noris/noris.types'
 
@@ -123,6 +130,84 @@ export class RequestUpdateNorisDeliveryMethodsDto {
   @IsObject()
   @ValidateNested()
   data: RequestUpdateNorisDeliveryMethodsData
+}
+
+export class RequestAdminCreateTestingTaxNorisData {
+  @ApiProperty({
+    description: 'Delivery method for the tax',
+    enum: DeliveryMethod,
+    nullable: true,
+  })
+  @IsEnum(DeliveryMethod)
+  @IsOptional()
+  deliveryMethod: DeliveryMethod | null
+
+  @ApiProperty({
+    description: 'Birth number in format with slash',
+    example: '000000/0000',
+  })
+  @IsString()
+  fakeBirthNumber: string
+
+  @ApiProperty({
+    description: 'Variable symbol for the tax payment',
+    example: '1234567890',
+  })
+  @IsString()
+  variabilnySymbol: string
+
+  @ApiProperty({
+    description: 'Full name and surname of the tax payer',
+    example: 'John Doe',
+  })
+  @IsString()
+  nameSurname: string
+
+  @ApiProperty({
+    description: 'Total tax amount as string',
+    example: '100.00',
+  })
+  @IsString()
+  taxTotal: string
+
+  @ApiProperty({
+    description: 'Amount already paid as string',
+    example: '0.00',
+  })
+  @IsString()
+  alreadyPaid: string
+}
+
+export class RequestAdminCreateTestingTaxDto {
+  @ApiProperty({
+    description: 'Year of tax',
+    default: 2022,
+  })
+  @IsNumber()
+  year: number
+
+  @ApiProperty({
+    description: 'Fake Noris Data',
+  })
+  @IsObject()
+  @ValidateNested()
+  norisData: RequestAdminCreateTestingTaxNorisData
+}
+
+export class RequestAdminDeleteTaxDto {
+  @ApiProperty({
+    description: 'Year of tax',
+    default: 2022,
+  })
+  @IsNumber()
+  year: number
+
+  @ApiProperty({
+    description: 'Birth number in format with slash',
+    example: '000000/0000',
+  })
+  @IsString()
+  birthNumber: string
 }
 
 export type NorisRequestGeneral =

--- a/nest-tax-backend/src/admin/utils/testing-tax-mock.ts
+++ b/nest-tax-backend/src/admin/utils/testing-tax-mock.ts
@@ -1,0 +1,151 @@
+import { randomBytes } from 'node:crypto'
+
+import { TaxEmployee } from '@prisma/client'
+
+import { RequestAdminCreateTestingTaxNorisData } from '../dtos/requests.dto'
+
+/**
+ * Creates a mock Noris tax record for testing purposes based on user input
+ */
+export const createTestingTaxMock = (
+  norisData: RequestAdminCreateTestingTaxNorisData,
+  taxEmployee: TaxEmployee,
+  year: number,
+) => {
+  return {
+    ICO_RC: norisData.fakeBirthNumber,
+    subjekt_nazev: norisData.nameSurname,
+    dan_spolu: norisData.taxTotal,
+    rok: year,
+
+    // payment data
+    specificky_symbol: '2024100000',
+    variabilny_symbol: '0000000001',
+    uhrazeno: norisData.alreadyPaid,
+    zbyva_uhradit: (
+      parseFloat(norisData.taxTotal.replace(',', '.')) -
+      parseFloat(norisData.alreadyPaid.replace(',', '.'))
+    ).toString(),
+
+    // existing tax employee data to not overwrite
+    vyb_email: taxEmployee.email,
+    cislo_poradace: +taxEmployee.externalId,
+    vyb_id: taxEmployee.id,
+    vyb_nazov: taxEmployee.name,
+    vyb_telefon_prace: taxEmployee.phoneNumber,
+    cislo_konania: randomBytes(4).toString('hex'),
+
+    // mock values for testing
+    subjekt_refer: '123456789',
+    dan_pozemky: '0',
+    dan_stavby_SPOLU: '0',
+    ulica_tb: 'test ulica',
+    ulica_tb_cislo: 'test ulica cislo',
+    psc_ref_tb: 'test psc',
+    psc_naz_tb: 'test psc nazov',
+    stat_nazov_plny: 'test stat',
+    obec_nazev_tb: 'test obec',
+    TXT_UL: 'test ulica txt',
+    TXT_MENO: 'test meno txt',
+
+    // splátky (installments) data
+    TXTSPL1: 'TEST: Daň za rok je splatná do xx.yy',
+    SPL1: norisData.taxTotal,
+    TXTSPL4_1: 'Test splatka1',
+    SPL4_1: (parseFloat(norisData.taxTotal.replace(',', '.')) / 4)
+      .toFixed(2)
+      .replace('.', ','),
+    TXTSPL4_2: 'Test splatka2',
+    SPL4_2: (parseFloat(norisData.taxTotal.replace(',', '.')) / 4)
+      .toFixed(2)
+      .replace('.', ','),
+    TXTSPL4_3: 'Test splatka3',
+    SPL4_3: (parseFloat(norisData.taxTotal.replace(',', '.')) / 4)
+      .toFixed(2)
+      .replace('.', ','),
+    TXTSPL4_4: 'Test splatka4',
+    SPL4_4: (parseFloat(norisData.taxTotal.replace(',', '.')) / 4)
+      .toFixed(2)
+      .replace('.', ','),
+
+    // tax detail fields - mock only
+    det_zaklad_dane_byt: '100,50',
+    det_dan_byty_byt: '10,50',
+    det_zaklad_dane_nebyt: '200,75',
+    det_dan_byty_nebyt: '20,75',
+    det_pozemky_ZAKLAD_A: '300,25',
+    det_pozemky_DAN_A: '30,25',
+    det_pozemky_VYMERA_A: '50',
+    det_pozemky_ZAKLAD_B: '400,75',
+    det_pozemky_DAN_B: '40,75',
+    det_pozemky_VYMERA_B: '60',
+    det_pozemky_ZAKLAD_C: '500,25',
+    det_pozemky_DAN_C: '50,25',
+    det_pozemky_VYMERA_C: '70',
+    det_pozemky_ZAKLAD_D: '600,25',
+    det_pozemky_DAN_D: '60,25',
+    det_pozemky_VYMERA_D: '80',
+    det_pozemky_ZAKLAD_E: '700,25',
+    det_pozemky_DAN_E: '70,25',
+    det_pozemky_VYMERA_E: '90',
+    det_pozemky_ZAKLAD_F: '800,25',
+    det_pozemky_DAN_F: '80,25',
+    det_pozemky_VYMERA_F: '100',
+    det_pozemky_ZAKLAD_G: '900,25',
+    det_pozemky_DAN_G: '90,25',
+    det_pozemky_VYMERA_G: '110',
+    det_pozemky_ZAKLAD_H: '1000,25',
+    det_pozemky_DAN_H: '100,25',
+    det_pozemky_VYMERA_H: '120',
+    det_stavba_ZAKLAD_A: '600,25',
+    det_stavba_DAN_A: '60,25',
+    det_stavba_ZAKLAD_B: '700,75',
+    det_stavba_DAN_B: '70,75',
+    det_stavba_ZAKLAD_C: '800,75',
+    det_stavba_DAN_C: '80,75',
+    det_stavba_ZAKLAD_D: '900,75',
+    det_stavba_DAN_D: '90,75',
+    det_stavba_ZAKLAD_E: '1000,75',
+    det_stavba_DAN_E: '100,75',
+    det_stavba_ZAKLAD_F: '1100,75',
+    det_stavba_DAN_F: '110,75',
+    det_stavba_ZAKLAD_G: '1200,75',
+    det_stavba_DAN_G: '120,75',
+    det_stavba_ZAKLAD_jH: '1300,75',
+    det_stavba_DAN_jH: '130,75',
+    det_stavba_ZAKLAD_jI: '1400,75',
+    det_stavba_DAN_jI: '140,75',
+    det_stavba_ZAKLAD_H: '1500,75',
+    det_stavba_DAN_H: '150,75',
+
+    // additional required fields
+    sposob_dorucenia: 'TEST',
+    cislo_subjektu: 123_456,
+    akt_datum: new Date().toISOString().split('T')[0],
+    dan_stavby: '600,50',
+    dan_stavby_viac: '300,25',
+    dan_byty: norisData.taxTotal,
+    adresa_tp_sidlo: 'test sidlo',
+
+    // envelope data
+    obalka_ulica: 'Testovacia ulica 123',
+    obalka_psc: '85000',
+    obalka_mesto: 'Bratislava',
+    obalka_stat: 'Slovensko',
+
+    // money transfer data
+    pouk_cena_bez_hal: norisData.taxTotal.split(',')[0],
+    pouk_cena_hal: norisData.taxTotal.includes(',')
+      ? norisData.taxTotal.split(',')[1]
+      : '00',
+
+    // user attribute
+    uzivatelsky_atribut: 'Test attribute',
+
+    // user type
+    TYP_USER: 'FO',
+
+    // delivery method
+    delivery_method: norisData.deliveryMethod,
+  }
+}

--- a/nest-tax-backend/src/admin/utils/testing-tax-mock.ts
+++ b/nest-tax-backend/src/admin/utils/testing-tax-mock.ts
@@ -17,6 +17,7 @@ export const createTestingTaxMock = (
     subjekt_nazev: norisData.nameSurname,
     dan_spolu: norisData.taxTotal,
     rok: year,
+    datum_platnosti: norisData.dateTaxRuling,
 
     // payment data
     specificky_symbol: '2024100000',

--- a/nest-tax-backend/src/auth/guards/not-production.guard.ts
+++ b/nest-tax-backend/src/auth/guards/not-production.guard.ts
@@ -1,0 +1,13 @@
+import { CanActivate, ForbiddenException, Injectable } from '@nestjs/common'
+
+@Injectable()
+export class NotProductionGuard implements CanActivate {
+  canActivate(): boolean {
+    if (process.env.CLUSTER_ENV === 'production') {
+      throw new ForbiddenException(
+        'This endpoint is not available in production environment.',
+      )
+    }
+    return true
+  }
+}


### PR DESCRIPTION
Creates an endpoint, which mocks the creation of a tax for testing purposes. Most of the values are mocked, however, some like tax amount can be set for each testing tax.

Furthermore creates an endpoint to delete these testing taxes.

Will create some documentation on how to do this testing, since it is necessary to not have any conflict with the real data.