### PR TITLE
Add email secrets and documentation

### DIFF
--- a/nest-tax-backend/kubernetes/base/deployment.yml
+++ b/nest-tax-backend/kubernetes/base/deployment.yml
@@ -47,6 +47,8 @@ spec:
             name: noris-secret
         - secretRef:
             name: reporting-secret
+        - secretRef:
+            name: email-secret
         - configMapRef:
             name: env
         readinessProbe:

--- a/nest-tax-backend/kubernetes/envs/Dev/kustomization.yml
+++ b/nest-tax-backend/kubernetes/envs/Dev/kustomization.yml
@@ -2,6 +2,7 @@ resources:
   - ../../base
   - scaler.yml
   - ./secrets/reporting.secret.yml
+  - ./secrets/email.secret.yml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/nest-tax-backend/kubernetes/envs/Dev/secrets/email.secret.yml
+++ b/nest-tax-backend/kubernetes/envs/Dev/secrets/email.secret.yml
@@ -1,0 +1,24 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  labels:
+    app: ${BUILD_REPOSITORY_NAME}
+    source: ${BUILD_REPOSITORY_NAME}
+  name: ${BUILD_REPOSITORY_NAME}-email-secret
+  namespace: ${NAMESPACE}
+spec:
+  encryptedData:
+    AWS_SES_SENDER_EMAIL: AgA6avjQboH7kq+wmTaD8QC9N4pZZYr+XirPIwgsCcg3kHSRUZxM6zun59Qh7WuzOMm6cAZjQ25OgRqNp1oJEn62bCjV8J6746T9mB59cnPwjCYSE+UdqJRk2tAMy3p5wnYEKdeHISsXL4NsmE4LP44FIwScfeg07fHVv5g/GA/VXsS34fxm+NnJ1FEh5eeoBdjCNbC6CUfDH8Kg0s9nLIt0jc9ZtB4QZtfIMWuisGb/BTuG5uQ/VrdKGMIGjr454Cg2g1dhMkBwrr0bchaOjoFr+KbXRGAGOzXAagHPs7cchsaf1wfRNFr7OVLzKQXbbZy8cX1a3zqB0hvwP/7rgqUjtE29LsaKlgTSOgNdGU76gtz2j+kxvqPd0nCew55te2ppwV1zpdfjjdvQM7ywBKN9iTWCKXhc0Yw6U8Q7LYK1Kjm48ME0xg/5KELCLr5MAqxlFp+QCn1nss7EiY8FG67MthU+vpTN/QGskuqgqvmP2SSI6LAHxB3sfaKvgkluaQP2k3jkDAbt2oHrIZJh6Y5mdVLQpO+HJjMduNPt0x33IG8kUzkteBm7d/XqRbI5VQLboEV0nliUdOPQ97KrCHFAxYHRwllLZGVAkaVMGSZwGD9fkit15r+tAFe3kpqgOQYKqw9GDEHu7L92Mh9HWTyi5O1ymmj9mj86gkmGoK7QiiluF5hmGdpfwYjVKBWNzNSekgGYGIPBBMrJ+k9AECqgKWwzD938RhtZ9mbh
+    AWS_SES_SMTP_PASSWORD: AgCQ7QEY4l034EEEUFxjW6/bNxhMmbjELb7DT6GTYFhSQfZIo/clefgTDENnNJ9kFTRJAUiEKKC6Iv/FVlmprhVTdpr+ibIMC2M+oOK31QPWrQjQvi9s6jASpd9hJ7hYUfPMaFFG5hNOs/tfp8Zjl/s6JKzahZouVRb+3/yYAqepbAUDDRTxx7z5D/x75S6+VnXwLhQZjqe8wurAz5+Vrjyt9KtnRR8HdjUFUCxFtJewvb9T2FUsMWTJGuXmrBdtW9SAZA03J4tDFRaZnWUZQMKh1rNJwSXwIB0a/hIGSXd7Nr+7AQOx8TW63W3TE0S0qXewCPY+ZvQQ9foHlhGoVrymZ2VA9OkZP/s/bQaBTO6SJ+//FtQYi/HJzIuPUPgx9IgN8n8WwxnvBUXo3aapNJHBAHuj6ZeY5jw3MljSgxTDujV5zwKuMxG+/kjuLBBm2dqV9XtnmkIBuJmuDMUFvyn5sZUl7Dkz4GF+a5Ekakmubu6L+7Cz6sgFJ4OfXwN0I4zGNOgqIU0EVm9KvcLiGg/ehpO2x0cMcbZ+iC/5tOF1VNGDIyUzAHLhC+n7nqHNTsZ5ewiFNa3vmOVNvVPUQQ9JRFWFbecKu5sOOyrIZ4B6/VVVeBsvavYU2yklsH/4anx7VZsj6P4r6lyiVRolue8J7+ekNIhLkoUoA1bD7XYpeu0EppUSVmcwIlAv0tO18j18kyKyNXaBuDVwaEP9/xN+uMz/Q0/wb1Cumr/UIPsRbOfB4WkpQLbTvGD+ydM=
+    AWS_SES_SMTP_USERNAME: AgAMgkG7+7ZLaoTPeH9+7JBMpVaQrBegMF/SaBrzELgA1Vw1R1nkD8jb9xk5M8N9ZyLO2++WOmf7Sz714B8waxd43ptyj6dFoaTxUsUdrdTE5cWmrv/98Ngvvv1lmvYh+1l9XeIFSmydzheJGQXRJzgyF63E3tX4YokcKeXBimDntKxmZDDNaDDcf6SJHeC0guE910H58TQZZWfjFmmi5Ptayx1UG4V/68Nhpr7Gw13+nxPOQ/22nR0OLB076jEWxYpKgTGCilhR2kBUfw//D4Kx5qKHs3fQj6bgFMAd3Skw27urblWDo9knpLtuAgXPkDvXm6QbXCdCa2DeJdple5x58Bv5l+rmTKR6Xt/oud9RaieFRElqSewkfI8PMsNWnDinze8REsPWa9w47OXDIdb9PO5Zae2rSnxGlQtaOcRyeUbvk1tE35CpfYAX7/rP67i0H6ae6QkncqAmUFiQ3pZu6DD++bzrlF3dc5mU53+w5JGYnkqxKqqgV8pRmYBg802+0TmnjEPN4uZzl3sOXVOB1WIIgpkyOZ+jzjhVCpOKX//psHGxzYpCnXjiB9jxn+cjeYo3prI4uO4/AzEYNdIUbSfl6di7lRuSsSbYsGjUVmnoyOvT4IqjoAvO3xQErtW/sbU6Jt8pX9ARMkiz5MA9OEKkUi1Sl9WU7wJ5A8LMMadnk+HjgQsV2rYXTtjFFOHgiYpZ2SOgCnmT100MytufQLM=
+  template:
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      labels:
+        app: ${BUILD_REPOSITORY_NAME}
+        source: ${BUILD_REPOSITORY_NAME}
+      name: ${BUILD_REPOSITORY_NAME}-email-secret
+      namespace: ${NAMESPACE}

