### PR TITLE
Mark user accounts as deceased

### DIFF
--- a/nest-city-account/prisma/migrations/20250623100430_create_fields_for_marking_deceased_users/migration.sql
+++ b/nest-city-account/prisma/migrations/20250623100430_create_fields_for_marking_deceased_users/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isDeceased" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "markedDeceasedAt" TIMESTAMP(3);

--- a/nest-city-account/prisma/schema.prisma
+++ b/nest-city-account/prisma/schema.prisma
@@ -40,6 +40,8 @@ model User {
   lastTaxDeliveryMethodsUpdateYear Int?
   cognitoTier                      CognitoUserAttributesTierEnum?
   userIdCardVerify                 UserIdCardVerify[]
+  isDeceased                       Boolean                        @default(false)
+  markedDeceasedAt                 DateTime?
 }
 
 // In this table we store for one month the data used by a user to verify their account by ID card.

--- a/nest-city-account/src/admin/admin.controller.ts
+++ b/nest-city-account/src/admin/admin.controller.ts
@@ -196,7 +196,11 @@ export class AdminController {
   @Post('validated-users-to-physical-entities')
   async validatedUsersToPhysicalEntities() {
     const users = await this.prismaService.user.findMany({
-      where: { birthNumber: { not: null }, physicalEntity: null },
+      where: {
+        birthNumber: { not: null },
+        physicalEntity: null,
+        isDeceased: { not: true },
+      },
       take: 1000,
     })
 

--- a/nest-city-account/src/admin/admin.controller.ts
+++ b/nest-city-account/src/admin/admin.controller.ts
@@ -5,6 +5,7 @@ import {
   HttpCode,
   HttpException,
   Param,
+  Patch,
   Post,
   Query,
   UseGuards,
@@ -27,6 +28,7 @@ import ThrowerErrorGuard from '../utils/guards/errors.guard'
 import { AdminService } from './admin.service'
 import {
   ManuallyVerifyUserRequestDto,
+  MarkDeceasedAccountRequestDto,
   RequestBatchQueryUsersByBirthNumbersDto,
   RequestBodyValidateEdeskForUserIdsDto,
   RequestDeleteTaxDto,
@@ -36,6 +38,7 @@ import {
 import {
   DeactivateAccountResponseDto,
   GetUserDataByBirthNumbersBatchResponseDto,
+  MarkDeceasedAccountResponseDto,
   OnlySuccessDto,
   ResponseUserByBirthNumberDto,
   ResponseValidatePhysicalEntityRfoDto,
@@ -120,6 +123,20 @@ export class AdminController {
     @Param('externalId') externalId: string
   ): Promise<DeactivateAccountResponseDto> {
     const response = await this.adminService.deactivateAccount(externalId)
+    return response
+  }
+
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Mark accounts as deceased',
+    description: 'Deactivates user account in cognito and marks it as deceased.',
+  })
+  @UseGuards(AdminGuard)
+  @Patch('mark-deceased')
+  async markAccountsAsDeceasedByBirthnumber(
+    @Body() data: MarkDeceasedAccountRequestDto
+  ): Promise<MarkDeceasedAccountResponseDto> {
+    const response = await this.adminService.markAccountsAsDeceased(data.birthNumbers)
     return response
   }
 

--- a/nest-city-account/src/admin/admin.controller.ts
+++ b/nest-city-account/src/admin/admin.controller.ts
@@ -23,7 +23,7 @@ import {
 import * as _ from 'lodash'
 import { PhysicalEntityService } from 'src/physical-entity/physical-entity.service'
 import { AdminGuard } from '../auth/guards/admin.guard'
-import { PrismaService } from '../prisma/prisma.service'
+import { ACTIVE_USER_FILTER, PrismaService } from '../prisma/prisma.service'
 import ThrowerErrorGuard from '../utils/guards/errors.guard'
 import { AdminService } from './admin.service'
 import {
@@ -200,7 +200,7 @@ export class AdminController {
       where: {
         birthNumber: { not: null },
         physicalEntity: null,
-        isDeceased: { not: true },
+        ...ACTIVE_USER_FILTER,
       },
       take: 1000,
     })

--- a/nest-city-account/src/admin/admin.controller.ts
+++ b/nest-city-account/src/admin/admin.controller.ts
@@ -129,7 +129,8 @@ export class AdminController {
   @HttpCode(200)
   @ApiOperation({
     summary: 'Mark accounts as deceased',
-    description: 'Deactivates user account in cognito and marks it as deceased.',
+    description:
+      'This endpoint is intended to be used manually when a person is reported as deceased. When called, it deactivates the user account in cognito and marks it as deceased.',
   })
   @UseGuards(AdminGuard)
   @Patch('mark-deceased')

--- a/nest-city-account/src/admin/admin.service.ts
+++ b/nest-city-account/src/admin/admin.service.ts
@@ -55,7 +55,7 @@ export class AdminService {
 
   async getUserDataByBirthNumber(birthNumber: string): Promise<ResponseUserByBirthNumberDto> {
     const user = await this.prismaService.user.findUnique({
-      where: { birthNumber },
+      where: { birthNumber, isDeceased: { not: true } },
     })
     if (!user) {
       throw this.throwerErrorGuard.NotFoundException(
@@ -91,6 +91,7 @@ export class AdminService {
         birthNumber: {
           in: birthNumbers,
         },
+        isDeceased: { not: true },
       },
     })
     const result: Record<string, ResponseUserByBirthNumberDto> = {}
@@ -139,6 +140,7 @@ export class AdminService {
     const user = await this.prismaService.user.findUnique({
       where: {
         email,
+        isDeceased: { not: true },
       },
     })
     if (user !== null) {
@@ -331,6 +333,7 @@ export class AdminService {
     const user = await this.prismaService.user.findUnique({
       where: {
         email,
+        isDeceased: { not: true },
       },
     })
 
@@ -404,6 +407,7 @@ export class AdminService {
       user = await this.prismaService.user.findUnique({
         where: {
           email,
+          isDeceased: { not: true },
         },
       })
     }
@@ -451,6 +455,7 @@ export class AdminService {
       await this.prismaService.user.update({
         where: {
           email,
+          isDeceased: { not: true },
         },
         data: {
           ifo: data.ifo,
@@ -510,6 +515,7 @@ export class AdminService {
         externalId: {
           not: null,
         },
+        isDeceased: { not: true },
       },
     })
 
@@ -571,7 +577,7 @@ export class AdminService {
 
   async deleteTax(data: RequestAdminDeleteTaxDto): Promise<OnlySuccessDto> {
     const user = await this.prismaService.user.findUnique({
-      where: { birthNumber: data.birthNumber },
+      where: { birthNumber: data.birthNumber, isDeceased: { not: true } },
     })
     if (!user) {
       throw this.throwerErrorGuard.NotFoundException(

--- a/nest-city-account/src/admin/admin.service.ts
+++ b/nest-city-account/src/admin/admin.service.ts
@@ -9,7 +9,7 @@ import {
   UpvsIdentityByUriServiceCreateManyParam,
 } from 'src/upvs-identity-by-uri/upvs-identity-by-uri.service'
 import { BloomreachService } from '../bloomreach/bloomreach.service'
-import { PrismaService } from '../prisma/prisma.service'
+import { ACTIVE_USER_FILTER, PrismaService } from '../prisma/prisma.service'
 import {
   VerificationErrorsEnum,
   VerificationErrorsResponseEnum,
@@ -55,7 +55,7 @@ export class AdminService {
 
   async getUserDataByBirthNumber(birthNumber: string): Promise<ResponseUserByBirthNumberDto> {
     const user = await this.prismaService.user.findUnique({
-      where: { birthNumber, isDeceased: { not: true } },
+      where: { birthNumber, ...ACTIVE_USER_FILTER },
     })
     if (!user) {
       throw this.throwerErrorGuard.NotFoundException(
@@ -91,7 +91,7 @@ export class AdminService {
         birthNumber: {
           in: birthNumbers,
         },
-        isDeceased: { not: true },
+        ...ACTIVE_USER_FILTER,
       },
     })
     const result: Record<string, ResponseUserByBirthNumberDto> = {}
@@ -140,7 +140,7 @@ export class AdminService {
     const user = await this.prismaService.user.findUnique({
       where: {
         email,
-        isDeceased: { not: true },
+        ...ACTIVE_USER_FILTER,
       },
     })
     if (user !== null) {
@@ -265,6 +265,7 @@ export class AdminService {
         birthNumber: {
           in: birthNumberList,
         },
+        ...ACTIVE_USER_FILTER,
       },
       data: {
         isDeceased: true,
@@ -333,7 +334,7 @@ export class AdminService {
     const user = await this.prismaService.user.findUnique({
       where: {
         email,
-        isDeceased: { not: true },
+        ...ACTIVE_USER_FILTER,
       },
     })
 
@@ -407,7 +408,7 @@ export class AdminService {
       user = await this.prismaService.user.findUnique({
         where: {
           email,
-          isDeceased: { not: true },
+          ...ACTIVE_USER_FILTER,
         },
       })
     }
@@ -455,7 +456,7 @@ export class AdminService {
       await this.prismaService.user.update({
         where: {
           email,
-          isDeceased: { not: true },
+          ...ACTIVE_USER_FILTER,
         },
         data: {
           ifo: data.ifo,
@@ -515,7 +516,7 @@ export class AdminService {
         externalId: {
           not: null,
         },
-        isDeceased: { not: true },
+        ...ACTIVE_USER_FILTER,
       },
     })
 
@@ -577,7 +578,7 @@ export class AdminService {
 
   async deleteTax(data: RequestAdminDeleteTaxDto): Promise<OnlySuccessDto> {
     const user = await this.prismaService.user.findUnique({
-      where: { birthNumber: data.birthNumber, isDeceased: { not: true } },
+      where: { birthNumber: data.birthNumber, ...ACTIVE_USER_FILTER },
     })
     if (!user) {
       throw this.throwerErrorGuard.NotFoundException(

--- a/nest-city-account/src/admin/dtos/requests.admin.dto.ts
+++ b/nest-city-account/src/admin/dtos/requests.admin.dto.ts
@@ -119,3 +119,15 @@ export class RequestDeleteTaxDto {
   @IsString()
   birthNumber: string
 }
+
+export class MarkDeceasedAccountRequestDto {
+  @ApiProperty({
+    description: 'List of birthnumbers/external IDs to mark as deceased',
+    example: ['1234567890', '2345678901', '3456789012'],
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  birthNumbers: string[]
+}

--- a/nest-city-account/src/admin/dtos/responses.admin.dto.ts
+++ b/nest-city-account/src/admin/dtos/responses.admin.dto.ts
@@ -152,6 +152,46 @@ export class DeactivateAccountResponseDto {
   taxDeliveryMethodsRemoved!: boolean
 }
 
+export class MarkDeceasedAccountResponseItemDto {
+  @ApiProperty({
+    description: 'Birth number of the deceased person',
+    example: '1234567890',
+  })
+  @IsString()
+  birthNumber!: string
+
+  @ApiProperty({
+    description: 'Whether the user was successfully marked as deceased in the database',
+    example: true,
+  })
+  @IsBoolean()
+  databaseMarked!: boolean
+
+  @ApiProperty({
+    description: 'Whether the user was successfully archived in Cognito / mail was changed.',
+    example: true,
+  })
+  @IsBoolean()
+  cognitoArchived!: boolean
+
+  @ApiProperty({
+    description: 'Status of the anonymization of user in Bloomreach',
+    example: AnonymizeResponse.SUCCESS,
+    enum: AnonymizeResponse,
+  })
+  @IsEnum(AnonymizeResponse)
+  bloomreachRemoved?: AnonymizeResponse
+}
+
+export class MarkDeceasedAccountResponseDto {
+  @ApiProperty({
+    description: 'List of birth numbers with success marked for each data storage.',
+    type: [MarkDeceasedAccountResponseItemDto],
+  })
+  @IsObject({ each: true })
+  results!: MarkDeceasedAccountResponseItemDto[]
+}
+
 export class VerificationDataForUser {
   @ApiProperty({
     description: 'Id of the user in cognito.',

--- a/nest-city-account/src/prisma/prisma.service.ts
+++ b/nest-city-account/src/prisma/prisma.service.ts
@@ -3,6 +3,8 @@ import { PrismaClient, Prisma } from '@prisma/client'
 import { LineLoggerSubservice } from '../utils/subservices/line-logger.subservice'
 import { escapeForLogfmt } from '../utils/logging'
 
+export const ACTIVE_USER_FILTER = { isDeceased: false }
+
 @Injectable()
 export class PrismaService
   extends PrismaClient<Prisma.PrismaClientOptions, 'info' | 'warn' | 'error'>

--- a/nest-city-account/src/user-verification/utils/subservice/database.subservice.ts
+++ b/nest-city-account/src/user-verification/utils/subservice/database.subservice.ts
@@ -24,12 +24,14 @@ export class DatabaseSubserviceUser {
       user = await this.prisma.user.findUnique({
         where: {
           email,
+          isDeceased: { not: true },
         },
       })
       if (!user) {
         user = await this.prisma.user.findUnique({
           where: {
             externalId,
+            isDeceased: { not: true },
           },
         })
       }
@@ -91,6 +93,7 @@ export class DatabaseSubserviceUser {
           await this.prisma.user.update({
             where: {
               id: user.id,
+              isDeceased: { not: true },
             },
             data: {
               lastVerificationIdentityCard: new Date(),
@@ -122,6 +125,7 @@ export class DatabaseSubserviceUser {
           await this.prisma.user.update({
             where: {
               id: user.id,
+              isDeceased: { not: true },
             },
             data: {
               ifo,
@@ -262,6 +266,7 @@ export class DatabaseSubserviceUser {
         return await this.prisma.user.update({
           where: {
             id: user.id,
+            isDeceased: { not: true },
           },
           data: {
             requeuedInVerification: {
@@ -295,6 +300,7 @@ export class DatabaseSubserviceUser {
         return await this.prisma.user.update({
           where: {
             id: user.id,
+            isDeceased: { not: true },
           },
           data: {
             requeuedInVerification: 0,

--- a/nest-city-account/src/user-verification/utils/subservice/database.subservice.ts
+++ b/nest-city-account/src/user-verification/utils/subservice/database.subservice.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common'
 
 import { LegalPerson, User } from '@prisma/client'
-import { PrismaService } from '../../../prisma/prisma.service'
+import { ACTIVE_USER_FILTER, PrismaService } from '../../../prisma/prisma.service'
 import { CognitoGetUserData } from '../../../utils/global-dtos/cognito.dto'
 import ThrowerErrorGuard, { ErrorMessengerGuard } from '../../../utils/guards/errors.guard'
 import { ResponseVerificationIdentityCardDto } from '../../dtos/requests.verification.dto'
@@ -24,14 +24,14 @@ export class DatabaseSubserviceUser {
       user = await this.prisma.user.findUnique({
         where: {
           email,
-          isDeceased: { not: true },
+          ...ACTIVE_USER_FILTER,
         },
       })
       if (!user) {
         user = await this.prisma.user.findUnique({
           where: {
             externalId,
-            isDeceased: { not: true },
+            ...ACTIVE_USER_FILTER,
           },
         })
       }
@@ -93,7 +93,7 @@ export class DatabaseSubserviceUser {
           await this.prisma.user.update({
             where: {
               id: user.id,
-              isDeceased: { not: true },
+              ...ACTIVE_USER_FILTER,
             },
             data: {
               lastVerificationIdentityCard: new Date(),
@@ -125,7 +125,7 @@ export class DatabaseSubserviceUser {
           await this.prisma.user.update({
             where: {
               id: user.id,
-              isDeceased: { not: true },
+              ...ACTIVE_USER_FILTER,
             },
             data: {
               ifo,
@@ -266,7 +266,7 @@ export class DatabaseSubserviceUser {
         return await this.prisma.user.update({
           where: {
             id: user.id,
-            isDeceased: { not: true },
+            ...ACTIVE_USER_FILTER,
           },
           data: {
             requeuedInVerification: {
@@ -300,7 +300,7 @@ export class DatabaseSubserviceUser {
         return await this.prisma.user.update({
           where: {
             id: user.id,
-            isDeceased: { not: true },
+            ...ACTIVE_USER_FILTER,
           },
           data: {
             requeuedInVerification: 0,

--- a/nest-city-account/src/user/utils/subservice/database.subservice.ts
+++ b/nest-city-account/src/user/utils/subservice/database.subservice.ts
@@ -32,6 +32,7 @@ export class DatabaseSubserviceUser {
       user = await this.prisma.user.update({
         where: {
           email: email,
+          isDeceased: { not: true },
         },
         data: {
           externalId: externalId,
@@ -183,17 +184,24 @@ export class DatabaseSubserviceUser {
   }
 
   async getUserById(id: string) {
-    const user = await this.prisma.user.findUnique({ where: { id: id } })
+    const user = await this.prisma.user.findUnique({
+      where: {
+        id,
+        isDeceased: { not: true },
+      },
+    })
     return user
   }
 
   async getUserByExternalId(externalId: string) {
-    const user = await this.prisma.user.findUnique({ where: { externalId } })
+    const user = await this.prisma.user.findUnique({
+      where: { externalId, isDeceased: { not: true } },
+    })
     return user
   }
 
   async getLegalPersonById(id: string) {
-    const legalPerson = await this.prisma.legalPerson.findUnique({ where: { id: id } })
+    const legalPerson = await this.prisma.legalPerson.findUnique({ where: { id } })
     return legalPerson
   }
 

--- a/nest-city-account/src/user/utils/subservice/database.subservice.ts
+++ b/nest-city-account/src/user/utils/subservice/database.subservice.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
 
-import { PrismaService } from '../../../prisma/prisma.service'
+import { ACTIVE_USER_FILTER, PrismaService } from '../../../prisma/prisma.service'
 import { prismaExclude } from '../../../utils/handlers/prisma.handlers'
 import {
   ResponseGdprLegalPersonDataDto,
@@ -32,7 +32,7 @@ export class DatabaseSubserviceUser {
       user = await this.prisma.user.update({
         where: {
           email: email,
-          isDeceased: { not: true },
+          ...ACTIVE_USER_FILTER,
         },
         data: {
           externalId: externalId,
@@ -187,7 +187,7 @@ export class DatabaseSubserviceUser {
     const user = await this.prisma.user.findUnique({
       where: {
         id,
-        isDeceased: { not: true },
+        ...ACTIVE_USER_FILTER,
       },
     })
     return user
@@ -195,7 +195,7 @@ export class DatabaseSubserviceUser {
 
   async getUserByExternalId(externalId: string) {
     const user = await this.prisma.user.findUnique({
-      where: { externalId, isDeceased: { not: true } },
+      where: { externalId, ...ACTIVE_USER_FILTER },
     })
     return user
   }

--- a/nest-city-account/src/utils/subservices/cognito.subservice.ts
+++ b/nest-city-account/src/utils/subservices/cognito.subservice.ts
@@ -138,6 +138,7 @@ export class CognitoSubservice {
       const user = await this.prisma.user.findUnique({
         where: {
           externalId: userId,
+          isDeceased: { not: true },
         },
       })
       if (!user) {

--- a/nest-city-account/src/utils/subservices/cognito.subservice.ts
+++ b/nest-city-account/src/utils/subservices/cognito.subservice.ts
@@ -3,7 +3,7 @@ import AWS from 'aws-sdk'
 
 import { CognitoUserAttributesTierEnum } from '@prisma/client'
 import { fromPairs } from 'lodash'
-import { PrismaService } from '../../prisma/prisma.service'
+import { ACTIVE_USER_FILTER, PrismaService } from '../../prisma/prisma.service'
 import {
   CognitoGetUserAttributesData,
   CognitoGetUserData,
@@ -138,7 +138,7 @@ export class CognitoSubservice {
       const user = await this.prisma.user.findUnique({
         where: {
           externalId: userId,
-          isDeceased: { not: true },
+          ...ACTIVE_USER_FILTER,
         },
       })
       if (!user) {

--- a/nest-city-account/src/utils/subservices/tasks.subservice.ts
+++ b/nest-city-account/src/utils/subservices/tasks.subservice.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { RequestUpdateNorisDeliveryMethodsDtoDataValue } from '../../generated-clients/nest-tax-backend'
-import { PrismaService } from '../../prisma/prisma.service'
+import { ACTIVE_USER_FILTER, PrismaService } from '../../prisma/prisma.service'
 import { GdprCategory, GdprSubType, GdprType } from '../../user/dtos/gdpr.user.dto'
 import { addSlashToBirthNumber } from '../birthNumbers'
 import { getTaxDeadlineDate } from '../constants/tax-deadline'
@@ -65,7 +65,7 @@ export class TasksSubservice {
           not: null,
         },
         OR: [{ lastTaxYear: null }, { lastTaxYear: { not: year } }],
-        isDeceased: { not: true },
+        ...ACTIVE_USER_FILTER,
       },
       orderBy: {
         lastTaxBackendUploadTry: 'asc',
@@ -98,7 +98,7 @@ export class TasksSubservice {
         birthNumber: {
           in: addedBirthNumbers,
         },
-        isDeceased: { not: true },
+        ...ACTIVE_USER_FILTER,
       },
       data: {
         lastTaxYear: year,
@@ -143,7 +143,7 @@ export class TasksSubservice {
           not: null,
           lt: taxDeadlineDate,
         },
-        isDeceased: { not: true },
+        ...ACTIVE_USER_FILTER,
       },
       include: {
         userGdprData: {

--- a/nest-city-account/src/utils/subservices/tasks.subservice.ts
+++ b/nest-city-account/src/utils/subservices/tasks.subservice.ts
@@ -65,6 +65,7 @@ export class TasksSubservice {
           not: null,
         },
         OR: [{ lastTaxYear: null }, { lastTaxYear: { not: year } }],
+        isDeceased: { not: true },
       },
       orderBy: {
         lastTaxBackendUploadTry: 'asc',
@@ -97,6 +98,7 @@ export class TasksSubservice {
         birthNumber: {
           in: addedBirthNumbers,
         },
+        isDeceased: { not: true },
       },
       data: {
         lastTaxYear: year,
@@ -141,6 +143,7 @@ export class TasksSubservice {
           not: null,
           lt: taxDeadlineDate,
         },
+        isDeceased: { not: true },
       },
       include: {
         userGdprData: {


### PR DESCRIPTION
### Description

This pull request introduces functionality to handle marking user accounts as deceased. The updates include:

- Addition of a method to mark user accounts as deceased.
- Implementation of an API endpoint for marking accounts as deceased.
- Updates to the Prisma schema to include fields for indicating deceased status.