### PR TITLE
Guest identity fix

### DIFF
--- a/next/clients/axios-instance.ts
+++ b/next/clients/axios-instance.ts
@@ -86,12 +86,12 @@ axiosInstance.interceptors.request.use(async (config) => {
     authSession = await config.getSsrAuthSession()
   }
 
-  // if (!authSession.identityId) {
-  //   // If guest access is enabled both in Amplify client configuration and Amplify admin console administration, this should never happen.
-  //   throw new Error(
-  //     'Failed to retrieve identityId from authentication session. Please check that guest access is enabled in the Amplify client configuration and the Amplify admin console.',
-  //   )
-  // }
+  if (!authSession.identityId) {
+    // If guest access is enabled both in Amplify client configuration and Amplify admin console administration, this should never happen.
+    throw new Error(
+      'Failed to retrieve identityId from authentication session. Please check that guest access is enabled in the Amplify client configuration and the Amplify admin console.',
+    )
+  }
 
   // `authSession.tokens` is synonymous with user being signed in
   if (authSession.tokens) {
@@ -106,7 +106,7 @@ axiosInstance.interceptors.request.use(async (config) => {
 
     case 'authOrGuestWithToken':
       // eslint-disable-next-line no-param-reassign
-      // config.headers['X-Cognito-Guest-Identity-Id'] = authSession.identityId
+      config.headers['X-Cognito-Guest-Identity-Id'] = authSession.identityId
       break
 
     default:

--- a/next/frontend/utils/amplifyClient.ts
+++ b/next/frontend/utils/amplifyClient.ts
@@ -19,6 +19,24 @@ export const removeAllCookiesAndClearLocalStorage = () => {
   localStorage.clear()
 }
 
+/**
+ * Temporary fix for: https://github.com/aws-amplify/amplify-js/issues/14378
+ *
+ * Removes guest identity cookie, Amplify should remove it after successful sign in but does not.
+ */
+export const removeAmplifyGuestIdentityIdCookies = () => {
+  const cookies = document.cookie.split(';').map((cookie) => cookie.trim())
+  cookies.forEach((cookie) => {
+    const cookieName = cookie.split('=')[0]
+
+    if (cookieName.startsWith('com.amplify.Cognito.') && cookieName.endsWith('.identityId')) {
+      // https://stackoverflow.com/questions/179355/clearing-all-cookies-with-javascript
+      document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
+      logger.info(`[AUTH] Deleted Cognito identity cookie: ${cookieName}`)
+    }
+  })
+}
+
 export const useSignOut = () => {
   const router = useRouter()
   const queryClient = useQueryClient()

--- a/next/frontend/utils/amplifyConfig.ts
+++ b/next/frontend/utils/amplifyConfig.ts
@@ -16,7 +16,7 @@ export const amplifyConfig: ResourcesConfig = {
       signUpVerificationMethod: 'code', // 'code' | 'link'
       // `Guest access` must be enabled in `Identity pools` in Amplify Console, otherwise the whole application will
       // stop working.
-      // allowGuestAccess: true,
+      allowGuestAccess: true,
     },
   },
 }

--- a/next/pages/prihlasenie.tsx
+++ b/next/pages/prihlasenie.tsx
@@ -2,7 +2,6 @@ import { AuthError, getCurrentUser, resendSignUpCode, signIn } from 'aws-amplify
 import AccountContainer from 'components/forms/segments/AccountContainer/AccountContainer'
 import LoginForm from 'components/forms/segments/LoginForm/LoginForm'
 import LoginRegisterLayout from 'components/layouts/LoginRegisterLayout'
-import { removeAllCookiesAndClearLocalStorage } from 'frontend/utils/amplifyClient'
 import { GENERIC_ERROR_MESSAGE, isError } from 'frontend/utils/errors'
 import logger from 'frontend/utils/logger'
 import { useRouter } from 'next/router'
@@ -11,6 +10,10 @@ import { useRef, useState } from 'react'
 import { SsrAuthProviderHOC } from '../components/logic/SsrAuthContext'
 import { ROUTES } from '../frontend/api/constants'
 import { useQueryParamRedirect } from '../frontend/hooks/useQueryParamRedirect'
+import {
+  removeAllCookiesAndClearLocalStorage,
+  removeAmplifyGuestIdentityIdCookies,
+} from '../frontend/utils/amplifyClient'
 import { amplifyGetServerSideProps } from '../frontend/utils/amplifyServer'
 import { slovakServerSideTranslations } from '../frontend/utils/slovakServerSideTranslations'
 
@@ -47,6 +50,8 @@ const LoginPage = () => {
       const { nextStep, isSignedIn } = await signIn({ username: email, password })
       if (isSignedIn) {
         logger.info(`[AUTH] Successfully signed in for email ${email}`)
+        // Temporary fix for: https://github.com/aws-amplify/amplify-js/issues/14378
+        removeAmplifyGuestIdentityIdCookies()
         await redirect()
         return
       }


### PR DESCRIPTION
It will take a while to fix https://github.com/aws-amplify/amplify-js/issues/14378, I don't want to change strategy to use guest identities, this will allow us to handle the bugs on our side.

Revert disable of guest identities, and implement two fixes I expect to be fixed in Amplify:
 - guest identity ID cookie is removed right after sucessful sign in
 - if user has disabled (or non-existing) guest identity id (when user signs in, the guest identity they've had is disabled) it will force cookie removal which will result in new guest identity assignment