### PR TITLE
Group eslint dependabot updates for backends

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,15 @@ updates:
       - dependency-name: 'ajv-*'
       # Playwright must be updated in forms-shared at the same time
       - dependency-name: 'playwright'
+      # ESLint and related tooling are pinned and must be upgraded manually to version 9 and reconfigured.
+      # Once ready for an upgrade, remove these ignores to allow grouped updates via the eslint-dependencies group.
+      - dependency-name: 'eslint'
+      - dependency-name: 'eslint-*'
+      - dependency-name: '@eslint/*'
+      - dependency-name: '@types/eslint-*'
+      - dependency-name: '@darraghor/eslint-plugin-nestjs-typed'
+      - dependency-name: 'typescript-eslint'
+      - dependency-name: '@typescript-eslint/*'
     groups:
       nestjs-dependencies:
         patterns:
@@ -101,6 +110,16 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'sunday'
+    ignore:
+      # ESLint and related tooling are pinned and must be upgraded manually to version 9 and reconfigured.
+      # Once ready for an upgrade, remove these ignores to allow grouped updates via the eslint-dependencies group.
+      - dependency-name: 'eslint'
+      - dependency-name: 'eslint-*'
+      - dependency-name: '@eslint/*'
+      - dependency-name: '@types/eslint-*'
+      - dependency-name: '@darraghor/eslint-plugin-nestjs-typed'
+      - dependency-name: 'typescript-eslint'
+      - dependency-name: '@typescript-eslint/*'
     groups:
       nestjs-dependencies:
         patterns:
@@ -125,6 +144,16 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'sunday'
+    ignore:
+      # ESLint and related tooling are pinned and must be upgraded manually to version 9 and reconfigured.
+      # Once ready for an upgrade, remove these ignores to allow grouped updates via the eslint-dependencies group.
+      - dependency-name: 'eslint'
+      - dependency-name: 'eslint-*'
+      - dependency-name: '@eslint/*'
+      - dependency-name: '@types/eslint-*'
+      - dependency-name: '@darraghor/eslint-plugin-nestjs-typed'
+      - dependency-name: 'typescript-eslint'
+      - dependency-name: '@typescript-eslint/*'
     groups:
       nestjs-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,15 @@ updates:
         patterns:
           - '@aws-sdk/*'
           - 'aws-jwt-verify'
+      eslint-dependencies:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - '@types/eslint-*'
+          - '@darraghor/eslint-plugin-nestjs-typed'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
   - package-ecosystem: 'npm'
     directory: '/nest-clamav-scanner'
     schedule:
@@ -78,6 +87,15 @@ updates:
           - 'prisma'
           - 'prisma-*'
           - '@prisma/*'
+      eslint-dependencies:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - '@types/eslint-*'
+          - '@darraghor/eslint-plugin-nestjs-typed'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
   - package-ecosystem: 'npm'
     directory: '/nest-tax-backend'
     schedule:
@@ -93,6 +111,15 @@ updates:
           - 'prisma'
           - 'prisma-*'
           - '@prisma/*'
+      eslint-dependencies:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - '@types/eslint-*'
+          - '@darraghor/eslint-plugin-nestjs-typed'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
   - package-ecosystem: 'npm'
     directory: '/nest-city-account'
     schedule:
@@ -107,3 +134,12 @@ updates:
           - 'prisma'
           - 'prisma-*'
           - '@prisma/*'
+      eslint-dependencies:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - '@types/eslint-*'
+          - '@darraghor/eslint-plugin-nestjs-typed'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'


### PR DESCRIPTION
Several eslint updates are dependent on each other and failing separately needing manual resolution. If grouped, this should not be problem anymore. Also, there are many and frequent eslint updates cluttering PRs and needing separate reviews and wasting pipeline resources.