--- a/nest-tax-backend/kubernetes/envs/Prod/kustomization.yml
+++ b/nest-tax-backend/kubernetes/envs/Prod/kustomization.yml
@@ -2,6 +2,7 @@ resources:
   - ../../base
   - scaler.yml
   - ./secrets/reporting.secret.yml
+  - ./secrets/email.secret.yml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/nest-tax-backend/kubernetes/envs/Prod/secrets/email.secret.yml
+++ b/nest-tax-backend/kubernetes/envs/Prod/secrets/email.secret.yml
@@ -1,0 +1,24 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  labels:
+    app: ${BUILD_REPOSITORY_NAME}
+    source: ${BUILD_REPOSITORY_NAME}
+  name: ${BUILD_REPOSITORY_NAME}-email-secret
+  namespace: ${NAMESPACE}
+spec:
+  encryptedData:
+    AWS_SES_SENDER_EMAIL: AgAVTa+2rAEDMnD8VatcQfhmkzdSUcvWnY9MlXvbjVQwKkH+POeZztNpZjgP8AaaAY4GjMrT3U+Poo6jYQY2fcHt+0Cnc+hHe2dRow++LN1blnA7ExYXp06u6HZSwcIjS36vQhIwVuQrELX4FjgJ93sQ9VEa5KUkHOMJA3xvJZMQ4WHHQQIn0YZgQC8GOPyUqomAvtFFygsGDGBG9iev6rijlSSKEt5hpLuiZxFeDvIayzxxWvnyleIyshCLHaRI4ScBZ2RhSGuZUK7ByAFQ5w5/nqq+XaNBlroQ/gEYkgW5ZS+MHf6++Kw+T+BeyZ4D0osJdeyMaS9UqUr+nPtNF0bxuHKtVePkyYxOmmAQ66WQwwwvXF/+CP1x2Mg7JX8Kq4+u1naphcQMrDdyOIcsT7SDhhWV1awzfvGG16zQTWhlvbHLtS6gHPiGaI3V10DvlCO6lnpM+CDt4E1pujrE//MBC7PUMmXg4RnHd3qBm7J32tm8y2avlcchD9ouwxvE6StvH3jubvVNG+iCamouSgU325S+ViUiMHS9sk/gy3JmFqo5jGXTmQji7C8yQQHOSglde0TRUEpsQOpnr1WDTCwYHo010kkkyMtnZ1y0XNFdCx0QzD+Rc8ZYoQ98zGdCANpHaZnMM1knHh8J55X9Ogm+if50Qo87SVpJUhtVQHoHpM6xdXoTCRMVPFvQ8oIdkBmDKrzYH5CzxzrC7Mxi7x33BnCibVOOPnjeBvdeGaTBbE5RSK/qP3BN
+    AWS_SES_SMTP_PASSWORD: AgCdnZkHaoPZTmqAlHtyYANnrQ6IQFk+fUCvLFEiUM7Gx+NZCFCNbzaqwS5ng+bB5m26h4ruMgvzfwwym69e8//LNEV0fU5sxUHpBx1S0JxUgE8EsJkzf+aslYRgyN6kQiGSJusF1YSzrounTlzbBFYk3d2SObEAmlG6ua9opnlgyMOYyoj0SkZQprxH5HYgAy0KkooLP4nvolKlhxH+v/rnCs+Z0o2CyEkaPwCZ7VBRAhfTTDtyOvXOFuiRMjdqFhEjzsZYPyiedZK6xviStuYOhwunm8J2zcpFeGRCRqMitw4w1qrgwbKTxSpm1aD4TU42yzEv5e19ZQTWuSOgFabF/1f/4K1WF5GFLMBplTrCYeW6venAKz9ddyAxe6qytkumfM3weTWEpE26glEqdbaZf9tBpGdwVBvihDxLSGA6t/U2MkGMVPcPoDV3I206Onvec0p5dtDt9r/jZeFABuHQlJKZzQ4btAsCwB9ih4xBvbiPEbRjWcqLMcGMiwbPWGnv8BQ6gdvsBMHzbMQEaHGQht6Nek2JMx7a/FHjW9N+QF6bc9Qz0LS6h1S+b4xAJmFoLdbfj1ZhbHhSsupuIP/pTldlqYqyDxzj34XUJ07so1hn+iXH9I4g0uP5XYaBkt6HZmKuYCULtfxBrJeapgYgc0Y/P0o69CF1hDD9GwUtbvBUNEH6HhYAEJYA+c+RtIHjlAvRaE0NWtG7P9Ixn99V32VUTwrmHaF/rZUx1evri3SlITjkO7Aer2ZVeso=
+    AWS_SES_SMTP_USERNAME: AgAqj5jx07rmraE3TLVK8H3sz4NOMvr14sZejTyz7W/frSUqY0va1adkZocY9pmiz5JZzmJrR/oemhIl7oJWTRFyZuYk0vGTuCjtGDYAgERiT7YkPuJeAD+CNvEsMOI+HCGNFA28iMriTgr8EBLQnUR/Z/tJvCt3oKoj7jsvsva5w8/YIdA+aAEquB819dptUVWcRlyPCv+iIyjoF6/xRA2kOv4ZjEUyxVnFDgfRoEfCghG+TvF0mRlqsB61HXXYnhV59x2JW3onOGeTfFtzBlYb444UiYzN49YGm7V9BCUj50x2xzAWXXE2MF0DJJeUOvPpl3umJ6KmP8vMJXUE6fzF6evRbESi7dss0OHQfeKJvjbIFuy0pnkIB6j/FT7d7SXGtD+I0roP4Fo4hueQiDmVmJ2z5SCHzATYAUjY1+oyVhgbWBV4KyaDpoolnhfvdCR5ltu83Tvzk6/5NKiprKVBen2ADfO6MttR2qCTcuu1eKky7ALkCB59iWt+pFfWG80QU4A1wqP1c48oiRid1/TAmACrT0nQloZkoA9YFBM4rdrtjU/d/syvlMfz9qau2VnknyRNvFX2z7BUSY9xY6IRAIvFPfVCgPeVajaylUAUEdMqiLpi1M4p/KTv6grCsTJNh5MQKnnjNHYfmQJoQ4fmHdRxnkH91QDNjBL3Z5jUbDw3hauN60+Rvbi5qc+iriEVEDuC1Ejs2nyymBZIzRtLliTopn0=
+  template:
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      labels:
+        app: ${BUILD_REPOSITORY_NAME}
+        source: ${BUILD_REPOSITORY_NAME}
+      name: ${BUILD_REPOSITORY_NAME}-email-secret
+      namespace: ${NAMESPACE}

