### PR TITLE
Implement ginis file upload string length restrictions

### DIFF
--- a/nest-forms-backend/src/ginis/subservices/ginis-api.service.ts
+++ b/nest-forms-backend/src/ginis/subservices/ginis-api.service.ts
@@ -72,10 +72,10 @@ export default class GinisAPIService {
 
     const fileUpload = await this.ginis.ssl.pridatSouborMtom({
       'Id-dokumentu': documentId,
-      'Jmeno-souboru': fileName,
+      'Jmeno-souboru': fileName.slice(-254), // filenames usually differ at the end
       'Typ-vazby': 'elektronicka-priloha',
-      'Popis-souboru': baseName,
-      'Podrobny-popis-souboru': baseName,
+      'Popis-souboru': baseName.slice(0, 50),
+      'Podrobny-popis-souboru': baseName.slice(0, 254),
       Obsah: contentStream,
     })
 


### PR DESCRIPTION
According to the ginis documentation for SSL `pridat-soubor`:
**`Jmeno-souboru`**: string; Max. 254, Min. 1
**`Popis-souboru`**: string; Max. 50, Min. 0
**`Podrobny-popis-souboru`**: string; Max. 254, Min. 1