### PR TITLE
Skip nases outbox if we are sending the message to ourselves

### DIFF
--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
@@ -517,8 +517,16 @@ export default class NasesUtilsService {
         },
       }
     }
+
+    // skip saving the message to outbox if we are sending it to ourselves as it will be available in inbox
+    const sktalkReceiveFn =
+      !senderUri ||
+      senderUri === (this.configService.get<string>('NASES_SENDER_URI') ?? '')
+        ? slovenskoSkApi.apiSktalkReceivePost
+        : slovenskoSkApi.apiSktalkReceiveAndSaveToOutboxPost
+
     try {
-      const response = await slovenskoSkApi.apiSktalkReceiveAndSaveToOutboxPost(
+      const response = await sktalkReceiveFn(
         {
           message,
         },


### PR DESCRIPTION
This behavior is requested by Lubo (ref. reg.). Since we are sending the message to ourselves, we can see it in inbox just fine, no need for it to have in outbox, and it clutters the outbox too much.

If there is any other sender, we still want to save the message to their outbox.