--- a/nest-tax-backend/kubernetes/envs/Staging/kustomization.yml
+++ b/nest-tax-backend/kubernetes/envs/Staging/kustomization.yml
@@ -2,6 +2,7 @@ resources:
   - ../../base
   - scaler.yml
   - ./secrets/reporting.secret.yml
+  - ./secrets/email.secret.yml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/nest-tax-backend/kubernetes/envs/Staging/secrets/email.secret.yml
+++ b/nest-tax-backend/kubernetes/envs/Staging/secrets/email.secret.yml
@@ -1,0 +1,24 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  labels:
+    app: ${BUILD_REPOSITORY_NAME}
+    source: ${BUILD_REPOSITORY_NAME}
+  name: ${BUILD_REPOSITORY_NAME}-email-secret
+  namespace: ${NAMESPACE}
+spec:
+  encryptedData:
+    AWS_SES_SENDER_EMAIL: AgByzYyT6ysRVR+4gyxkdwqKfisloLqF9F6sPOZrHZwe0fwXjf11eOtJhxC4mktQj3bZxPziiStiuwKTs+KzKlkXGX2iA+IHKljE0zGiiMfh85Tv79ZO6XrHjZfUDiKhv8pRMWnjM33Kxplv4bgTtWHqXYSgTbVNQtmME4ktVq0To7vbvj0MSglTJsqqkzW+XH2GoRMP5wf/ka2inmm6+FxeVXuPMNXMx1EP2XKWm8lZ09zQ7N2IETJMwVZ42mVKjztvT04Rl7tMRc4iZVDeg7iwgJytDW9Yo2rp1txlLYA8M+8tTqhfo3pvysTwqCG7R8lcsSyyaQW9Gwsqadr+G5Oc1f9JLEmzPw9oyyehFTRmBma3sW6JlNP655usMyIOzsA47RVRrRSmDlp/31/p+5JBBoI6lZk/wthbgUV+AtyHQGTTmfVjT7M2b+6qTiMyxnq38Mt5CYdXJblMPAc6ep2hzKGZXa7PibFsoqTzlrgjr/iL68F/Zr+EczeHT57/56v12UfIUt7jKubhuY6TAyDlzw82m6EfDusZF/mXSdDsT6J7cGMYOThX/BEYfYCsRNbw9HBXSQAuuoLsQsptivZGb8gDcDGx9LlB8x/rGYlhjsVDMEyPnnP9fyan2AMiI066uaWrWg39D+QcM2sDOnnvdmLvFIP3Gyodr7i2LusyoOv+E1EKsF8VUwRnGV1tkmHsK8WqtFH54hMpDUYjgfbAyXGh3eRuyAaG6+wX
+    AWS_SES_SMTP_PASSWORD: AgCAZ/YmFANXFm7YkT94cvKR1ZduTdWp97uMO28w3TXLLKGXmoUBaMbYzfuC+5RYTwhBftbXcTTbE2NV3mfh4KZ9M2cSYcZYdfioVtxigAGHMfkJsJjHsmlVbrk/R4QwLdZVZB+Y3xyzuKNcikaTA52IobyQgcisKYZQ6OM27orTG33SNZ5mF0at/Y1aSZiXaQaUiFTMHOXxKtJ4DrBtEceMqTtuv/ZSLRvyV05HIuiQBLTBuzpF9EHQTzXbzny+pM8IOSqVC7KECKcsMEAye1yaYk/PTqjGbPDwQsVIDHcgE++dPP6wYM30W9iANoYX09MrWGJPZGWh2G4S1ZU89fMrv42HaIIr8lNwUFjmaMx3KplMHOcPDrOutPbqJp0WWU5wiyEObyTUJTU+S3JGP8jeNvuy/NFD2sHUTYNvC/iI2grLWnb7fsDEh8MZEJQFsmvq4q84HE40kEiiRXFDiGqAyuixnO2/Gbz24Izlv1g78SOYF51HTAXdhq78M9T7IymD6dd2Uhd5woaLWrOBkufJ4HOu+7FJ75FU8ltmDTu+ZvtdKIjXcpbuwaI61fmnjvDUVp/0XaQrvhHGKpJrfcY7GO3940A/HSQWCfRMEj90wqczPChRTx3ju60g19n7qckXPgBKJaIpYOC5QpUu7ps4xF5soAD9CBWQM9IPbinlCt5QUWIxFsmOTR4C4293gRrV6T+UaBGD/t8uvYKT8hw2PfIsKkcPTmDvEsZ2fwAVBdv0fXqt4ZfAku9zyrE=
+    AWS_SES_SMTP_USERNAME: AgAYuviqwiejyxZoLL2lx13ieOvUcCLsAc6oCDkPFY1HfFml2KUBzJ0pHIwTWSnwXPDEj6N48mCgRfzZ1iKQhsmUlaGoLVWBjLuNeH8q1Tjw0fcYhyrfaOGsJIjlq3XvPGfoHxXmCNckkDpNE0lveGCcUekw8Y36R2aaj+LeNfvT59WeL4NqBv1pMhliPFyuTb1nTFSQ6gw2vcOZwM8EybOeOMelE4jNK0vs2t7FOo5hehlNfOoO25BnVPWLu5wVVJ91CfRCTmeGcYoDXldw06Y36ZQ9qOeiebY8olGDtdozsyof5XxFx/+hKAFNlyXG8WccAJyV9uNFggAm8bvWHrvMxd9gmsRFkueg6S7fmDIWqMP6s9/m0p7zU+TzdRm2lOPnvmbCw/J/d/qn1lhAqthnTjkFOdk2b/j3ASvWE/aKF6iQI6fV2q+YtCu0Kyb/d8HJn5xvpUg77KRjXdfUWpDE59oqL3q4r3tI58P+ShfwpVzMU5cqJxThci/AXFZuFspzufYQAYsFRD4Ztzy2QJpGNAKSrZSwm6opOyPKx2ZH0kq/6RQGHeaQMvTrChQ6cvAQUha6mxyLdTUyA7y27sosIO7WJLkMouZYh6M+1gqdN1gqQn+e+q/HCygXuCpVdqxDqaQWhr1OOboceWPVBxLvnygn4sctWRbl6eImWl+NDr2OfbL+fLYVL6jhD8wUNXPrKTSaISHkhJyTbk7d1nDgpLI=
+  template:
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      labels:
+        app: ${BUILD_REPOSITORY_NAME}
+        source: ${BUILD_REPOSITORY_NAME}
+      name: ${BUILD_REPOSITORY_NAME}-email-secret
+      namespace: ${NAMESPACE}

