### PR TITLE
885 - Save tax employee info for each tax payer from Noris

### DIFF
--- a/nest-tax-backend/prisma/migrations/20250702110129_move_tax_employee_to_tax_payer/migration.sql
+++ b/nest-tax-backend/prisma/migrations/20250702110129_move_tax_employee_to_tax_payer/migration.sql
@@ -1,0 +1,25 @@
+-- DropForeignKey
+ALTER TABLE "Tax" DROP CONSTRAINT "Tax_taxEmployeeId_fkey";
+
+-- AlterTable
+ALTER TABLE "TaxPayer" ADD COLUMN "taxEmployeeId" INTEGER;
+
+-- Update TaxPayer.taxEmployeeId with the taxEmployeeId from the latest Tax
+WITH LatestTaxes AS (
+  SELECT DISTINCT ON ("taxPayerId") 
+    "taxPayerId",
+    "taxEmployeeId"
+  FROM "Tax"
+  WHERE "taxEmployeeId" IS NOT NULL
+  ORDER BY "taxPayerId", "createdAt" DESC
+)
+UPDATE "TaxPayer"
+SET "taxEmployeeId" = LatestTaxes."taxEmployeeId"
+FROM LatestTaxes
+WHERE "TaxPayer".id = LatestTaxes."taxPayerId";
+
+-- AlterTable
+ALTER TABLE "Tax" DROP COLUMN "taxEmployeeId";
+
+-- AddForeignKey
+ALTER TABLE "TaxPayer" ADD CONSTRAINT "TaxPayer_taxEmployeeId_fkey" FOREIGN KEY ("taxEmployeeId") REFERENCES "TaxEmployee"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/nest-tax-backend/prisma/migrations/20250702141655_rename_tax_employee_to_tax_administrator/migration.sql
+++ b/nest-tax-backend/prisma/migrations/20250702141655_rename_tax_employee_to_tax_administrator/migration.sql
@@ -1,0 +1,14 @@
+-- Rename table
+ALTER TABLE "TaxEmployee" RENAME TO "TaxAdministrator";
+
+-- Drop the existing foreign key constraint
+ALTER TABLE "TaxPayer" DROP CONSTRAINT "TaxPayer_taxEmployeeId_fkey";
+
+-- Rename column
+ALTER TABLE "TaxPayer" RENAME COLUMN "taxEmployeeId" TO "taxAdministratorId";
+
+-- Add the foreign key constraint with the new name
+ALTER TABLE "TaxPayer" ADD CONSTRAINT "TaxPayer_taxAdministratorId_fkey" FOREIGN KEY ("taxAdministratorId") REFERENCES "TaxAdministrator"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Rename the primary key constraint
+ALTER TABLE "TaxAdministrator" RENAME CONSTRAINT "TaxEmployee_pkey" TO "TaxAdministrator_pkey";

