### PR TITLE
Add missing region

### DIFF
--- a/strapi/config/env/production/plugins.ts
+++ b/strapi/config/env/production/plugins.ts
@@ -13,6 +13,8 @@ export default ({ env }) => ({
             accessKeyId: env('MINIO_ACCESS_KEY'),
             secretAccessKey: env('MINIO_SECRET_KEY'),
           },
+          // https://github.com/strapi/strapi/issues/19299#issuecomment-2885165824
+          region: env('MINIO_AUTO_REGION'),
           endpoint: env('MINIO_PRIVATE_ENDPOINT'),
           params: {
             Bucket: env('MINIO_BUCKET'),

--- a/strapi/kubernetes/base/.env
+++ b/strapi/kubernetes/base/.env
@@ -3,6 +3,7 @@ PORT=1337
 MINIO_BUCKET=city-account-strapi
 MINIO_PRIVATE_ENDPOINT=https://s3.bratislava.sk
 MINIO_PUBLIC_ENDPOINT=https://city-account-strapi.s3.bratislava.sk
+MINIO_AUTO_REGION=auto
 
 DATABASE_CLIENT=postgres
 DATABASE_HOST=city-account-strapi-database


### PR DESCRIPTION
```
2025-07-02 13:03:48.332 | at async /home/node/app/node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:34:22 |  
-- | -- | --
  |   | 2025-07-02 13:03:48.332 | at async /home/node/app/node_modules/@aws-sdk/middleware-sdk-s3/dist-cjs/index.js:121:14 |  
  |   | 2025-07-02 13:03:48.332 | at async /home/node/app/node_modules/@aws-sdk/middleware-sdk-s3/dist-cjs/index.js:90:28 |  
  |   | 2025-07-02 13:03:48.332 | at async region (/home/node/app/node_modules/@smithy/config-resolver/dist-cjs/index.js:142:30) |  
  |   | 2025-07-02 13:03:48.332 | at async /home/node/app/node_modules/@smithy/property-provider/dist-cjs/index.js:135:20 |  
  |   | 2025-07-02 13:03:48.332 | at async coalesceProvider (/home/node/app/node_modules/@smithy/property-provider/dist-cjs/index.js:124:18) |  
  |   | 2025-07-02 13:03:48.332 | at process.processTicksAndRejections (node:internal/process/task_queues:95:5) |  
  |   | 2025-07-02 13:03:48.332 | at /home/node/app/node_modules/@smithy/property-provider/dist-cjs/index.js:97:33 |  
  |   | 2025-07-02 13:03:48.332 | at /home/node/app/node_modules/@smithy/node-config-provider/dist-cjs/index.js:90:104 |  
  |   | 2025-07-02 13:03:48.332 | at default (/home/node/app/node_modules/@smithy/config-resolver/dist-cjs/index.js:117:11) |  
  |   | 2025-07-02 13:03:48.332 | Error: Region is missing |  
  |   | 2025-07-02 13:03:48.332 | [2025-07-02 11:03:48.332] error: Region is missing
```

Soluton: https://github.com/strapi/strapi/issues/19299#issuecomment-2885165824
