### PR TITLE
Feat/endpoint to cancel tax

### DIFF
--- a/nest-city-account/src/admin/admin.controller.ts
+++ b/nest-city-account/src/admin/admin.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common'
 import {
   ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiResponse,
   ApiSecurity,
@@ -44,6 +45,7 @@ import {
 } from './dtos/responses.admin.dto'
 import { ErrorsEnum, ErrorsResponseEnum } from '../utils/guards/dtos/error.dto'
 import { LineLoggerSubservice } from '../utils/subservices/line-logger.subservice'
+import { RequestAdminDeleteTaxDto } from '../generated-clients/nest-tax-backend'
 
 @ApiTags('ADMIN')
 @Controller('admin')
@@ -289,5 +291,19 @@ export class AdminController {
   @Post('validate-physical-entity-rfo')
   async validatePhysicalEntityRfo(@Body() data: RequestValidatePhysicalEntityRfoDto) {
     return this.physicalEntityService.updateFromRFO(data.physicalEntityId)
+  }
+
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Delete tax for user',
+    description: 'Delete tax for user, for example when the tax is cancelled in Noris.',
+  })
+  @ApiOkResponse({
+    description: 'Success if all was updated accordingly.',
+  })
+  @UseGuards(AdminGuard)
+  @Post('delete-tax')
+  async deleteTax(@Body() data: RequestAdminDeleteTaxDto): Promise<void> {
+    await this.adminService.deleteTax(data)
   }
 }

--- a/nest-city-account/src/admin/admin.service.ts
+++ b/nest-city-account/src/admin/admin.service.ts
@@ -37,6 +37,7 @@ import {
   removeLegalPersonDataFromDatabase,
   removeUserDataFromDatabase,
 } from './utils/account-deactivate.utils'
+import { RequestAdminDeleteTaxDto } from '../generated-clients/nest-tax-backend'
 
 @Injectable()
 export class AdminService {
@@ -503,5 +504,26 @@ export class AdminService {
       validatedUsers: result.success.length,
       entities: result,
     }
+  }
+
+  async deleteTax(data: RequestAdminDeleteTaxDto): Promise<OnlySuccessDto> {
+    const user = await this.prismaService.user.findUnique({
+      where: { birthNumber: data.birthNumber },
+    })
+    if (!user) {
+      throw this.throwerErrorGuard.NotFoundException(
+        UserErrorsEnum.USER_NOT_FOUND,
+        UserErrorsResponseEnum.USER_NOT_FOUND
+      )
+    }
+    
+    await this.prismaService.user.update({
+      where: { birthNumber: data.birthNumber },
+      data: {
+        lastTaxYear: null,
+      },
+    })
+    await this.taxSubservice.deleteTax(data)
+    return { success: true }
   }
 }

--- a/nest-city-account/src/generated-clients/nest-tax-backend/.openapi-generator/FILES
+++ b/nest-city-account/src/generated-clients/nest-tax-backend/.openapi-generator/FILES
@@ -1,6 +1,5 @@
 .gitignore
 .npmignore
-.openapi-generator-ignore
 api.ts
 base.ts
 common.ts

