### PR TITLE
Implement skipGinisStateUpdate flag

### DIFF
--- a/forms-shared/src/definitions/formDefinitionTypes.ts
+++ b/forms-shared/src/definitions/formDefinitionTypes.ts
@@ -30,6 +30,7 @@ type FormDefinitionSlovenskoSkBase = FormDefinitionBase & {
   pospVersion: string
   publisher: string
   isSigned: boolean
+  skipGinisStateUpdate?: boolean
 }
 
 export type FormDefinitionSlovenskoSkGeneric = FormDefinitionSlovenskoSkBase & {

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -195,6 +195,7 @@ export const formDefinitions: FormDefinition[] = [
     termsAndConditions: ziadostONajomBytuTermsAndConditions,
     messageSubjectDefault: 'Žiadosť o nájom bytu',
     sharepointData: ziadostONajomBytuSharepointData,
+    skipGinisStateUpdate: true,
     ginisAssignment: {
       ginisOrganizationName: 'SNB',
     },


### PR DESCRIPTION
I would like to avoid:
 - having form specific hardcoded behaviour all over the code - I strongly prefer flags even for these one-off features
 - the previous logic relied on the processing state, however this now filters only Slovensko.sk forms in `slugsToProcess`