--- a/nest-tax-backend/src/utils/subservices/email.subservice.ts
+++ b/nest-tax-backend/src/utils/subservices/email.subservice.ts
@@ -11,7 +11,7 @@ import { LineLoggerSubservice } from './line-logger.subservice'
  * transporter with optional support for attachments.
  *
  * The service is configured via environment variables, including a fixed sender
- * email set by the SENDER_EMAIL variable.
+ * email set by the AWS_SES_SENDER_EMAIL variable.
  *
  * @note We use AWS SES (Simple Email Service) instead of Mailgun due to GDPR
  * compliance requirements, ensuring that email data is handled securely and

--- a/nest-tax-backend/src/utils/subservices/email.subservice.ts
+++ b/nest-tax-backend/src/utils/subservices/email.subservice.ts
@@ -32,8 +32,8 @@ export default class EmailSubservice {
       port: 465,
       secure: true,
       auth: {
-        user: this.configService.getOrThrow<string>('SMTP_USERNAME'),
-        pass: this.configService.getOrThrow<string>('SMTP_PASSWORD'),
+        user: this.configService.getOrThrow<string>('AWS_SES_SMTP_USERNAME'),
+        pass: this.configService.getOrThrow<string>('AWS_SES_SMTP_PASSWORD'),
       },
     })
   }
