### PR TITLE
Adjust ginis service processing

### DIFF
--- a/nest-forms-backend/src/ginis/ginis.service.spec.ts
+++ b/nest-forms-backend/src/ginis/ginis.service.spec.ts
@@ -189,7 +189,7 @@ describe('GinisService', () => {
 
       expect(registerSpy).not.toHaveBeenCalled()
       expect(result.requeue).toBeTruthy()
-      jest.resetAllMocks()
+      jest.clearAllMocks()
 
       // should try to register and requeue if it couldn't find the document
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
@@ -203,7 +203,7 @@ describe('GinisService', () => {
       result = await service.onQueueConsumption(messageBase)
       expect(registerSpy).toHaveBeenCalled()
       expect(result.requeue).toBeTruthy()
-      jest.resetAllMocks()
+      jest.clearAllMocks()
 
       // should only change state if there was error to allow register again
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
@@ -255,7 +255,7 @@ describe('GinisService', () => {
       let result = await service.onQueueConsumption(messageBase)
       expect(result.requeue).toBeTruthy()
       expect(uploadSpy).toHaveBeenCalled()
-      jest.resetAllMocks()
+      jest.clearAllMocks()
 
       // When one error - requeue, do not upload, report error
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
@@ -280,7 +280,7 @@ describe('GinisService', () => {
       result = await service.onQueueConsumption(messageBase)
       expect(result.requeue).toBeTruthy()
       expect(uploadSpy).not.toHaveBeenCalled()
-      jest.resetAllMocks()
+      jest.clearAllMocks()
 
       // When all errors - requeue, do not upload, report error (TODO update behavior)
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
@@ -305,7 +305,7 @@ describe('GinisService', () => {
       result = await service.onQueueConsumption(messageBase)
       expect(result.requeue).toBeTruthy()
       expect(uploadSpy).not.toHaveBeenCalled()
-      jest.resetAllMocks()
+      jest.clearAllMocks()
 
       // When no more files, change to Attachments uploaded
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
@@ -353,7 +353,6 @@ describe('GinisService', () => {
       result = await service.onQueueConsumption(messageBase)
       expect(result.requeue).toBeTruthy()
       expect(uploadSpy).not.toHaveBeenCalled()
-      jest.resetAllMocks()
     })
 
     it('should mark as files uploaded if there are no files', async () => {
@@ -476,7 +475,7 @@ describe('GinisService', () => {
       expect(sendMailSpy).not.toHaveBeenCalled()
       expect(sendToSharepointSpy).not.toHaveBeenCalled()
 
-      jest.resetAllMocks()
+      jest.clearAllMocks()
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
         type: FormDefinitionType.SlovenskoSkGeneric,
         pospID: 'pospIdValue',
@@ -543,7 +542,7 @@ describe('GinisService', () => {
       expect(sendMailSpy).not.toHaveBeenCalled()
       expect(sendToSharepointSpy).toHaveBeenCalled()
 
-      jest.resetAllMocks()
+      jest.clearAllMocks()
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
         type: FormDefinitionType.SlovenskoSkGeneric,
         pospID: 'pospIdValue',

--- a/nest-forms-backend/src/ginis/ginis.service.spec.ts
+++ b/nest-forms-backend/src/ginis/ginis.service.spec.ts
@@ -253,8 +253,8 @@ describe('GinisService', () => {
 
       // When upload for first time - just upload
       let result = await service.onQueueConsumption(messageBase)
-      expect(result.requeue).toBeTruthy()
       expect(uploadSpy).toHaveBeenCalled()
+      expect(result.requeue).toBeTruthy()
       jest.clearAllMocks()
 
       // When one error - requeue, do not upload, report error
@@ -278,8 +278,8 @@ describe('GinisService', () => {
         ],
       } as FormWithFiles)
       result = await service.onQueueConsumption(messageBase)
-      expect(result.requeue).toBeTruthy()
       expect(uploadSpy).not.toHaveBeenCalled()
+      expect(result.requeue).toBeTruthy()
       jest.clearAllMocks()
 
       // When all errors - requeue, do not upload, report error (TODO update behavior)
@@ -303,8 +303,8 @@ describe('GinisService', () => {
         ],
       } as FormWithFiles)
       result = await service.onQueueConsumption(messageBase)
-      expect(result.requeue).toBeTruthy()
       expect(uploadSpy).not.toHaveBeenCalled()
+      expect(result.requeue).toBeTruthy()
       jest.clearAllMocks()
 
       // When no more files, change to Attachments uploaded
@@ -319,8 +319,6 @@ describe('GinisService', () => {
         files: [],
       } as FormWithFiles)
       result = await service.onQueueConsumption(messageBase)
-      expect(result.requeue).toBeTruthy()
-      expect(uploadSpy).not.toHaveBeenCalled()
       expect(prismaMock.forms['update']).toHaveBeenCalledWith(
         expect.objectContaining({
           data: {
@@ -329,6 +327,8 @@ describe('GinisService', () => {
           },
         }),
       )
+      expect(uploadSpy).not.toHaveBeenCalled()
+      expect(result.requeue).toBeTruthy()
 
       // When missing ginisDocumentId, skip upload
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
@@ -351,8 +351,8 @@ describe('GinisService', () => {
       } as FormWithFiles)
 
       result = await service.onQueueConsumption(messageBase)
-      expect(result.requeue).toBeTruthy()
       expect(uploadSpy).not.toHaveBeenCalled()
+      expect(result.requeue).toBeTruthy()
     })
 
     it('should mark as files uploaded if there are no files', async () => {

--- a/nest-forms-backend/src/ginis/ginis.service.spec.ts
+++ b/nest-forms-backend/src/ginis/ginis.service.spec.ts
@@ -416,7 +416,7 @@ describe('GinisService', () => {
       expect(result.requeue).toBeTruthy()
       expect(assignSpy).toHaveBeenCalledWith('docId', 'nodeId', 'functionId')
 
-      // The same should happen if the state is ERROR_ASSIGN_SUBMISSION
+      // If ERROR_ASSIGN_SUBMISSION, skip upload, manual intervention required
 
       // missing ginisDocumentId
       prismaMock.forms.findUnique.mockResolvedValue({
@@ -437,7 +437,7 @@ describe('GinisService', () => {
       } as FormWithFiles)
       result = await service.onQueueConsumption(messageBase)
       expect(result.requeue).toBeTruthy()
-      expect(assignSpy).toHaveBeenCalledWith('docId', 'nodeId', 'functionId')
+      expect(assignSpy).not.toHaveBeenCalled()
     })
 
     it('should mark as ready for processing if there is no sharepoint', async () => {

--- a/nest-forms-backend/src/ginis/ginis.service.spec.ts
+++ b/nest-forms-backend/src/ginis/ginis.service.spec.ts
@@ -257,7 +257,7 @@ describe('GinisService', () => {
       expect(result.requeue).toBeTruthy()
       jest.clearAllMocks()
 
-      // When one error - requeue, do not upload, report error
+      // When one error - requeue, upload, report error
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
         type: FormDefinitionType.SlovenskoSkGeneric,
         pospID: 'pospIdValue',
@@ -278,11 +278,11 @@ describe('GinisService', () => {
         ],
       } as FormWithFiles)
       result = await service.onQueueConsumption(messageBase)
-      expect(uploadSpy).not.toHaveBeenCalled()
+      expect(uploadSpy).toHaveBeenCalled()
       expect(result.requeue).toBeTruthy()
       jest.clearAllMocks()
 
-      // When all errors - requeue, do not upload, report error (TODO update behavior)
+      // When all errors - requeue, upload, report error
       ;(getFormDefinitionBySlug as jest.Mock).mockReturnValue({
         type: FormDefinitionType.SlovenskoSkGeneric,
         pospID: 'pospIdValue',
@@ -303,7 +303,7 @@ describe('GinisService', () => {
         ],
       } as FormWithFiles)
       result = await service.onQueueConsumption(messageBase)
-      expect(uploadSpy).not.toHaveBeenCalled()
+      expect(uploadSpy).toHaveBeenCalled()
       expect(result.requeue).toBeTruthy()
       jest.clearAllMocks()
 

--- a/nest-forms-backend/src/ginis/ginis.service.ts
+++ b/nest-forms-backend/src/ginis/ginis.service.ts
@@ -388,10 +388,7 @@ export default class GinisService {
     }
 
     // Assign submission
-    if (
-      form.ginisState === GinisState.ATTACHMENTS_UPLOADED ||
-      form.ginisState === GinisState.ERROR_ASSIGN_SUBMISSION
-    ) {
+    if (form.ginisState === GinisState.ATTACHMENTS_UPLOADED) {
       if (!form.ginisDocumentId) {
         alertError(
           `ERROR assignSubmission - ginisDocumentId does not exists in form - Ginis consumption queue. Form id: ${form.id}`,
@@ -405,6 +402,13 @@ export default class GinisService {
         formDefinition.ginisAssignment.ginisFunctionId,
       )
       return this.nackTrueWithWait(20_000)
+    }
+
+    if (form.ginisState === GinisState.ERROR_ASSIGN_SUBMISSION) {
+      this.logger.error(
+        '---- ERROR assigning submission (manual intervention required) ----',
+      )
+      return this.nackTrueWithWait(600_000)
     }
 
     // Send externally

--- a/nest-forms-backend/src/ginis/ginis.service.ts
+++ b/nest-forms-backend/src/ginis/ginis.service.ts
@@ -316,7 +316,6 @@ export default class GinisService {
       )
     }
 
-    const filesWithError = form.files.filter((file) => file.ginisUploadedError)
     const filesToUpload = form.files.filter((file) => !file.ginisUploaded)
 
     // Registration
@@ -348,7 +347,11 @@ export default class GinisService {
     }
 
     // Attachments upload
-    if (form.ginisState === GinisState.REGISTERED && filesToUpload.length > 0) {
+    if (
+      (form.ginisState === GinisState.REGISTERED ||
+        form.ginisState === GinisState.RUNNING_UPLOAD_ATTACHMENTS) &&
+      filesToUpload.length > 0
+    ) {
       if (!form.ginisDocumentId) {
         alertError(
           `ERROR uploadAttachments - ginisDocumentId does not exists in form - Ginis consumption queue. Form id: ${form.id}`,
@@ -356,18 +359,8 @@ export default class GinisService {
         )
         return this.nackTrueWithWait(20_000)
       }
-      this.logger.debug('---- start to upload attachments ----')
+      this.logger.debug('---- uploading attachments ----')
       await this.uploadAttachments(form, formDefinition.pospID)
-      return this.nackTrueWithWait(20_000)
-    }
-
-    if (
-      form.ginisState === GinisState.ERROR_ATTACHMENT_UPLOAD ||
-      filesWithError.length > 0
-    ) {
-      this.logger.error(
-        '---- ERROR uploading attachments (manual intervention required) ----',
-      )
       return this.nackTrueWithWait(20_000)
     }
 


### PR DESCRIPTION
After several weeks of observing ginis errors using the new ginis API approach to form processing (that replaced previous ginis automation approach), two changes are in order:

1. failure of attachment upload shall be retried indefinitely
   - new API allows file upload even if the owner of the ginis document changes and it no longer belongs to us
   - errors experienced were (with one exception) always cleared after simply retrying the same flow with no changes
   - the one exception was a file with `|` in the name, that has been mitigated since then on the minio side
2. failure of submission assignment shall not be retried
   - occurs when submission is already assigned to someone else manually (i.e. the owner of the document changes and it no longer belongs to us)
   - this is the last step on the ginis side, and if it fails because the owner is already assigned, there is nothing to do in ginis anyway (as this is only supposed to assign the new owner)
   - there might be further steps after this outside of ginis, so the logging for manual intervention will be in place and the form will be kept in the queue, but no more alerting every 20s for this situation is needed, as it is not very time sensitive and only requires some attention eventually