--- a/nest-city-account/src/generated-clients/nest-tax-backend/api.ts
+++ b/nest-city-account/src/generated-clients/nest-tax-backend/api.ts
@@ -47,6 +47,111 @@ export interface CreateBirthNumbersResponseDto {
   birthNumbers: Array<string>
 }
 /**
+ * delivery_method
+ * @export
+ * @enum {string}
+ */
+
+export const DeliveryMethodNamed = {
+  Edesk: 'EDESK',
+  Postal: 'POSTAL',
+  CityAccount: 'CITY_ACCOUNT',
+} as const
+
+export type DeliveryMethodNamed = (typeof DeliveryMethodNamed)[keyof typeof DeliveryMethodNamed]
+
+/**
+ *
+ * @export
+ * @interface RequestAdminCreateTestingTaxDto
+ */
+export interface RequestAdminCreateTestingTaxDto {
+  /**
+   * Year of tax
+   * @type {number}
+   * @memberof RequestAdminCreateTestingTaxDto
+   */
+  year: number
+  /**
+   * Fake Noris Data
+   * @type {RequestAdminCreateTestingTaxNorisData}
+   * @memberof RequestAdminCreateTestingTaxDto
+   */
+  norisData: RequestAdminCreateTestingTaxNorisData
+}
+/**
+ *
+ * @export
+ * @interface RequestAdminCreateTestingTaxNorisData
+ */
+export interface RequestAdminCreateTestingTaxNorisData {
+  /**
+   * Delivery method for the tax
+   * @type {string}
+   * @memberof RequestAdminCreateTestingTaxNorisData
+   */
+  deliveryMethod: RequestAdminCreateTestingTaxNorisDataDeliveryMethodEnum | null
+  /**
+   * Birth number in format with slash
+   * @type {string}
+   * @memberof RequestAdminCreateTestingTaxNorisData
+   */
+  fakeBirthNumber: string
+  /**
+   * Full name and surname of the tax payer
+   * @type {string}
+   * @memberof RequestAdminCreateTestingTaxNorisData
+   */
+  nameSurname: string
+  /**
+   * Total tax amount as string
+   * @type {string}
+   * @memberof RequestAdminCreateTestingTaxNorisData
+   */
+  taxTotal: string
+  /**
+   * Amount already paid as string
+   * @type {string}
+   * @memberof RequestAdminCreateTestingTaxNorisData
+   */
+  alreadyPaid: string
+  /**
+   * Date of tax ruling (dátum právoplatnosti)
+   * @type {string}
+   * @memberof RequestAdminCreateTestingTaxNorisData
+   */
+  dateTaxRuling: string | null
+}
+
+export const RequestAdminCreateTestingTaxNorisDataDeliveryMethodEnum = {
+  E: 'E',
+  O: 'O',
+  P: 'P',
+} as const
+
+export type RequestAdminCreateTestingTaxNorisDataDeliveryMethodEnum =
+  (typeof RequestAdminCreateTestingTaxNorisDataDeliveryMethodEnum)[keyof typeof RequestAdminCreateTestingTaxNorisDataDeliveryMethodEnum]
+
+/**
+ *
+ * @export
+ * @interface RequestAdminDeleteTaxDto
+ */
+export interface RequestAdminDeleteTaxDto {
+  /**
+   * Year of tax
+   * @type {number}
+   * @memberof RequestAdminDeleteTaxDto
+   */
+  year: number
+  /**
+   * Birth number in format with slash
+   * @type {string}
+   * @memberof RequestAdminDeleteTaxDto
+   */
+  birthNumber: string
+}
+/**
  *
  * @export
  * @interface RequestPostNorisLoadDataDto
@@ -391,10 +496,10 @@ export interface ResponseTaxDetailsDto {
   type: TaxDetailTypeEnum
   /**
    * Area type of tax detail - exact type of object of tax
-   * @type {TaxDetailTypeEnum}
+   * @type {TaxDetailareaType}
    * @memberof ResponseTaxDetailsDto
    */
-  areaType: TaxDetailTypeEnum
+  areaType: TaxDetailareaType
   /**
    * Area of tax detail - square meters
    * @type {string}
@@ -494,6 +599,12 @@ export interface ResponseTaxDto {
    */
   dateCreateTax: string | null
   /**
+   * Date and time of tax ruling (právoplatnosť rozhodnutia)
+   * @type {string}
+   * @memberof ResponseTaxDto
+   */
+  dateTaxRuling: string | null
+  /**
    * Part of tax amount for lands in cents in Eur.
    * @type {number}
    * @memberof ResponseTaxDto
@@ -571,6 +682,18 @@ export interface ResponseTaxDto {
    * @memberof ResponseTaxDto
    */
   lastCheckedPayments: string