--- a/nest-tax-backend/prisma/schema.prisma
+++ b/nest-tax-backend/prisma/schema.prisma
@@ -12,10 +12,10 @@ datasource db {
 }
 
 model TaxPayer {
-  id                          Int         @id @default(autoincrement())
-  uuid                        String      @default(uuid()) @db.Uuid
-  createdAt                   DateTime    @default(now())
-  updatedAt                   DateTime    @default(now()) @updatedAt
+  id                          Int               @id @default(autoincrement())
+  uuid                        String            @default(uuid()) @db.Uuid
+  createdAt                   DateTime          @default(now())
+  updatedAt                   DateTime          @default(now()) @updatedAt
   active                      Boolean // if it is active tax payer or is only past tax pay
   birthNumber                 String // with slash
   taxAdministratorId          Int?

--- a/nest-tax-backend/prisma/schema.prisma
+++ b/nest-tax-backend/prisma/schema.prisma
@@ -18,8 +18,8 @@ model TaxPayer {
   updatedAt                   DateTime    @default(now()) @updatedAt
   active                      Boolean // if it is active tax payer or is only past tax pay
   birthNumber                 String // with slash
-  taxEmployeeId               Int?
-  taxEmployee                 TaxEmployee? @relation(fields: [taxEmployeeId], references: [id])
+  taxAdministratorId          Int?
+  taxAdministrator            TaxAdministrator? @relation(fields: [taxAdministratorId], references: [id])
   permanentResidenceAddress   String?
   externalId                  String?
   name                        String?
@@ -106,7 +106,7 @@ model TaxDetail {
   amount    Int
 }
 
-model TaxEmployee {
+model TaxAdministrator {
   id          Int        @id @default(autoincrement())
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @default(now()) @updatedAt

--- a/nest-tax-backend/prisma/schema.prisma
+++ b/nest-tax-backend/prisma/schema.prisma
@@ -12,12 +12,14 @@ datasource db {
 }
 
 model TaxPayer {
-  id                          Int      @id @default(autoincrement())
-  uuid                        String   @default(uuid()) @db.Uuid
-  createdAt                   DateTime @default(now())
-  updatedAt                   DateTime @default(now()) @updatedAt
+  id                          Int         @id @default(autoincrement())
+  uuid                        String      @default(uuid()) @db.Uuid
+  createdAt                   DateTime    @default(now())
+  updatedAt                   DateTime    @default(now()) @updatedAt
   active                      Boolean // if it is active tax payer or is only past tax pay
   birthNumber                 String // with slash
+  taxEmployeeId               Int?
+  taxEmployee                 TaxEmployee? @relation(fields: [taxEmployeeId], references: [id])
   permanentResidenceAddress   String?
   externalId                  String?
   name                        String?
@@ -43,7 +45,6 @@ model Tax {
   taxPayer                        TaxPayer             @relation(fields: [taxPayerId], references: [id])
   amount                          Int
   variableSymbol                  String
-  taxEmployeeId                   Int
   qrCodeWeb                       String?
   qrCodeEmail                     String?
   taxId                           String?
@@ -55,7 +56,6 @@ model Tax {
   taxPayments                     TaxPayment[]
   taxInstallments                 TaxInstallment[]
   taxDetails                      TaxDetail[]
-  taxEmployees                    TaxEmployee          @relation(fields: [taxEmployeeId], references: [id])
   lastCheckedPayments             DateTime             @default(now())
   lastCheckedUpdates              DateTime             @default(now())
   deliveryMethod                  DeliveryMethodNamed?
@@ -107,14 +107,14 @@ model TaxDetail {
 }
 
 model TaxEmployee {
-  id          Int      @id @default(autoincrement())
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @default(now()) @updatedAt
-  tax         Tax[]
+  id          Int        @id @default(autoincrement())
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @default(now()) @updatedAt
   externalId  String
   name        String
   phoneNumber String
   email       String
+  TaxPayer    TaxPayer[]
 }
 
 model CsvFile {

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -60,22 +60,22 @@ export class AdminService {
     year: number,
   ) {
     const userData = await this.prismaService.$transaction(async (tx) => {
-      const taxPayerData = mapNorisToTaxPayerData(dataFromNoris)
-      const taxPayer = await tx.taxPayer.upsert({
-        where: {
-          birthNumber: dataFromNoris.ICO_RC,
-        },
-        create: taxPayerData,
-        update: taxPayerData,
-      })
-
       const taxEmployeeData = mapNorisToTaxEmployeeData(dataFromNoris)
       const taxEmployee = await tx.taxEmployee.upsert({
         where: {
           id: dataFromNoris.vyb_id,
         },
         create: taxEmployeeData,
-        update: {},
+        update: taxEmployeeData,
+      })
+
+      const taxPayerData = mapNorisToTaxPayerData(dataFromNoris, taxEmployee)
+      const taxPayer = await tx.taxPayer.upsert({
+        where: {
+          birthNumber: dataFromNoris.ICO_RC,
+        },
+        create: taxPayerData,
+        update: taxPayerData,
       })
 
       const [qrCodeEmail, qrCodeWeb] = await Promise.all([
@@ -97,7 +97,6 @@ export class AdminService {
         dataFromNoris,
         year,
         taxPayer.id,
-        taxEmployee.id,
         qrCodeEmail,
         qrCodeWeb,
       )

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -66,7 +66,7 @@ export class AdminService {
           id: dataFromNoris.vyb_id,
         },
         create: taxEmployeeData,
-        update: taxEmployeeData,
+        update: {},
       })
 
       const taxPayerData = mapNorisToTaxPayerData(dataFromNoris, taxEmployee)

--- a/nest-tax-backend/src/admin/utils/__tests__/admin.helper.spec.ts
+++ b/nest-tax-backend/src/admin/utils/__tests__/admin.helper.spec.ts
@@ -1,0 +1,227 @@
+import { TaxAdministrator } from '@prisma/client'
+
+import { NorisTaxPayersDto } from '../../../noris/noris.dto'
+import {
+  convertCurrencyToInt,
+  mapNorisToTaxAdministratorData,
+  mapNorisToTaxData,
+  mapNorisToTaxInstallmentsData,
+  mapNorisToTaxPayerData,
+} from '../admin.helper'
+
+describe('admin.helper', () => {
+  describe('convertCurrencyToInt', () => {
+    it('should convert string currency with comma to integer', () => {
+      expect(convertCurrencyToInt('123,45')).toBe(12_345)
+    })
+
+    it('should convert string currency with dot to integer', () => {
+      expect(convertCurrencyToInt('123.45')).toBe(12_345)
+    })
+
+    it('should convert string currency without decimals to integer', () => {
+      expect(convertCurrencyToInt('123')).toBe(12_300)
+    })
+
+    it('should handle zero value', () => {
+      expect(convertCurrencyToInt('0')).toBe(0)
+    })
+
+    it('should handle empty string', () => {
+      expect(convertCurrencyToInt('')).toBe(0)
+    })
+  })
+
+  describe('mapNorisToTaxPayerData', () => {
+    const mockNorisData: NorisTaxPayersDto = {
+      ICO_RC: '1234567890',
+      adresa_tp_sidlo: 'Test Address',
+      subjekt_refer: 'EXT123',
+      subjekt_nazev: 'Test Subject',
+      ulica_tb_cislo: 'Test Street 1',
+      psc_ref_tb: '12345',
+      TXT_UL: 'Test Street Text',
+      obec_nazev_tb: 'Test City',
+      TXT_MENO: 'Test Name',
+    } as NorisTaxPayersDto
+
+    const mockTaxAdministrator: TaxAdministrator = {
+      id: 1,
+      name: 'Test Admin',
+      email: 'admin@test.com',
+      phoneNumber: '123456789',
+      externalId: 'ADM123',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+
+    it('should map Noris data to TaxPayer data correctly', () => {
+      const result = mapNorisToTaxPayerData(mockNorisData, mockTaxAdministrator)
+
+      expect(result).toEqual({
+        active: true,
+        birthNumber: '1234567890',
+        permanentResidenceAddress: 'Test Address',
+        externalId: 'EXT123',
+        name: 'Test Subject',
+        permanentResidenceStreet: 'Test Street 1',
+        permanentResidenceZip: '12345',
+        permanentResidenceStreetTxt: 'Test Street Text',
+        permanentResidenceCity: 'Test City',
+        nameTxt: 'Test Name',
+        taxAdministratorId: 1,
+      })
+    })
+  })
+
+  describe('mapNorisToTaxAdministratorData', () => {
+    const mockNorisData: NorisTaxPayersDto = {
+      vyb_email: 'admin@test.com',
+      cislo_poradace: 123,
+      vyb_id: 456,
+      vyb_nazov: 'Test Admin',
+      vyb_telefon_prace: '123456789',
+    } as NorisTaxPayersDto
+
+    it('should map Noris data to TaxAdministrator data correctly', () => {
+      const result = mapNorisToTaxAdministratorData(mockNorisData)
+
+      expect(result).toEqual({
+        email: 'admin@test.com',
+        externalId: '123',
+        id: 456,
+        name: 'Test Admin',
+        phoneNumber: '123456789',
+      })
+    })
+
+    it('should convert cislo_poradace to string for externalId', () => {
+      const result = mapNorisToTaxAdministratorData(mockNorisData)
+      expect(typeof result.externalId).toBe('string')
+      expect(result.externalId).toBe('123')
+    })
+  })
+
+  describe('mapNorisToTaxData', () => {
+    const mockNorisData: NorisTaxPayersDto = {
+      dan_spolu: '100,50',
+      variabilny_symbol: 'VS123',
+      akt_datum: '2023-01-01',
+      datum_platnosti: '2023-12-31',
+      cislo_konania: 'CK123',
+      dan_pozemky: '20,00',
+      dan_stavby_SPOLU: '50,25',
+      dan_byty: '30,25',
+    } as NorisTaxPayersDto
+
+    it('should map Noris data to Tax data correctly', () => {
+      const result = mapNorisToTaxData(
+        mockNorisData,
+        2023,
+        1,
+        'qr_code_email',
+        'qr_code_web',
+      )
+
+      expect(result).toEqual({
+        amount: 10_050,
+        year: 2023,
+        taxPayerId: 1,
+        variableSymbol: 'VS123',
+        dateCreateTax: '2023-01-01',
+        dateTaxRuling: '2023-12-31',
+        taxId: 'CK123',
+        taxLand: 2000,
+        taxConstructions: 5025,
+        taxFlat: 3025,
+        qrCodeEmail: 'qr_code_email',
+        qrCodeWeb: 'qr_code_web',
+      })
+    })
+
+    it('should convert currency values to integers', () => {
+      const result = mapNorisToTaxData(
+        mockNorisData,
+        2023,
+        1,
+        'qr_code_email',
+        'qr_code_web',
+      )
+
+      expect(result.amount).toBe(10_050)
+      expect(result.taxLand).toBe(2000)
+      expect(result.taxConstructions).toBe(5025)
+      expect(result.taxFlat).toBe(3025)
+    })
+  })
+
+  describe('mapNorisToTaxInstallmentsData', () => {
+    const taxId = 1
+
+    it('should return single installment when SPL4_2 is empty', () => {
+      const mockNorisData: NorisTaxPayersDto = {
+        SPL4_2: '',
+        SPL1: '100,00',
+        TXTSPL1: 'Single Payment',
+      } as NorisTaxPayersDto
+
+      const result = mapNorisToTaxInstallmentsData(mockNorisData, taxId)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        taxId: 1,
+        amount: 10_000,
+        text: 'Single Payment',
+      })
+    })
+
+    it('should return three installments when SPL4_2 is not empty', () => {
+      const mockNorisData: NorisTaxPayersDto = {
+        SPL4_2: '50,00',
+        SPL4_1: '30,00',
+        SPL4_3: '20,00',
+        TXTSPL4_1: 'First Payment',
+        TXTSPL4_2: 'Second Payment',
+        TXTSPL4_3: 'Third Payment',
+      } as NorisTaxPayersDto
+
+      const result = mapNorisToTaxInstallmentsData(mockNorisData, taxId)
+
+      expect(result).toHaveLength(3)
+      expect(result).toEqual([
+        {
+          taxId: 1,
+          amount: 3000,
+          text: 'First Payment',
+        },
+        {
+          taxId: 1,
+          amount: 5000,
+          text: 'Second Payment',
+        },
+        {
+          taxId: 1,
+          amount: 2000,
+          text: 'Third Payment',
+        },
+      ])
+    })
+
+    it('should convert currency amounts to integers in installments', () => {
+      const mockNorisData: NorisTaxPayersDto = {
+        SPL4_2: '25,75',
+        SPL4_1: '10,25',
+        SPL4_3: '15,50',
+        TXTSPL4_1: 'First',
+        TXTSPL4_2: 'Second',
+        TXTSPL4_3: 'Third',
+      } as NorisTaxPayersDto
+
+      const result = mapNorisToTaxInstallmentsData(mockNorisData, taxId)
+
+      expect(result[0].amount).toBe(1025)
+      expect(result[1].amount).toBe(2575)
+      expect(result[2].amount).toBe(1550)
+    })
+  })
+})

--- a/nest-tax-backend/src/admin/utils/admin.helper.ts
+++ b/nest-tax-backend/src/admin/utils/admin.helper.ts
@@ -1,4 +1,4 @@
-import { TaxEmployee } from '@prisma/client'
+import { TaxAdministrator } from '@prisma/client'
 import currency from 'currency.js'
 
 import { NorisTaxPayersDto } from '../../noris/noris.dto'
@@ -10,7 +10,7 @@ export const convertCurrencyToInt = (value: string): number => {
 // Helper mapping functions to improve maintainability
 export const mapNorisToTaxPayerData = (
   data: NorisTaxPayersDto,
-  taxEmployee: TaxEmployee,
+  taxAdministrator: TaxAdministrator,
 ) => {
   return {
     active: true,
@@ -23,11 +23,11 @@ export const mapNorisToTaxPayerData = (
     permanentResidenceStreetTxt: data.TXT_UL,
     permanentResidenceCity: data.obec_nazev_tb,
     nameTxt: data.TXT_MENO,
-    taxEmployeeId: taxEmployee.id,
+    taxAdministratorId: taxAdministrator.id,
   }
 }
 
-export const mapNorisToTaxEmployeeData = (data: NorisTaxPayersDto) => {
+export const mapNorisToTaxAdministratorData = (data: NorisTaxPayersDto) => {
   return {
     email: data.vyb_email,
     externalId: data.cislo_poradace.toString(),

--- a/nest-tax-backend/src/admin/utils/admin.helper.ts
+++ b/nest-tax-backend/src/admin/utils/admin.helper.ts
@@ -1,3 +1,4 @@
+import { TaxEmployee } from '@prisma/client'
 import currency from 'currency.js'
 
 import { NorisTaxPayersDto } from '../../noris/noris.dto'
@@ -7,7 +8,10 @@ export const convertCurrencyToInt = (value: string): number => {
 }
 
 // Helper mapping functions to improve maintainability
-export const mapNorisToTaxPayerData = (data: NorisTaxPayersDto) => {
+export const mapNorisToTaxPayerData = (
+  data: NorisTaxPayersDto,
+  taxEmployee: TaxEmployee,
+) => {
   return {
     active: true,
     birthNumber: data.ICO_RC,
@@ -19,6 +23,7 @@ export const mapNorisToTaxPayerData = (data: NorisTaxPayersDto) => {
     permanentResidenceStreetTxt: data.TXT_UL,
     permanentResidenceCity: data.obec_nazev_tb,
     nameTxt: data.TXT_MENO,
+    taxEmployeeId: taxEmployee.id,
   }
 }
 
@@ -36,14 +41,12 @@ export const mapNorisToTaxData = (
   data: NorisTaxPayersDto,
   year: number,
   taxPayerId: number,
-  taxEmployeeId: number,
   qrCodeEmail: string,
   qrCodeWeb: string,
 ) => {
   return {
     amount: convertCurrencyToInt(data.dan_spolu),
     year,
-    taxEmployeeId,
     taxPayerId,
     variableSymbol: data.variabilny_symbol,
     dateCreateTax: data.akt_datum,

--- a/nest-tax-backend/src/admin/utils/testing-tax-mock.ts
+++ b/nest-tax-backend/src/admin/utils/testing-tax-mock.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto'
 
-import { TaxEmployee } from '@prisma/client'
+import { TaxAdministrator } from '@prisma/client'
 
 import { RequestAdminCreateTestingTaxNorisData } from '../dtos/requests.dto'
 
@@ -9,7 +9,7 @@ import { RequestAdminCreateTestingTaxNorisData } from '../dtos/requests.dto'
  */
 export const createTestingTaxMock = (
   norisData: RequestAdminCreateTestingTaxNorisData,
-  taxEmployee: TaxEmployee,
+  taxAdministrator: TaxAdministrator,
   year: number,
 ) => {
   return {
@@ -28,12 +28,12 @@ export const createTestingTaxMock = (
       parseFloat(norisData.alreadyPaid.replace(',', '.'))
     ).toString(),
 
-    // existing tax employee data to not overwrite
-    vyb_email: taxEmployee.email,
-    cislo_poradace: +taxEmployee.externalId,
-    vyb_id: taxEmployee.id,
-    vyb_nazov: taxEmployee.name,
-    vyb_telefon_prace: taxEmployee.phoneNumber,
+    // existing tax administrator data to not overwrite
+    vyb_email: taxAdministrator.email,
+    cislo_poradace: +taxAdministrator.externalId,
+    vyb_id: taxAdministrator.id,
+    vyb_nazov: taxAdministrator.name,
+    vyb_telefon_prace: taxAdministrator.phoneNumber,
     cislo_konania: randomBytes(4).toString('hex'),
 
     // mock values for testing

--- a/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
+++ b/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
@@ -167,12 +167,12 @@ export class ResponseTaxPayerDto {
   birthNumber: string
 
   @ApiProperty({
-    description: 'Id of tax employee - id is from Noris',
+    description: 'Id of tax administrator - id is from Noris',
     default: 5_172_727,
   })
   @IsNumber()
   @IsOptional()
-  taxEmployeeId: number | null
+  taxAdministratorId: number | null
 }
 
 export class ResponseTaxDetailInstallmentsDto {
@@ -280,20 +280,23 @@ export class ResponseTaxDetailsDto {
   amount: number
 }
 
-export class ResponseTaxEmployeeDto {
-  @ApiProperty({ description: 'Name of the tax employee', example: 'John Doe' })
+export class ResponseTaxAdministratorDto {
+  @ApiProperty({
+    description: 'Name of the tax administrator',
+    example: 'John Doe',
+  })
   @IsString()
   name: string
 
   @ApiProperty({
-    description: 'Phone number of the tax employee',
+    description: 'Phone number of the tax administrator',
     example: '+421 123 456 789',
   })
   @IsString()
   phoneNumber: string
 
   @ApiProperty({
-    description: 'Email address of the tax employee',
+    description: 'Email address of the tax administrator',
     example: 'johndoe@example.com',
   })
   @IsEmail()
@@ -502,7 +505,7 @@ export class ResponseTaxDto {
   taxInstallments: ResponseTaxDetailInstallmentsDto[]
 
   @ApiProperty({
-    description: 'Tax employee',
+    description: 'Tax administrator',
     default: [
       {
         id: 20,
@@ -559,14 +562,14 @@ export class ResponseTaxDto {
   bloomreachUnpaidTaxReminderSent: boolean
 
   @ApiProperty({
-    description: 'Assigned tax employee',
-    type: ResponseTaxEmployeeDto,
+    description: 'Assigned tax administrator',
+    type: ResponseTaxAdministratorDto,
   })
   @IsObject()
   @ValidateNested()
-  @Type(() => ResponseTaxEmployeeDto)
+  @Type(() => ResponseTaxAdministratorDto)
   @IsOptional()
-  taxEmployee: ResponseTaxEmployeeDto | null
+  taxAdministrator: ResponseTaxAdministratorDto | null
 }
 
 export class ResponseGetTaxesBodyDto {
@@ -640,14 +643,14 @@ export class ResponseGetTaxesDto {
   items: ResponseGetTaxesBodyDto[]
 
   @ApiProperty({
-    description: 'Assigned tax employee',
-    type: ResponseTaxEmployeeDto,
+    description: 'Assigned tax administrator',
+    type: ResponseTaxAdministratorDto,
   })
   @IsObject()
   @ValidateNested()
-  @Type(() => ResponseTaxEmployeeDto)
+  @Type(() => ResponseTaxAdministratorDto)
   @IsOptional()
-  taxEmployee: ResponseTaxEmployeeDto | null
+  taxAdministrator: ResponseTaxAdministratorDto | null
 }
 
 export class ResponseApartmentTaxDetailDto {
@@ -1029,12 +1032,12 @@ export class ResponseTaxSummaryDetailDto {
   installmentPayment: ResponseInstallmentPaymentDetailDto
 
   @ApiProperty({
-    description: 'Assigned tax employee',
-    type: ResponseTaxEmployeeDto,
+    description: 'Assigned tax administrator',
+    type: ResponseTaxAdministratorDto,
   })
   @IsObject()
   @ValidateNested()
-  @Type(() => ResponseTaxEmployeeDto)
+  @Type(() => ResponseTaxAdministratorDto)
   @IsOptional()
-  taxEmployee: ResponseTaxEmployeeDto | null
+  taxAdministrator: ResponseTaxAdministratorDto | null
 }

--- a/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
+++ b/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
@@ -56,18 +56,12 @@ export enum InstallmentPaidStatusEnum {
   AFTER_DUE_DATE = 'AFTER_DUE_DATE',
 }
 
-export class ResponseTaxPayerDto {
+export class ResponseTaxEmployeesDto {
   @ApiProperty({
-    description: 'Numeric id of tax payer',
+    description: 'Numeric id of Employee from noris',
     default: 1,
   })
   id: number
-
-  @ApiProperty({
-    description: 'Uuid of tax payer',
-    default: '15fc5751-d5e2-4e14-9f8d-dc4b3e1dec27',
-  })
-  uuid: string
 
   @ApiProperty({
     description: 'Created at timestamp',
@@ -82,57 +76,130 @@ export class ResponseTaxPayerDto {
   updatedAt: Date
 
   @ApiProperty({
+    description: 'External of employee',
+    default: '12562',
+  })
+  externalId: string
+
+  @ApiProperty({
+    description: 'Name of employee',
+    default: 'Zamestnanec Bratislavský',
+  })
+  name: string
+
+  @ApiProperty({
+    description: 'Phone number of employee',
+    default: '+421 000 000 000',
+  })
+  phoneNumber: string
+
+  @ApiProperty({
+    description: 'Email of employee',
+    default: 'zamestnanec.bratislavsky@bratislava.sk',
+  })
+  email: string
+}
+
+export class ResponseTaxPayerDto {
+  @ApiProperty({
+    description: 'Numeric id of tax payer',
+    default: 1,
+  })
+  @IsNumber()
+  id: number
+
+  @ApiProperty({
+    description: 'Uuid of tax payer',
+    default: '15fc5751-d5e2-4e14-9f8d-dc4b3e1dec27',
+  })
+  @IsUUID()
+  uuid: string
+
+  @ApiProperty({
+    description: 'Created at timestamp',
+    default: '2023-04-13T14:39:49.004Z',
+  })
+  @IsDate()
+  @Type(() => Date)
+  createdAt: Date
+
+  @ApiProperty({
+    description: 'Updated at timestamp',
+    default: '2023-04-13T14:39:49.004Z',
+  })
+  @IsDate()
+  @Type(() => Date)
+  updatedAt: Date
+
+  @ApiProperty({
     description: 'Is tax payer active',
     default: true,
   })
+  @IsBoolean()
   active: boolean
 
   @ApiProperty({
     description: 'Permanent address of tax payer',
     default: 'Bratislava, Hlavne námestie 1',
   })
+  @IsString()
+  @IsOptional()
   permanentResidenceAddress: string | null
 
   @ApiProperty({
     description: 'Id of tax payer from Noris',
     default: '12345',
   })
+  @IsString()
+  @IsOptional()
   externalId: string | null
 
   @ApiProperty({
     description: 'Name of taxpayer',
     default: 'Bratislavčan Daňový',
   })
+  @IsString()
+  @IsOptional()
   name: string | null
 
   @ApiProperty({
     description: 'Text of description of name for pdf',
     default: 'Meno daňovníka/ subjektu',
   })
+  @IsString()
+  @IsOptional()
   nameTxt: string | null
 
   @ApiProperty({
     description: 'Text of description of street for pdf',
     default: 'Ulica trvalého pobytu',
   })
+  @IsString()
+  @IsOptional()
   permanentResidenceStreetTxt: string | null
 
   @ApiProperty({
     description: 'Street of permanent residence with number',
     default: 'Uršulínska 6 3/6',
   })
+  @IsString()
+  @IsOptional()
   permanentResidenceStreet: string | null
 
   @ApiProperty({
     description: 'Zip of permanent residence with number',
     default: '811 01',
   })
+  @IsString()
+  @IsOptional()
   permanentResidenceZip: string | null
 
   @ApiProperty({
     description: 'City of permanent residence with number',
     default: 'Bratislava',
   })
+  @IsString()
+  @IsOptional()
   permanentResidenceCity: string | null
 
   // TODO more missing properties which are sent
@@ -140,7 +207,34 @@ export class ResponseTaxPayerDto {
     description: 'Birth number with slash',
     default: '920101/1111',
   })
+  @IsString()
   birthNumber: string
+
+  @ApiProperty({
+    description: 'Id of tax employee - id is from Noris',
+    default: 5_172_727,
+  })
+  @IsNumber()
+  @IsOptional()
+  taxEmployeeId: number | null
+
+  @ApiProperty({
+    description: 'Tax into details on area type',
+    default: {
+      id: 1,
+      createdAt: '2023-04-13T14:39:49.004Z',
+      updatedAt: '2023-04-13T14:39:49.004Z',
+      externalId: '1234',
+      name: 'Zamestnanec Bratsilavský',
+      phoneNumber: '+421 000 000 000',
+      email: 'zamestnanec.bratislavsky@bratislava.sk',
+    },
+  })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => ResponseTaxEmployeesDto)
+  @IsOptional()
+  taxEmployee: ResponseTaxEmployeesDto | null
 }
 
 export class ResponseTaxDetailInstallmentsDto {
@@ -248,50 +342,6 @@ export class ResponseTaxDetailsDto {
   amount: number
 }
 
-export class ResponseTaxEmployeesDto {
-  @ApiProperty({
-    description: 'Numeric id of Employee from noris',
-    default: 1,
-  })
-  id: number
-
-  @ApiProperty({
-    description: 'Created at timestamp',
-    default: '2023-04-13T14:39:49.004Z',
-  })
-  createdAt: Date
-
-  @ApiProperty({
-    description: 'Updated at timestamp',
-    default: '2023-04-13T14:39:49.004Z',
-  })
-  updatedAt: Date
-
-  @ApiProperty({
-    description: 'External of employee',
-    default: '12562',
-  })
-  externalId: string
-
-  @ApiProperty({
-    description: 'Name of employee',
-    default: 'Zamestnanec Bratislavský',
-  })
-  name: string
-
-  @ApiProperty({
-    description: 'Phone number of employee',
-    default: '+421 000 000 000',
-  })
-  phoneNumber: string
-
-  @ApiProperty({
-    description: 'Email of employee',
-    default: 'zamestnanec.bratislavsky@bratislava.sk',
-  })
-  email: string
-}
-
 export class ResponseTaxDto {
   @ApiProperty({
     description: 'Numeric id of tax',
@@ -357,13 +407,6 @@ export class ResponseTaxDto {
   })
   @IsString()
   variableSymbol: string
-
-  @ApiProperty({
-    description: 'Id of tax employee - id is from Noris',
-    default: 5_172_727,
-  })
-  @IsNumber()
-  taxEmployeeId: number
 
   @ApiProperty({
     description: 'Tax Id from order of exact year',
@@ -520,23 +563,6 @@ export class ResponseTaxDto {
   @ValidateNested({ each: true })
   @Type(() => ResponseTaxDetailsDto)
   taxDetails: ResponseTaxDetailsDto[]
-
-  @ApiProperty({
-    description: 'Tax into details on area type',
-    default: {
-      id: 1,
-      createdAt: '2023-04-13T14:39:49.004Z',
-      updatedAt: '2023-04-13T14:39:49.004Z',
-      externalId: '1234',
-      name: 'Zamestnanec Bratsilavský',
-      phoneNumber: '+421 000 000 000',
-      email: 'zamestnanec.bratislavsky@bratislava.sk',
-    },
-  })
-  @IsObject()
-  @ValidateNested()
-  @Type(() => ResponseTaxEmployeesDto)
-  taxEmployees: ResponseTaxEmployeesDto
 
   @ApiProperty({
     description:
@@ -1047,5 +1073,6 @@ export class ResponseTaxSummaryDetailDto {
   @IsObject()
   @ValidateNested()
   @Type(() => ResponseTaxEmployeeDto)
-  taxEmployee: ResponseTaxEmployeeDto
+  @IsOptional()
+  taxEmployee: ResponseTaxEmployeeDto | null
 }

--- a/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
+++ b/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
@@ -56,50 +56,6 @@ export enum InstallmentPaidStatusEnum {
   AFTER_DUE_DATE = 'AFTER_DUE_DATE',
 }
 
-export class ResponseTaxEmployeesDto {
-  @ApiProperty({
-    description: 'Numeric id of Employee from noris',
-    default: 1,
-  })
-  id: number
-
-  @ApiProperty({
-    description: 'Created at timestamp',
-    default: '2023-04-13T14:39:49.004Z',
-  })
-  createdAt: Date
-
-  @ApiProperty({
-    description: 'Updated at timestamp',
-    default: '2023-04-13T14:39:49.004Z',
-  })
-  updatedAt: Date
-
-  @ApiProperty({
-    description: 'External of employee',
-    default: '12562',
-  })
-  externalId: string
-
-  @ApiProperty({
-    description: 'Name of employee',
-    default: 'Zamestnanec Bratislavský',
-  })
-  name: string
-
-  @ApiProperty({
-    description: 'Phone number of employee',
-    default: '+421 000 000 000',
-  })
-  phoneNumber: string
-
-  @ApiProperty({
-    description: 'Email of employee',
-    default: 'zamestnanec.bratislavsky@bratislava.sk',
-  })
-  email: string
-}
-
 export class ResponseTaxPayerDto {
   @ApiProperty({
     description: 'Numeric id of tax payer',
@@ -217,24 +173,6 @@ export class ResponseTaxPayerDto {
   @IsNumber()
   @IsOptional()
   taxEmployeeId: number | null
-
-  @ApiProperty({
-    description: 'Tax into details on area type',
-    default: {
-      id: 1,
-      createdAt: '2023-04-13T14:39:49.004Z',
-      updatedAt: '2023-04-13T14:39:49.004Z',
-      externalId: '1234',
-      name: 'Zamestnanec Bratsilavský',
-      phoneNumber: '+421 000 000 000',
-      email: 'zamestnanec.bratislavsky@bratislava.sk',
-    },
-  })
-  @IsObject()
-  @ValidateNested()
-  @Type(() => ResponseTaxEmployeesDto)
-  @IsOptional()
-  taxEmployee: ResponseTaxEmployeesDto | null
 }
 
 export class ResponseTaxDetailInstallmentsDto {
@@ -340,6 +278,26 @@ export class ResponseTaxDetailsDto {
     default: 0,
   })
   amount: number
+}
+
+export class ResponseTaxEmployeeDto {
+  @ApiProperty({ description: 'Name of the tax employee', example: 'John Doe' })
+  @IsString()
+  name: string
+
+  @ApiProperty({
+    description: 'Phone number of the tax employee',
+    example: '+421 123 456 789',
+  })
+  @IsString()
+  phoneNumber: string
+
+  @ApiProperty({
+    description: 'Email address of the tax employee',
+    example: 'johndoe@example.com',
+  })
+  @IsEmail()
+  email: string
 }
 
 export class ResponseTaxDto {
@@ -599,6 +557,16 @@ export class ResponseTaxDto {
   })
   @IsBoolean()
   bloomreachUnpaidTaxReminderSent: boolean
+
+  @ApiProperty({
+    description: 'Assigned tax employee',
+    type: ResponseTaxEmployeeDto,
+  })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => ResponseTaxEmployeeDto)
+  @IsOptional()
+  taxEmployee: ResponseTaxEmployeeDto | null
 }
 
 export class ResponseGetTaxesBodyDto {
@@ -659,13 +627,27 @@ export class ResponseGetTaxesDto {
     description: 'Birth number of user is in Noris actual or historical Tax',
     example: true,
   })
+  @IsBoolean()
   isInNoris: boolean
 
   @ApiProperty({
     isArray: true,
     type: ResponseGetTaxesBodyDto,
   })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ResponseGetTaxesBodyDto)
   items: ResponseGetTaxesBodyDto[]
+
+  @ApiProperty({
+    description: 'Assigned tax employee',
+    type: ResponseTaxEmployeeDto,
+  })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => ResponseTaxEmployeeDto)
+  @IsOptional()
+  taxEmployee: ResponseTaxEmployeeDto | null
 }
 
 export class ResponseApartmentTaxDetailDto {
@@ -1000,26 +982,6 @@ export class ResponseInstallmentPaymentDetailDto {
   @ValidateNested()
   @Type(() => ResponseActiveInstallmentDto)
   activeInstallment?: ResponseActiveInstallmentDto
-}
-
-export class ResponseTaxEmployeeDto {
-  @ApiProperty({ description: 'Name of the tax employee', example: 'John Doe' })
-  @IsString()
-  name: string
-
-  @ApiProperty({
-    description: 'Phone number of the tax employee',
-    example: '+421 123 456 789',
-  })
-  @IsString()
-  phoneNumber: string
-
-  @ApiProperty({
-    description: 'Email address of the tax employee',
-    example: 'johndoe@example.com',
-  })
-  @IsEmail()
-  email: string
 }
 
 export class ResponseTaxSummaryDetailDto {

--- a/nest-tax-backend/src/tax/tax.service.ts
+++ b/nest-tax-backend/src/tax/tax.service.ts
@@ -21,8 +21,8 @@ import {
   ResponseGetTaxesDto,
   ResponseInstallmentPaymentDetailDto,
   ResponseOneTimePaymentDetailsDto,
+  ResponseTaxAdministratorDto,
   ResponseTaxDto,
-  ResponseTaxEmployeeDto,
   ResponseTaxSummaryDetailDto,
 } from './dtos/response.tax.dto'
 import { taxDetailsToPdf, taxTotalsToPdf } from './utils/helpers/pdf.helper'
@@ -54,7 +54,7 @@ export class TaxService {
         taxInstallments: true,
         taxPayer: {
           include: {
-            taxEmployee: true,
+            taxAdministrator: true,
           },
         },
         taxDetails: true,
@@ -127,7 +127,7 @@ export class TaxService {
       paidStatus,
       pdfExport,
       isPayable,
-      taxEmployee: tax.taxPayer.taxEmployee,
+      taxAdministrator: tax.taxPayer.taxAdministrator,
     }
   }
 
@@ -177,7 +177,7 @@ export class TaxService {
         birthNumber,
       },
       include: {
-        taxEmployee: true,
+        taxAdministrator: true,
       },
     })
 
@@ -202,7 +202,7 @@ export class TaxService {
     return {
       isInNoris: items.length > 0,
       items,
-      taxEmployee: taxPayer ? taxPayer.taxEmployee : null,
+      taxAdministrator: taxPayer ? taxPayer.taxAdministrator : null,
     }
   }
 
@@ -292,11 +292,12 @@ export class TaxService {
         : undefined,
     }
 
-    const taxEmployee: ResponseTaxEmployeeDto | null = tax.taxPayer.taxEmployee
+    const taxAdministrator: ResponseTaxAdministratorDto | null = tax.taxPayer
+      .taxAdministrator
       ? {
-          name: tax.taxPayer.taxEmployee.name,
-          phoneNumber: tax.taxPayer.taxEmployee.phoneNumber,
-          email: tax.taxPayer.taxEmployee.email,
+          name: tax.taxPayer.taxAdministrator.name,
+          phoneNumber: tax.taxPayer.taxAdministrator.phoneNumber,
+          email: tax.taxPayer.taxAdministrator.email,
         }
       : null
 
@@ -304,7 +305,7 @@ export class TaxService {
       ...detailWithoutQrCode,
       oneTimePayment,
       installmentPayment,
-      taxEmployee,
+      taxAdministrator,
     }
   }
 }

--- a/nest-tax-backend/src/tax/tax.service.ts
+++ b/nest-tax-backend/src/tax/tax.service.ts
@@ -21,7 +21,6 @@ import {
   ResponseGetTaxesDto,
   ResponseInstallmentPaymentDetailDto,
   ResponseOneTimePaymentDetailsDto,
-  ResponseTaxAdministratorDto,
   ResponseTaxDto,
   ResponseTaxSummaryDetailDto,
 } from './dtos/response.tax.dto'
@@ -292,14 +291,7 @@ export class TaxService {
         : undefined,
     }
 
-    const taxAdministrator: ResponseTaxAdministratorDto | null = tax.taxPayer
-      .taxAdministrator
-      ? {
-          name: tax.taxPayer.taxAdministrator.name,
-          phoneNumber: tax.taxPayer.taxAdministrator.phoneNumber,
-          email: tax.taxPayer.taxAdministrator.email,
-        }
-      : null
+    const { taxAdministrator } = tax.taxPayer
 
     return {
       ...detailWithoutQrCode,

--- a/nest-tax-backend/src/tax/tax.service.ts
+++ b/nest-tax-backend/src/tax/tax.service.ts
@@ -127,6 +127,7 @@ export class TaxService {
       paidStatus,
       pdfExport,
       isPayable,
+      taxEmployee: tax.taxPayer.taxEmployee,
     }
   }
 
@@ -171,6 +172,15 @@ export class TaxService {
       },
     })
 
+    const taxPayer = await this.prisma.taxPayer.findUnique({
+      where: {
+        birthNumber,
+      },
+      include: {
+        taxEmployee: true,
+      },
+    })
+
     const items: ResponseGetTaxesBodyDto[] = taxes.map((tax) => {
       const taxPaymentItem = taxPayments.find(
         (taxPayment) => taxPayment.taxId === tax.id,
@@ -192,6 +202,7 @@ export class TaxService {
     return {
       isInNoris: items.length > 0,
       items,
+      taxEmployee: taxPayer ? taxPayer.taxEmployee : null,
     }
   }
 

--- a/nest-tax-backend/src/tax/tax.service.ts
+++ b/nest-tax-backend/src/tax/tax.service.ts
@@ -52,9 +52,12 @@ export class TaxService {
       },
       include: {
         taxInstallments: true,
-        taxPayer: true,
+        taxPayer: {
+          include: {
+            taxEmployee: true,
+          },
+        },
         taxDetails: true,
-        taxEmployees: true,
         taxPayments: true,
       },
     })
@@ -278,11 +281,13 @@ export class TaxService {
         : undefined,
     }
 
-    const taxEmployee: ResponseTaxEmployeeDto = {
-      name: tax.taxEmployees.name,
-      phoneNumber: tax.taxEmployees.phoneNumber,
-      email: tax.taxEmployees.email,
-    }
+    const taxEmployee: ResponseTaxEmployeeDto | null = tax.taxPayer.taxEmployee
+      ? {
+          name: tax.taxPayer.taxEmployee.name,
+          phoneNumber: tax.taxPayer.taxEmployee.phoneNumber,
+          email: tax.taxPayer.taxEmployee.email,
+        }
+      : null
 
     return {
       ...detailWithoutQrCode,

--- a/next/pages/dane-a-poplatky/index.tsx
+++ b/next/pages/dane-a-poplatky/index.tsx
@@ -45,7 +45,7 @@ const getTaxes = async (getSsrAuthSession: () => Promise<AuthSession>) => {
       // TODO: This should be replace with a proper error code (which is not returned)
       error.response?.data?.message === 'Forbidden tier'
     ) {
-      return { isInNoris: false, items: [] } as ResponseGetTaxesDto
+      return { isInNoris: false, items: [], taxAdministrator: null } as ResponseGetTaxesDto
     }
     throw error
   }

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -293,6 +293,31 @@ export type RequestUpdateNorisDeliveryMethodsDtoDataValueOneOf1DeliveryMethodEnu
 /**
  *
  * @export
+ * @interface ResponseActiveInstallmentDto
+ */
+export interface ResponseActiveInstallmentDto {
+  /**
+   * Remaining amount to pay in the installment
+   * @type {number}
+   * @memberof ResponseActiveInstallmentDto
+   */
+  remainingAmount: number
+  /**
+   * Variable symbol
+   * @type {string}
+   * @memberof ResponseActiveInstallmentDto
+   */
+  variableSymbol?: string
+  /**
+   * QR code
+   * @type {string}
+   * @memberof ResponseActiveInstallmentDto
+   */
+  qrCode?: string
+}
+/**
+ *
+ * @export
  * @interface ResponseErrorDto
  */
 export interface ResponseErrorDto {
@@ -408,7 +433,53 @@ export interface ResponseGetTaxesDto {
    * @memberof ResponseGetTaxesDto
    */
   items: Array<ResponseGetTaxesBodyDto>
+  /**
+   * Assigned tax employee
+   * @type {ResponseTaxEmployeeDto}
+   * @memberof ResponseGetTaxesDto
+   */
+  taxEmployee: ResponseTaxEmployeeDto | null
 }
+/**
+ *
+ * @export
+ * @interface ResponseInstallmentPaymentDetailDto
+ */
+export interface ResponseInstallmentPaymentDetailDto {
+  /**
+   * Indicates if installment payment is possible
+   * @type {boolean}
+   * @memberof ResponseInstallmentPaymentDetailDto
+   */
+  isPossible: boolean
+  /**
+   * Reason why installment is not possible
+   * @type {string}
+   * @memberof ResponseInstallmentPaymentDetailDto
+   */
+  reasonNotPossible?: ResponseInstallmentPaymentDetailDtoReasonNotPossibleEnum
+  /**
+   * List of exactly 3 installments or none at all
+   * @type {Array<Array<string>>}
+   * @memberof ResponseInstallmentPaymentDetailDto
+   */
+  installments?: Array<Array<string>>
+  /**
+   * Details of active installment
+   * @type {ResponseActiveInstallmentDto}
+   * @memberof ResponseInstallmentPaymentDetailDto
+   */
+  activeInstallment?: ResponseActiveInstallmentDto
+}
+
+export const ResponseInstallmentPaymentDetailDtoReasonNotPossibleEnum = {
+  BelowThreshold: 'BELOW_THRESHOLD',
+  AfterDate: 'AFTER_DATE',
+} as const
+
+export type ResponseInstallmentPaymentDetailDtoReasonNotPossibleEnum =
+  (typeof ResponseInstallmentPaymentDetailDtoReasonNotPossibleEnum)[keyof typeof ResponseInstallmentPaymentDetailDtoReasonNotPossibleEnum]
+
 /**
  *
  * @export
@@ -428,6 +499,76 @@ export interface ResponseInternalServerErrorDto {
    */
   message: string
 }
+/**
+ *
+ * @export
+ * @interface ResponseOneTimePaymentDetailsDto
+ */
+export interface ResponseOneTimePaymentDetailsDto {
+  /**
+   * Indicates if one-time payment is possible.
+   * @type {boolean}
+   * @memberof ResponseOneTimePaymentDetailsDto
+   */
+  isPossible: boolean
+  /**
+   * Type of payment
+   * @type {string}
+   * @memberof ResponseOneTimePaymentDetailsDto
+   */
+  type?: ResponseOneTimePaymentDetailsDtoTypeEnum
+  /**
+   * Reason why payment is not possible
+   * @type {string}
+   * @memberof ResponseOneTimePaymentDetailsDto
+   */
+  reasonNotPossible?: ResponseOneTimePaymentDetailsDtoReasonNotPossibleEnum
+  /**
+   * Payment amount
+   * @type {number}
+   * @memberof ResponseOneTimePaymentDetailsDto
+   */
+  amount?: number
+  /**
+   * Due date
+   * @type {string}
+   * @memberof ResponseOneTimePaymentDetailsDto
+   */
+  dueDate?: string
+  /**
+   * QR code for payment
+   * @type {string}
+   * @memberof ResponseOneTimePaymentDetailsDto
+   */
+  qrCode?: string
+  /**
+   * Variable symbol for payment
+   * @type {string}
+   * @memberof ResponseOneTimePaymentDetailsDto
+   */
+  variableSymbol?: string
+  /**
+   * Link to payment gateway (only when type is ONE_TIME_PAYMENT)
+   * @type {string}
+   * @memberof ResponseOneTimePaymentDetailsDto
+   */
+  paymentGatewayLink?: string
+}
+
+export const ResponseOneTimePaymentDetailsDtoTypeEnum = {
+  OneTimePayment: 'ONE_TIME_PAYMENT',
+  RemainingAmountPayment: 'REMAINING_AMOUNT_PAYMENT',
+} as const
+
+export type ResponseOneTimePaymentDetailsDtoTypeEnum =
+  (typeof ResponseOneTimePaymentDetailsDtoTypeEnum)[keyof typeof ResponseOneTimePaymentDetailsDtoTypeEnum]
+export const ResponseOneTimePaymentDetailsDtoReasonNotPossibleEnum = {
+  AlreadyPaid: 'ALREADY_PAID',
+} as const
+
+export type ResponseOneTimePaymentDetailsDtoReasonNotPossibleEnum =
+  (typeof ResponseOneTimePaymentDetailsDtoReasonNotPossibleEnum)[keyof typeof ResponseOneTimePaymentDetailsDtoReasonNotPossibleEnum]
+
 /**
  *
  * @export
@@ -476,6 +617,49 @@ export interface ResponseTaxDetailInstallmentsDto {
    * @memberof ResponseTaxDetailInstallmentsDto
    */
   text: string | null
+}
+/**
+ *
+ * @export
+ * @interface ResponseTaxDetailItemizedDto
+ */
+export interface ResponseTaxDetailItemizedDto {
+  /**
+   * Total amount of tax for apartment
+   * @type {number}
+   * @memberof ResponseTaxDetailItemizedDto
+   */
+  apartmentTotalAmount: number
+  /**
+   * Total amount of tax for construction
+   * @type {number}
+   * @memberof ResponseTaxDetailItemizedDto
+   */
+  constructionTotalAmount: number
+  /**
+   * Total amount of tax for ground
+   * @type {number}
+   * @memberof ResponseTaxDetailItemizedDto
+   */
+  groundTotalAmount: number
+  /**
+   * Apartment tax itemized
+   * @type {Array<Array<string>>}
+   * @memberof ResponseTaxDetailItemizedDto
+   */
+  apartmentTaxDetail: Array<Array<string>>
+  /**
+   * Ground tax itemized
+   * @type {Array<Array<string>>}
+   * @memberof ResponseTaxDetailItemizedDto
+   */
+  groundTaxDetail: Array<Array<string>>
+  /**
+   * Construction tax itemized
+   * @type {Array<Array<string>>}
+   * @memberof ResponseTaxDetailItemizedDto
+   */
+  constructionTaxDetail: Array<Array<string>>
 }
 /**
  *
@@ -600,12 +784,6 @@ export interface ResponseTaxDto {
    */
   variableSymbol: string
   /**
-   * Id of tax employee - id is from Noris
-   * @type {number}
-   * @memberof ResponseTaxDto
-   */
-  taxEmployeeId: number
-  /**
    * Tax Id from order of exact year
    * @type {string}
    * @memberof ResponseTaxDto
@@ -690,12 +868,6 @@ export interface ResponseTaxDto {
    */
   taxDetails: Array<ResponseTaxDetailsDto>
   /**
-   * Tax into details on area type
-   * @type {ResponseTaxEmployeesDto}
-   * @memberof ResponseTaxDto
-   */
-  taxEmployees: ResponseTaxEmployeesDto
-  /**
    * When were last checked payments for this tax with automatic task.
    * @type {string}
    * @memberof ResponseTaxDto
@@ -719,54 +891,36 @@ export interface ResponseTaxDto {
    * @memberof ResponseTaxDto
    */
   bloomreachUnpaidTaxReminderSent: boolean
+  /**
+   * Assigned tax employee
+   * @type {ResponseTaxEmployeeDto}
+   * @memberof ResponseTaxDto
+   */
+  taxEmployee: ResponseTaxEmployeeDto | null
 }
 
 /**
  *
  * @export
- * @interface ResponseTaxEmployeesDto
+ * @interface ResponseTaxEmployeeDto
  */
-export interface ResponseTaxEmployeesDto {
+export interface ResponseTaxEmployeeDto {
   /**
-   * Numeric id of Employee from noris
-   * @type {number}
-   * @memberof ResponseTaxEmployeesDto
-   */
-  id: number
-  /**
-   * Created at timestamp
+   * Name of the tax employee
    * @type {string}
-   * @memberof ResponseTaxEmployeesDto
-   */
-  createdAt: string
-  /**
-   * Updated at timestamp
-   * @type {string}
-   * @memberof ResponseTaxEmployeesDto
-   */
-  updatedAt: string
-  /**
-   * External of employee
-   * @type {string}
-   * @memberof ResponseTaxEmployeesDto
-   */
-  externalId: string
-  /**
-   * Name of employee
-   * @type {string}
-   * @memberof ResponseTaxEmployeesDto
+   * @memberof ResponseTaxEmployeeDto
    */
   name: string
   /**
-   * Phone number of employee
+   * Phone number of the tax employee
    * @type {string}
-   * @memberof ResponseTaxEmployeesDto
+   * @memberof ResponseTaxEmployeeDto
    */
   phoneNumber: string
   /**
-   * Email of employee
+   * Email address of the tax employee
    * @type {string}
-   * @memberof ResponseTaxEmployeesDto
+   * @memberof ResponseTaxEmployeeDto
    */
   email: string
 }
@@ -825,13 +979,13 @@ export interface ResponseTaxPayerDto {
    */
   name: string | null
   /**
-   * Text of descreption of name for pdf
+   * Text of description of name for pdf
    * @type {string}
    * @memberof ResponseTaxPayerDto
    */
   nameTxt: string | null
   /**
-   * Text of descreption of street for pdf
+   * Text of description of street for pdf
    * @type {string}
    * @memberof ResponseTaxPayerDto
    */
@@ -860,6 +1014,61 @@ export interface ResponseTaxPayerDto {
    * @memberof ResponseTaxPayerDto
    */
   birthNumber: string
+  /**
+   * Id of tax employee - id is from Noris
+   * @type {number}
+   * @memberof ResponseTaxPayerDto
+   */
+  taxEmployeeId: number | null
+}
+/**
+ *
+ * @export
+ * @interface ResponseTaxSummaryDetailDto
+ */
+export interface ResponseTaxSummaryDetailDto {
+  /**
+   * Total amount paid
+   * @type {number}
+   * @memberof ResponseTaxSummaryDetailDto
+   */
+  overallPaid: number
+  /**
+   * Total remaining balance
+   * @type {number}
+   * @memberof ResponseTaxSummaryDetailDto
+   */
+  overallBalance: number
+  /**
+   * Total tax amount
+   * @type {number}
+   * @memberof ResponseTaxSummaryDetailDto
+   */
+  overallAmount: number
+  /**
+   * Itemized details
+   * @type {Array<ResponseTaxDetailItemizedDto>}
+   * @memberof ResponseTaxSummaryDetailDto
+   */
+  itemizedDetail: Array<ResponseTaxDetailItemizedDto>
+  /**
+   * One-time payment details
+   * @type {ResponseOneTimePaymentDetailsDto}
+   * @memberof ResponseTaxSummaryDetailDto
+   */
+  oneTimePayment: ResponseOneTimePaymentDetailsDto
+  /**
+   * Installment payment details
+   * @type {ResponseInstallmentPaymentDetailDto}
+   * @memberof ResponseTaxSummaryDetailDto
+   */
+  installmentPayment: ResponseInstallmentPaymentDetailDto
+  /**
+   * Assigned tax employee
+   * @type {ResponseTaxEmployeeDto}
+   * @memberof ResponseTaxSummaryDetailDto
+   */
+  taxEmployee: ResponseTaxEmployeeDto | null
 }
 /**
  * Type of tax detail - object of tax
@@ -2684,6 +2893,52 @@ export const TaxApiAxiosParamCreator = function (configuration?: Configuration) 
         options: localVarRequestOptions,
       }
     },
+    /**
+     *
+     * @summary Get tax detail by year.
+     * @param {number} year
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    taxControllerV2GetTaxDetailByYearV2: async (
+      year: number,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'year' is not null or undefined
+      assertParamExists('taxControllerV2GetTaxDetailByYearV2', 'year', year)
+      const localVarPath = `/v2/tax/get-tax-detail-by-year`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication bearer required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+      if (year !== undefined) {
+        localVarQueryParameter['year'] = year
+      }
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
   }
 }
 
@@ -2772,6 +3027,36 @@ export const TaxApiFp = function (configuration?: Configuration) {
           configuration,
         )(axios, localVarOperationServerBasePath || basePath)
     },
+    /**
+     *
+     * @summary Get tax detail by year.
+     * @param {number} year
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async taxControllerV2GetTaxDetailByYearV2(
+      year: number,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ResponseTaxSummaryDetailDto>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.taxControllerV2GetTaxDetailByYearV2(
+        year,
+        options,
+      )
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath =
+        operationServerMap['TaxApi.taxControllerV2GetTaxDetailByYearV2']?.[
+          localVarOperationServerIndex
+        ]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
   }
 }
 
@@ -2830,6 +3115,21 @@ export const TaxApiFactory = function (
         .taxControllerGetTaxByYearPdf(year, options)
         .then((request) => request(axios, basePath))
     },
+    /**
+     *
+     * @summary Get tax detail by year.
+     * @param {number} year
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    taxControllerV2GetTaxDetailByYearV2(
+      year: number,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<ResponseTaxSummaryDetailDto> {
+      return localVarFp
+        .taxControllerV2GetTaxDetailByYearV2(year, options)
+        .then((request) => request(axios, basePath))
+    },
   }
 }
 
@@ -2879,6 +3179,20 @@ export class TaxApi extends BaseAPI {
   public taxControllerGetTaxByYearPdf(year: number, options?: RawAxiosRequestConfig) {
     return TaxApiFp(this.configuration)
       .taxControllerGetTaxByYearPdf(year, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   *
+   * @summary Get tax detail by year.
+   * @param {number} year
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TaxApi
+   */
+  public taxControllerV2GetTaxDetailByYearV2(year: number, options?: RawAxiosRequestConfig) {
+    return TaxApiFp(this.configuration)
+      .taxControllerV2GetTaxDetailByYearV2(year, options)
       .then((request) => request(this.axios, this.basePath))
   }
 }

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -434,11 +434,11 @@ export interface ResponseGetTaxesDto {
    */
   items: Array<ResponseGetTaxesBodyDto>
   /**
-   * Assigned tax employee
-   * @type {ResponseTaxEmployeeDto}
+   * Assigned tax administrator
+   * @type {ResponseTaxAdministratorDto}
    * @memberof ResponseGetTaxesDto
    */
-  taxEmployee: ResponseTaxEmployeeDto | null
+  taxAdministrator: ResponseTaxAdministratorDto | null
 }
 /**
  *
@@ -569,6 +569,31 @@ export const ResponseOneTimePaymentDetailsDtoReasonNotPossibleEnum = {
 export type ResponseOneTimePaymentDetailsDtoReasonNotPossibleEnum =
   (typeof ResponseOneTimePaymentDetailsDtoReasonNotPossibleEnum)[keyof typeof ResponseOneTimePaymentDetailsDtoReasonNotPossibleEnum]
 
+/**
+ *
+ * @export
+ * @interface ResponseTaxAdministratorDto
+ */
+export interface ResponseTaxAdministratorDto {
+  /**
+   * Name of the tax administrator
+   * @type {string}
+   * @memberof ResponseTaxAdministratorDto
+   */
+  name: string
+  /**
+   * Phone number of the tax administrator
+   * @type {string}
+   * @memberof ResponseTaxAdministratorDto
+   */
+  phoneNumber: string
+  /**
+   * Email address of the tax administrator
+   * @type {string}
+   * @memberof ResponseTaxAdministratorDto
+   */
+  email: string
+}
 /**
  *
  * @export
@@ -862,7 +887,7 @@ export interface ResponseTaxDto {
    */
   taxInstallments: Array<ResponseTaxDetailInstallmentsDto>
   /**
-   * Tax employee
+   * Tax administrator
    * @type {Array<ResponseTaxDetailsDto>}
    * @memberof ResponseTaxDto
    */
@@ -892,38 +917,13 @@ export interface ResponseTaxDto {
    */
   bloomreachUnpaidTaxReminderSent: boolean
   /**
-   * Assigned tax employee
-   * @type {ResponseTaxEmployeeDto}
+   * Assigned tax administrator
+   * @type {ResponseTaxAdministratorDto}
    * @memberof ResponseTaxDto
    */
-  taxEmployee: ResponseTaxEmployeeDto | null
+  taxAdministrator: ResponseTaxAdministratorDto | null
 }
 
-/**
- *
- * @export
- * @interface ResponseTaxEmployeeDto
- */
-export interface ResponseTaxEmployeeDto {
-  /**
-   * Name of the tax employee
-   * @type {string}
-   * @memberof ResponseTaxEmployeeDto
-   */
-  name: string
-  /**
-   * Phone number of the tax employee
-   * @type {string}
-   * @memberof ResponseTaxEmployeeDto
-   */
-  phoneNumber: string
-  /**
-   * Email address of the tax employee
-   * @type {string}
-   * @memberof ResponseTaxEmployeeDto
-   */
-  email: string
-}
 /**
  *
  * @export
@@ -1015,11 +1015,11 @@ export interface ResponseTaxPayerDto {
    */
   birthNumber: string
   /**
-   * Id of tax employee - id is from Noris
+   * Id of tax administrator - id is from Noris
    * @type {number}
    * @memberof ResponseTaxPayerDto
    */
-  taxEmployeeId: number | null
+  taxAdministratorId: number | null
 }
 /**
  *
@@ -1064,11 +1064,11 @@ export interface ResponseTaxSummaryDetailDto {
    */
   installmentPayment: ResponseInstallmentPaymentDetailDto
   /**
-   * Assigned tax employee
-   * @type {ResponseTaxEmployeeDto}
+   * Assigned tax administrator
+   * @type {ResponseTaxAdministratorDto}
    * @memberof ResponseTaxSummaryDetailDto
    */
-  taxEmployee: ResponseTaxEmployeeDto | null
+  taxAdministrator: ResponseTaxAdministratorDto | null
 }
 /**
  * Type of tax detail - object of tax


### PR DESCRIPTION
- renames tax employee to tax **administrator**, to be consistent with frontend
- instead of one tax administrator for each tax, there will be one for each tax payer, so each tax payer will have just one administrator
- adds the information about the administrator to the response with tax details, makes the frontend ready to use this data instead of determining the tax administrator by the first letter of the surname
- add admin.helper tests