@@ -54,7 +54,7 @@ export default class EmailSubservice {
   ): Promise<void> {
     try {
       const emailOptions = {
-        from: this.configService.getOrThrow<string>('SENDER_EMAIL'),
+        from: this.configService.getOrThrow<string>('AWS_SES_SENDER_EMAIL'),
         to: to.join(', '),
         subject,
         text: message,

--- a/nest-tax-backend/src/utils/subservices/email.subservice.ts
+++ b/nest-tax-backend/src/utils/subservices/email.subservice.ts
@@ -6,6 +6,17 @@ import { ErrorsEnum } from '../guards/dtos/error.dto'
 import ThrowerErrorGuard from '../guards/errors.guard'
 import { LineLoggerSubservice } from './line-logger.subservice'
 
+/**
+ * EmailSubservice handles the functionality of sending emails using an SMTP
+ * transporter with optional support for attachments.
+ *
+ * The service is configured via environment variables, including a fixed sender
+ * email set by the SENDER_EMAIL variable.
+ *
+ * @note We use AWS SES (Simple Email Service) instead of Mailgun due to GDPR
+ * compliance requirements, ensuring that email data is handled securely and
+ * within GDPR-regulated regions.
+ */
 @Injectable()
 export default class EmailSubservice {
   private readonly logger = new LineLoggerSubservice(EmailSubservice.name)


### PR DESCRIPTION
- Added secrets for email subservice
- Added documentation about why we use AWS SES instead of Mailgun as suggested by @lukasbabula.