+  /**
+   * When were last checked updates for this tax with automatic task.
+   * @type {string}
+   * @memberof ResponseTaxDto
+   */
+  lastCheckedUpdates: string
+  /**
+   * delivery_method
+   * @type {DeliveryMethodNamed}
+   * @memberof ResponseTaxDto
+   */
+  deliveryMethod: DeliveryMethodNamed | null
 }
 
 /**
@@ -728,6 +851,31 @@ export const TaxDetailTypeEnum = {
 export type TaxDetailTypeEnum = (typeof TaxDetailTypeEnum)[keyof typeof TaxDetailTypeEnum]
 
 /**
+ * Area type of tax detail - exact type of object of tax
+ * @export
+ * @enum {string}
+ */
+
+export const TaxDetailareaType = {
+  Nonresidential: 'NONRESIDENTIAL',
+  Residential: 'RESIDENTIAL',
+  A: 'A',
+  B: 'B',
+  C: 'C',
+  D: 'D',
+  E: 'E',
+  F: 'F',
+  G: 'G',
+  H: 'H',
+  JH: 'jH',
+  JI: 'jI',
+  Byt: 'byt',
+  Nebyt: 'nebyt',
+} as const
+
+export type TaxDetailareaType = (typeof TaxDetailareaType)[keyof typeof TaxDetailareaType]
+
+/**
  * Type of paid status
  * @export
  * @enum {string}
@@ -748,6 +896,110 @@ export type TaxPaidStatusEnum = (typeof TaxPaidStatusEnum)[keyof typeof TaxPaidS
  */
 export const AdminApiAxiosParamCreator = function (configuration?: Configuration) {
   return {
+    /**
+     * Creates a testing tax record with specified details for development and testing purposes
+     * @summary Create a testing tax record
+     * @param {RequestAdminCreateTestingTaxDto} requestAdminCreateTestingTaxDto
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    adminControllerCreateTestingTax: async (
+      requestAdminCreateTestingTaxDto: RequestAdminCreateTestingTaxDto,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'requestAdminCreateTestingTaxDto' is not null or undefined
+      assertParamExists(
+        'adminControllerCreateTestingTax',
+        'requestAdminCreateTestingTaxDto',
+        requestAdminCreateTestingTaxDto
+      )
+      const localVarPath = `/admin/create-testing-tax`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication apiKey required
+      await setApiKeyToObject(localVarHeaderParameter, 'apiKey', configuration)
+
+      localVarHeaderParameter['Content-Type'] = 'application/json'
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        requestAdminCreateTestingTaxDto,
+        localVarRequestOptions,
+        configuration
+      )
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * Deletes a tax record for a specific birth number and year
+     * @summary Delete a tax record
+     * @param {RequestAdminDeleteTaxDto} requestAdminDeleteTaxDto
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    adminControllerDeleteTax: async (
+      requestAdminDeleteTaxDto: RequestAdminDeleteTaxDto,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'requestAdminDeleteTaxDto' is not null or undefined
+      assertParamExists(
+        'adminControllerDeleteTax',
+        'requestAdminDeleteTaxDto',
+        requestAdminDeleteTaxDto
+      )
+      const localVarPath = `/admin/delete-tax`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication apiKey required
+      await setApiKeyToObject(localVarHeaderParameter, 'apiKey', configuration)
+
+      localVarHeaderParameter['Content-Type'] = 'application/json'
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        requestAdminDeleteTaxDto,
+        localVarRequestOptions,
+        configuration
+      )
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
     /**
      *
      * @summary Integrate data from norris if not exists by birth numbers or all
@@ -1011,6 +1263,60 @@ export const AdminApiFp = function (configuration?: Configuration) {
   const localVarAxiosParamCreator = AdminApiAxiosParamCreator(configuration)
   return {
     /**
+     * Creates a testing tax record with specified details for development and testing purposes
+     * @summary Create a testing tax record
+     * @param {RequestAdminCreateTestingTaxDto} requestAdminCreateTestingTaxDto
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async adminControllerCreateTestingTax(
+      requestAdminCreateTestingTaxDto: RequestAdminCreateTestingTaxDto,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.adminControllerCreateTestingTax(
+        requestAdminCreateTestingTaxDto,
+        options
+      )
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath =
+        operationServerMap['AdminApi.adminControllerCreateTestingTax']?.[
+          localVarOperationServerIndex
+        ]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
+    /**
+     * Deletes a tax record for a specific birth number and year
+     * @summary Delete a tax record
+     * @param {RequestAdminDeleteTaxDto} requestAdminDeleteTaxDto
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async adminControllerDeleteTax(
+      requestAdminDeleteTaxDto: RequestAdminDeleteTaxDto,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.adminControllerDeleteTax(
+        requestAdminDeleteTaxDto,
+        options
+      )
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath =
+        operationServerMap['AdminApi.adminControllerDeleteTax']?.[localVarOperationServerIndex]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
+    /**
      *
      * @summary Integrate data from norris if not exists by birth numbers or all
      * @param {RequestPostNorisLoadDataDto} requestPostNorisLoadDataDto
@@ -1170,6 +1476,36 @@ export const AdminApiFactory = function (
   const localVarFp = AdminApiFp(configuration)
   return {
     /**
+     * Creates a testing tax record with specified details for development and testing purposes
+     * @summary Create a testing tax record
+     * @param {RequestAdminCreateTestingTaxDto} requestAdminCreateTestingTaxDto
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    adminControllerCreateTestingTax(
+      requestAdminCreateTestingTaxDto: RequestAdminCreateTestingTaxDto,
+      options?: any
+    ): AxiosPromise<void> {
+      return localVarFp
+        .adminControllerCreateTestingTax(requestAdminCreateTestingTaxDto, options)
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     * Deletes a tax record for a specific birth number and year
+     * @summary Delete a tax record
+     * @param {RequestAdminDeleteTaxDto} requestAdminDeleteTaxDto
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    adminControllerDeleteTax(
+      requestAdminDeleteTaxDto: RequestAdminDeleteTaxDto,
+      options?: any
+    ): AxiosPromise<void> {
+      return localVarFp
+        .adminControllerDeleteTax(requestAdminDeleteTaxDto, options)
+        .then((request) => request(axios, basePath))
+    },
+    /**
      *
      * @summary Integrate data from norris if not exists by birth numbers or all
      * @param {RequestPostNorisLoadDataDto} requestPostNorisLoadDataDto
@@ -1254,6 +1590,40 @@ export const AdminApiFactory = function (
  * @extends {BaseAPI}
  */
 export class AdminApi extends BaseAPI {
+  /**
+   * Creates a testing tax record with specified details for development and testing purposes
+   * @summary Create a testing tax record
+   * @param {RequestAdminCreateTestingTaxDto} requestAdminCreateTestingTaxDto
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof AdminApi
+   */
+  public adminControllerCreateTestingTax(
+    requestAdminCreateTestingTaxDto: RequestAdminCreateTestingTaxDto,
+    options?: RawAxiosRequestConfig
+  ) {
+    return AdminApiFp(this.configuration)
+      .adminControllerCreateTestingTax(requestAdminCreateTestingTaxDto, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * Deletes a tax record for a specific birth number and year
+   * @summary Delete a tax record
+   * @param {RequestAdminDeleteTaxDto} requestAdminDeleteTaxDto
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof AdminApi
+   */
+  public adminControllerDeleteTax(
+    requestAdminDeleteTaxDto: RequestAdminDeleteTaxDto,
+    options?: RawAxiosRequestConfig
+  ) {
+    return AdminApiFp(this.configuration)
+      .adminControllerDeleteTax(requestAdminDeleteTaxDto, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
   /**
    *
    * @summary Integrate data from norris if not exists by birth numbers or all

--- a/nest-city-account/src/utils/subservices/tax.subservice.ts
+++ b/nest-city-account/src/utils/subservices/tax.subservice.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common'
 import {
   AdminApi,
   Configuration,
+  RequestAdminDeleteTaxDto,
   RequestPostNorisLoadDataDto,
   RequestUpdateNorisDeliveryMethodsDto,
 } from '../../generated-clients/nest-tax-backend'
@@ -70,5 +71,16 @@ export class TaxSubservice {
         apiKey: this.config.taxBackendApiKey,
       },
     })
+  }
+
+  async deleteTax(data: RequestAdminDeleteTaxDto) {
+    return this.taxBackendAdminApi.adminControllerDeleteTax(
+      data,
+      {
+        headers: {
+          apiKey: this.config.taxBackendApiKey,
+        },
+      }
+    )
   }
 }

--- a/nest-tax-backend/src/admin/admin.controller.ts
+++ b/nest-tax-backend/src/admin/admin.controller.ts
@@ -153,11 +153,8 @@ export class AdminController {
     description: 'Internal server error or tax payer not found',
   })
   @UseGuards(AdminGuard)
-  @UseGuards(NotProductionGuard)
-  @Post('delete-testing-tax')
-  async deleteTestingTax(
-    @Body() request: RequestAdminDeleteTaxDto,
-  ): Promise<void> {
-    await this.adminService.deleteTestingTax(request)
+  @Post('delete-tax')
+  async deleteTax(@Body() request: RequestAdminDeleteTaxDto): Promise<void> {
+    await this.adminService.deleteTax(request)
   }
 }

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -649,9 +649,10 @@ export class AdminService {
     year,
     birthNumber,
   }: RequestAdminDeleteTaxDto): Promise<void> {
+    const birthNumberWithSlash = addSlashToBirthNumber(birthNumber)
     const taxPayer = await this.prismaService.taxPayer.findUnique({
       where: {
-        birthNumber,
+        birthNumber: birthNumberWithSlash,
       },
     })
     if (!taxPayer) {

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -645,7 +645,7 @@ export class AdminService {
     await this.processNorisTaxData([mockTaxRecord], year)
   }
 
-  async deleteTestingTax({
+  async deleteTax({
     year,
     birthNumber,
   }: RequestAdminDeleteTaxDto): Promise<void> {
@@ -676,28 +676,30 @@ export class AdminService {
       )
     }
 
-    await this.prismaService.taxPayment.deleteMany({
-      where: {
-        taxId: tax.id,
-      },
-    })
-    await this.prismaService.taxInstallment.deleteMany({
-      where: {
-        taxId: tax.id,
-      },
-    })
-    await this.prismaService.taxDetail.deleteMany({
-      where: {
-        taxId: tax.id,
-      },
-    })
-    await this.prismaService.tax.delete({
-      where: {
-        taxPayerId_year: {
-          taxPayerId: taxPayer.id,
-          year,
+    await this.prismaService.$transaction([
+      this.prismaService.taxPayment.deleteMany({
+        where: {
+          taxId: tax.id,
         },
-      },
-    })
+      }),
+      this.prismaService.taxInstallment.deleteMany({
+        where: {
+          taxId: tax.id,
+        },
+      }),
+      this.prismaService.taxDetail.deleteMany({
+        where: {
+          taxId: tax.id,
+        },
+      }),
+      this.prismaService.tax.delete({
+        where: {
+          taxPayerId_year: {
+            taxPayerId: taxPayer.id,
+            year,
+          },
+        },
+      }),
+    ])
   }
 }

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -955,17 +955,17 @@ export const AdminApiAxiosParamCreator = function (configuration?: Configuration
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    adminControllerDeleteTestingTax: async (
+    adminControllerDeleteTax: async (
       requestAdminDeleteTaxDto: RequestAdminDeleteTaxDto,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'requestAdminDeleteTaxDto' is not null or undefined
       assertParamExists(
-        'adminControllerDeleteTestingTax',
+        'adminControllerDeleteTax',
         'requestAdminDeleteTaxDto',
         requestAdminDeleteTaxDto,
       )
-      const localVarPath = `/admin/delete-testing-tax`
+      const localVarPath = `/admin/delete-tax`
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
       let baseOptions
@@ -1297,19 +1297,17 @@ export const AdminApiFp = function (configuration?: Configuration) {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async adminControllerDeleteTestingTax(
+    async adminControllerDeleteTax(
       requestAdminDeleteTaxDto: RequestAdminDeleteTaxDto,
       options?: RawAxiosRequestConfig,
     ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.adminControllerDeleteTestingTax(
+      const localVarAxiosArgs = await localVarAxiosParamCreator.adminControllerDeleteTax(
         requestAdminDeleteTaxDto,
         options,
       )
       const localVarOperationServerIndex = configuration?.serverIndex ?? 0
       const localVarOperationServerBasePath =
-        operationServerMap['AdminApi.adminControllerDeleteTestingTax']?.[
-          localVarOperationServerIndex
-        ]?.url
+        operationServerMap['AdminApi.adminControllerDeleteTax']?.[localVarOperationServerIndex]?.url
       return (axios, basePath) =>
         createRequestFunction(
           localVarAxiosArgs,
@@ -1499,12 +1497,12 @@ export const AdminApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    adminControllerDeleteTestingTax(
+    adminControllerDeleteTax(
       requestAdminDeleteTaxDto: RequestAdminDeleteTaxDto,
       options?: RawAxiosRequestConfig,
     ): AxiosPromise<void> {
       return localVarFp
-        .adminControllerDeleteTestingTax(requestAdminDeleteTaxDto, options)
+        .adminControllerDeleteTax(requestAdminDeleteTaxDto, options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -1617,12 +1615,12 @@ export class AdminApi extends BaseAPI {
    * @throws {RequiredError}
    * @memberof AdminApi
    */
-  public adminControllerDeleteTestingTax(
+  public adminControllerDeleteTax(
     requestAdminDeleteTaxDto: RequestAdminDeleteTaxDto,
     options?: RawAxiosRequestConfig,
   ) {
     return AdminApiFp(this.configuration)
-      .adminControllerDeleteTestingTax(requestAdminDeleteTaxDto, options)
+      .adminControllerDeleteTax(requestAdminDeleteTaxDto, options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/openapi-clients/tax/docs/AdminApi.md
+++ b/openapi-clients/tax/docs/AdminApi.md
@@ -5,7 +5,7 @@ All URIs are relative to _http://localhost:3000_
 | Method                                                                                              | HTTP request                                                     | Description                                                      |
 | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- |
 | [**adminControllerCreateTestingTax**](#admincontrollercreatetestingtax)                             | **POST** /admin/create-testing-tax                               | Create a testing tax record                                      |
-| [**adminControllerDeleteTestingTax**](#admincontrollerdeletetestingtax)                             | **POST** /admin/delete-testing-tax                               | Delete a tax record                                              |
+| [**adminControllerDeleteTax**](#admincontrollerdeletetax)                                           | **POST** /admin/delete-tax                                       | Delete a tax record                                              |
 | [**adminControllerLoadDataFromNorris**](#admincontrollerloaddatafromnorris)                         | **POST** /admin/create-data-from-noris                           | Integrate data from norris if not exists by birth numbers or all |
 | [**adminControllerRemoveDeliveryMethodsFromNoris**](#admincontrollerremovedeliverymethodsfromnoris) | **POST** /admin/remove-delivery-methods-from-noris/{birthNumber} | Remove delivery methods for given birth number.                  |
 | [**adminControllerUpdateDataFromNorris**](#admincontrollerupdatedatafromnorris)                     | **POST** /admin/update-data-from-norris                          | Integrate data from norris                                       |
@@ -61,9 +61,9 @@ void (empty response body)
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **adminControllerDeleteTestingTax**
+# **adminControllerDeleteTax**
 
-> adminControllerDeleteTestingTax(requestAdminDeleteTaxDto)
+> adminControllerDeleteTax(requestAdminDeleteTaxDto)
 
 Deletes a tax record for a specific birth number and year
 
@@ -77,7 +77,7 @@ const apiInstance = new AdminApi(configuration)
 
 let requestAdminDeleteTaxDto: RequestAdminDeleteTaxDto //
 
-const { status, data } = await apiInstance.adminControllerDeleteTestingTax(requestAdminDeleteTaxDto)
+const { status, data } = await apiInstance.adminControllerDeleteTax(requestAdminDeleteTaxDto)
 ```
 
 ### Parameters


### PR DESCRIPTION
Creates endpoint on city account which deletes tax for given user and year, for example if the tax was cancelled in Noris.ň

Also opens the delete tax endpoint in tax backend to production, until now it was only for testing on staging.