### PR TITLE
866 save postal as edesk in noris

### DIFF
--- a/nest-city-account/src/admin/admin.service.ts
+++ b/nest-city-account/src/admin/admin.service.ts
@@ -82,6 +82,7 @@ export class AdminService {
       externalId: user.externalId,
       userAttribute: user.userAttribute,
       cognitoAttributes: cognitoUser,
+      taxDeliveryMethodAtLockDate: user.taxDeliveryMethodAtLockDate,
     }
   }
 
@@ -120,6 +121,7 @@ export class AdminService {
         externalId: user.externalId,
         userAttribute: user.userAttribute,
         cognitoAttributes: cognitoUser,
+        taxDeliveryMethodAtLockDate: user.taxDeliveryMethodAtLockDate,
       }
     }
 

--- a/nest-city-account/src/admin/dtos/responses.admin.dto.ts
+++ b/nest-city-account/src/admin/dtos/responses.admin.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
-import { CognitoUserAttributesTierEnum } from '@prisma/client'
+import { CognitoUserAttributesTierEnum, DeliveryMethodEnum } from '@prisma/client'
 import {
   IsBoolean,
   IsEmail,
@@ -49,6 +49,14 @@ export class ResponseUserByBirthNumberDto {
   })
   // eslint-disable-next-line @typescript-eslint/ban-types
   cognitoAttributes?: CognitoGetUserData | {}
+
+  @ApiPropertyOptional({
+    description: 'Delivery method for tax documents at lock date',
+    example: DeliveryMethodEnum.EDESK,
+    enum: DeliveryMethodEnum,
+  })
+  @IsEnum(DeliveryMethodEnum)
+  taxDeliveryMethodAtLockDate: DeliveryMethodEnum | null
 }
 
 export class UserVerifyState {

--- a/nest-tax-backend/prisma/migrations/20250715085147_save_delivery_method_for_tax_payer/migration.sql
+++ b/nest-tax-backend/prisma/migrations/20250715085147_save_delivery_method_for_tax_payer/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "TaxPayer" ADD COLUMN     "deliveryMethod" "DeliveryMethodNamed";

--- a/nest-tax-backend/prisma/migrations/20250715085147_save_delivery_method_for_tax_payer/migration.sql
+++ b/nest-tax-backend/prisma/migrations/20250715085147_save_delivery_method_for_tax_payer/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TaxPayer" ADD COLUMN     "deliveryMethod" "DeliveryMethodNamed";

--- a/nest-tax-backend/prisma/schema.prisma
+++ b/nest-tax-backend/prisma/schema.prisma
@@ -28,7 +28,6 @@ model TaxPayer {
   permanentResidenceStreet    String?
   permanentResidenceZip       String?
   permanentResidenceCity      String?
-  deliveryMethod              DeliveryMethodNamed? // Current delivery method for the tax payer.
 
   taxes Tax[]
 

--- a/nest-tax-backend/prisma/schema.prisma
+++ b/nest-tax-backend/prisma/schema.prisma
@@ -28,6 +28,7 @@ model TaxPayer {
   permanentResidenceStreet    String?
   permanentResidenceZip       String?
   permanentResidenceCity      String?
+  deliveryMethod              DeliveryMethodNamed? // Current delivery method for the tax payer.
 
   taxes Tax[]
 
@@ -58,7 +59,7 @@ model Tax {
   taxDetails                      TaxDetail[]
   lastCheckedPayments             DateTime             @default(now())
   lastCheckedUpdates              DateTime             @default(now())
-  deliveryMethod                  DeliveryMethodNamed?
+  deliveryMethod                  DeliveryMethodNamed? // Delivery method for the given tax.
   bloomreachUnpaidTaxReminderSent Boolean              @default(false)
 
   @@unique([taxPayerId, year])

--- a/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
+++ b/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
@@ -27,7 +27,7 @@ import * as taxDetailHelper from '../utils/tax-detail.helper'
 
 jest.mock('../utils/tax-detail.helper')
 
-describe('TasksService', () => {
+describe('AdminService', () => {
   let service: AdminService
 
   let prismaMock: PrismaService
@@ -125,7 +125,6 @@ describe('TasksService', () => {
         '001234/567': { deliveryMethod: DeliveryMethod.EDESK },
         '000123/890': { deliveryMethod: DeliveryMethod.EDESK },
       }
-      const updateManySpy = jest.spyOn(prismaMock['taxPayer'], 'updateMany')
 
       await service.updateDeliveryMethodsInNoris({
         data: mockData,
@@ -144,23 +143,6 @@ describe('TasksService', () => {
           date: null,
         },
       ])
-
-      expect(updateManySpy).toHaveBeenCalledTimes(1)
-      expect(updateManySpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { birthNumber: { in: ['001234/567', '000123/890'] } },
-          data: {
-            deliveryMethod: DeliveryMethodNamed.EDESK,
-          },
-        }),
-      )
-      expect(updateManySpy).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: {
-            deliveryMethod: DeliveryMethodNamed.POSTAL,
-          },
-        }),
-      )
     })
 
     it('should handle empty input data', async () => {
@@ -237,47 +219,6 @@ describe('TasksService', () => {
       expect(
         service['norisService'].updateDeliveryMethods,
       ).not.toHaveBeenCalled()
-    })
-
-    it('should update delivery methods in database as well', async () => {
-      const mockData: RequestUpdateNorisDeliveryMethodsData = {
-        '123456/789': { deliveryMethod: DeliveryMethod.EDESK },
-        '234567/890': { deliveryMethod: DeliveryMethod.EDESK },
-        '345678/901': { deliveryMethod: DeliveryMethod.POSTAL },
-        '345678/902': { deliveryMethod: DeliveryMethod.POSTAL },
-        '456789/0123': {
-          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
-          date: mockDate1,
-        },
-        '456789/0103': {
-          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
-          date: mockDate2,
-        },
-      }
-
-      const updateManySpy = jest.spyOn(prismaMock['taxPayer'], 'updateMany')
-
-      await service.updateDeliveryMethodsInNoris({
-        data: mockData,
-      })
-
-      expect(updateManySpy).toHaveBeenCalledTimes(3)
-      expect(updateManySpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { birthNumber: { in: ['123456/789', '234567/890'] } },
-          data: {
-            deliveryMethod: DeliveryMethodNamed.EDESK,
-          },
-        }),
-      )
-      expect(updateManySpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { birthNumber: { in: ['345678/901', '345678/902'] } },
-          data: {
-            deliveryMethod: DeliveryMethodNamed.POSTAL,
-          },
-        }),
-      )
     })
   })
 
@@ -643,6 +584,9 @@ describe('TasksService', () => {
           mockData,
           2025,
           mockTransaction,
+          {
+            taxDeliveryMethodAtLockDate: DeliveryMethodNamed.EDESK,
+          } as ResponseUserByBirthNumberDto,
         ),
       ).rejects.toThrow(mockError)
     })
@@ -706,6 +650,9 @@ describe('TasksService', () => {
         mockData,
         2025,
         mockTransaction,
+        {
+          taxDeliveryMethodAtLockDate: DeliveryMethodNamed.EDESK,
+        } as ResponseUserByBirthNumberDto,
       )
       expect(result).toEqual(mockTaxPayer)
 

--- a/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
+++ b/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
@@ -354,12 +354,10 @@ describe('TasksService', () => {
         {
           ICO_RC: '123456/789',
           dan_spolu: '1000',
-          delivery_method: DeliveryMethod.EDESK,
         },
         {
           ICO_RC: '123456/9999',
           dan_spolu: '1000',
-          delivery_method: DeliveryMethod.EDESK,
         },
       ] as NorisTaxPayersDto[]
 
@@ -399,12 +397,10 @@ describe('TasksService', () => {
         {
           ICO_RC: '123456/789',
           dan_spolu: '1000',
-          delivery_method: DeliveryMethod.EDESK,
         },
         {
           ICO_RC: '123456/777',
           dan_spolu: '100',
-          delivery_method: DeliveryMethod.CITY_ACCOUNT,
         },
       ] as NorisTaxPayersDto[]
 
@@ -449,17 +445,14 @@ describe('TasksService', () => {
         {
           ICO_RC: '123456/789',
           dan_spolu: '1000',
-          delivery_method: DeliveryMethod.EDESK,
         },
         {
           ICO_RC: '123456/777',
           dan_spolu: '100',
-          delivery_method: DeliveryMethod.CITY_ACCOUNT,
         },
         {
           ICO_RC: '123456/888',
           dan_spolu: '100',
-          delivery_method: DeliveryMethod.CITY_ACCOUNT,
         },
       ] as NorisTaxPayersDto[]
 
@@ -516,12 +509,10 @@ describe('TasksService', () => {
         {
           ICO_RC: '123456/789',
           dan_spolu: '1000',
-          delivery_method: DeliveryMethod.EDESK,
         },
         {
           ICO_RC: '123456/777',
           dan_spolu: '100',
-          delivery_method: DeliveryMethod.CITY_ACCOUNT,
         },
       ] as NorisTaxPayersDto[]
 
@@ -566,7 +557,6 @@ describe('TasksService', () => {
       const mockData: NorisTaxPayersDto = {
         ICO_RC: '123456/789',
         dan_spolu: '1000',
-        delivery_method: DeliveryMethod.EDESK,
         cislo_poradace: '123456',
         variabilny_symbol: 'VS123',
         dan_pozemky: '200',
@@ -596,7 +586,6 @@ describe('TasksService', () => {
       const mockData: NorisTaxPayersDto = {
         ICO_RC: '123456/789',
         dan_spolu: '1000',
-        delivery_method: DeliveryMethod.EDESK,
         cislo_poradace: '123456',
         variabilny_symbol: 'VS123',
         dan_pozemky: '200',

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -22,7 +22,6 @@ import { QrCodeSubservice } from '../utils/subservices/qrcode.subservice'
 import {
   TaxIdVariableSymbolYear,
   TaxWithTaxPayer,
-  transformDeliveryMethodToDatabaseType,
 } from '../utils/types/types.prisma'
 import {
   NorisRequestGeneral,

--- a/nest-tax-backend/src/admin/utils/testing-tax-mock.ts
+++ b/nest-tax-backend/src/admin/utils/testing-tax-mock.ts
@@ -144,8 +144,5 @@ export const createTestingTaxMock = (
 
     // user type
     TYP_USER: 'FO',
-
-    // delivery method
-    delivery_method: norisData.deliveryMethod,
   }
 }

--- a/nest-tax-backend/src/noris/__tests__/noris.service.spec.ts
+++ b/nest-tax-backend/src/noris/__tests__/noris.service.spec.ts
@@ -87,6 +87,46 @@ describe('NorisService', () => {
       expect(closeSpy).toHaveBeenCalledTimes(1)
     })
 
+    it('should map POSTAL to EDESK', async () => {
+      const requestSpy = jest.spyOn(mssql, 'Request')
+      const querySpy = jest.spyOn(mockRequest, 'query')
+      const closeSpy = jest.spyOn(mockConnection, 'close')
+      const inputQuerySpy = jest.spyOn(mockRequest, 'input')
+
+      await service.updateDeliveryMethods([
+        {
+          birthNumbers: ['003322/4455', '003322/4456'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.POSTAL,
+          date: null,
+        },
+        {
+          birthNumbers: ['003322/4455', '003322/4456'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.EDESK,
+          date: null,
+        },
+        {
+          birthNumbers: ['003322/4455', '003322/4456'],
+          inCityAccount: IsInCityAccount.YES,
+          deliveryMethod: DeliveryMethod.CITY_ACCOUNT,
+          date: '2024-01-01',
+        },
+      ])
+
+      expect(requestSpy).toHaveBeenCalledTimes(3)
+      expect(querySpy).toHaveBeenCalledTimes(3)
+      expect(closeSpy).toHaveBeenCalledTimes(1)
+      expect(inputQuerySpy).not.toHaveBeenCalledWith(
+        'dkba_sposob_dorucovania',
+        DeliveryMethod.POSTAL,
+      )
+      expect(inputQuerySpy).toHaveBeenCalledWith(
+        'dkba_sposob_dorucovania',
+        DeliveryMethod.EDESK,
+      )
+    })
+
     it('should throw if something throws', async () => {
       jest.spyOn(mssql, 'Request').mockImplementation(() => {
         throw new Error('mock-error')

--- a/nest-tax-backend/src/noris/noris.dto.ts
+++ b/nest-tax-backend/src/noris/noris.dto.ts
@@ -1,5 +1,3 @@
-import { DeliveryMethod } from './noris.types'
-
 export interface NorisTaxPayersDto {
   adresa_tp_sidlo: string
   sposob_dorucenia: string
@@ -100,7 +98,6 @@ export interface NorisTaxPayersDto {
   uzivatelsky_atribut: string
   uhrazeno: string
   zbyva_uhradit: string
-  delivery_method: DeliveryMethod | null
 }
 
 export interface NorisPaymentsDto {

--- a/nest-tax-backend/src/noris/noris.queries.ts
+++ b/nest-tax-backend/src/noris/noris.queries.ts
@@ -183,9 +183,7 @@ SELECT
         left(replace (cast(floor( ( view_doklad_saldo.zbyva_uhradit  ) ) as varchar), '.', ''), len(replace (cast(floor( (  view_doklad_saldo.zbyva_uhradit  ) ) as varchar), '.', ''))-2) pouk_cena_bez_hal, 
         right(replace (cast(( ( view_doklad_saldo.zbyva_uhradit  ) ) as varchar), '.', ''), 2) pouk_cena_hal,     
     lcs.dane21_doklad.specificky_symbol,
-    lcs.nf_valuace_atributu(21276, 0, 'lcs.dane21_doklad.uzivatelsky_atribut', lcs.dane21_doklad.uzivatelsky_atribut) as uzivatelsky_atribut,
-    uda_21_organizacia_mag.dkba_sposob_dorucovania as delivery_method
-
+    lcs.nf_valuace_atributu(21276, 0, 'lcs.dane21_doklad.uzivatelsky_atribut', lcs.dane21_doklad.uzivatelsky_atribut) as uzivatelsky_atribut
 FROM 
     lcs.dane21_doklad  
 

--- a/nest-tax-backend/src/noris/noris.service.ts
+++ b/nest-tax-backend/src/noris/noris.service.ts
@@ -171,7 +171,6 @@ export class NorisService {
     return norisData.recordset
   }
 
-  // TODO - test that in input it does not call with POSTAL but mapped to EDESK
   async updateDeliveryMethods(
     data: UpdateNorisDeliveryMethods[],
   ): Promise<void> {

--- a/nest-tax-backend/src/noris/noris.service.ts
+++ b/nest-tax-backend/src/noris/noris.service.ts
@@ -17,6 +17,7 @@ import {
   setDeliveryMethodsForUser,
 } from './noris.queries'
 import { UpdateNorisDeliveryMethods } from './noris.types'
+import { mapDeliveryMethodToNoris } from './utils/noris.helper'
 
 @Injectable()
 export class NorisService {
@@ -170,6 +171,7 @@ export class NorisService {
     return norisData.recordset
   }
 
+  // TODO - test that in input it does not call with POSTAL but mapped to EDESK
   async updateDeliveryMethods(
     data: UpdateNorisDeliveryMethods[],
   ): Promise<void> {
@@ -198,7 +200,10 @@ export class NorisService {
             'dkba_datum_suhlasu',
             dataItem.date ? new Date(dataItem.date) : null,
           )
-          request.input('dkba_sposob_dorucovania', dataItem.deliveryMethod)
+          request.input(
+            'dkba_sposob_dorucovania',
+            mapDeliveryMethodToNoris(dataItem.deliveryMethod),
+          )
 
           const birthNumberPlaceholders = dataItem.birthNumbers
             .map((_, index) => `@birthnumber${index}`)

--- a/nest-tax-backend/src/noris/noris.types.ts
+++ b/nest-tax-backend/src/noris/noris.types.ts
@@ -9,6 +9,12 @@ export enum DeliveryMethod {
   POSTAL = 'P', // postal
 }
 
+// In Noris, postal delivery method should be saved as 'E', same as eDesk. This comes as a requirement from the Noris system.
+export enum DeliveryMethodNoris {
+  EDESK = DeliveryMethod.EDESK,
+  CITY_ACCOUNT = DeliveryMethod.CITY_ACCOUNT,
+}
+
 export interface UpdateNorisDeliveryMethods {
   birthNumbers: string[]
   inCityAccount: IsInCityAccount

--- a/nest-tax-backend/src/noris/utils/__tests__/noris.helper.spec.ts
+++ b/nest-tax-backend/src/noris/utils/__tests__/noris.helper.spec.ts
@@ -1,0 +1,32 @@
+import { DeliveryMethod, DeliveryMethodNoris } from '../../noris.types'
+import { mapDeliveryMethodToNoris } from '../noris.helper'
+
+describe('mapDeliveryMethodToNoris', () => {
+  it('should map CITY_ACCOUNT to CITY_ACCOUNT', () => {
+    expect(mapDeliveryMethodToNoris(DeliveryMethod.CITY_ACCOUNT)).toBe(
+      DeliveryMethodNoris.CITY_ACCOUNT,
+    )
+  })
+
+  it('should map EDESK to EDESK', () => {
+    expect(mapDeliveryMethodToNoris(DeliveryMethod.EDESK)).toBe(
+      DeliveryMethodNoris.EDESK,
+    )
+  })
+
+  it('should map POSTAL to EDESK', () => {
+    expect(mapDeliveryMethodToNoris(DeliveryMethod.POSTAL)).toBe(
+      DeliveryMethodNoris.EDESK,
+    )
+  })
+
+  it('should return null for null input', () => {
+    expect(mapDeliveryMethodToNoris(null)).toBeNull()
+  })
+
+  it('should throw an error for unknown delivery method', () => {
+    expect(() => mapDeliveryMethodToNoris('UNKNOWN' as any)).toThrow(
+      'Unknown delivery method: UNKNOWN',
+    )
+  })
+})

--- a/nest-tax-backend/src/noris/utils/noris.helper.ts
+++ b/nest-tax-backend/src/noris/utils/noris.helper.ts
@@ -1,0 +1,19 @@
+import { DeliveryMethod, DeliveryMethodNoris } from '../noris.types'
+
+export const mapDeliveryMethodToNoris = (
+  deliveryMethod: DeliveryMethod | null,
+): DeliveryMethodNoris | null => {
+  if (deliveryMethod === null) return null
+
+  const mapping: Record<DeliveryMethod, DeliveryMethodNoris> = {
+    [DeliveryMethod.EDESK]: DeliveryMethodNoris.EDESK,
+    [DeliveryMethod.CITY_ACCOUNT]: DeliveryMethodNoris.CITY_ACCOUNT,
+    [DeliveryMethod.POSTAL]: DeliveryMethodNoris.EDESK, // Postal maps to EDESK ('E')
+  }
+
+  const norisMethod = mapping[deliveryMethod]
+  if (!norisMethod) {
+    throw new Error(`Unknown delivery method: ${deliveryMethod}`)
+  }
+  return norisMethod
+}

--- a/nest-tax-backend/src/noris/utils/noris.helper.ts
+++ b/nest-tax-backend/src/noris/utils/noris.helper.ts
@@ -8,7 +8,7 @@ export const mapDeliveryMethodToNoris = (
   const mapping: Record<DeliveryMethod, DeliveryMethodNoris> = {
     [DeliveryMethod.EDESK]: DeliveryMethodNoris.EDESK,
     [DeliveryMethod.CITY_ACCOUNT]: DeliveryMethodNoris.CITY_ACCOUNT,
-    [DeliveryMethod.POSTAL]: DeliveryMethodNoris.EDESK, // Postal maps to EDESK ('E')
+    [DeliveryMethod.POSTAL]: DeliveryMethodNoris.EDESK, // Postal is saved in Noris as EDESK ('E')
   }
 
   const norisMethod = mapping[deliveryMethod]

--- a/nest-tax-backend/src/utils/types/types.prisma.ts
+++ b/nest-tax-backend/src/utils/types/types.prisma.ts
@@ -1,6 +1,4 @@
-import { DeliveryMethodNamed, Prisma } from '@prisma/client'
-
-import { DeliveryMethod } from '../../noris/noris.types'
+import { Prisma } from '@prisma/client'
 
 export type TaxPaymentWithTaxYear = Prisma.TaxPaymentGetPayload<{
   include: {
@@ -25,21 +23,3 @@ export type TaxIdVariableSymbolYear = Prisma.TaxGetPayload<{
     year: true
   }
 }>
-
-export const transformDeliveryMethodToDatabaseType = (
-  deliveryMethod: DeliveryMethod | null,
-): DeliveryMethodNamed | null => {
-  switch (deliveryMethod) {
-    case DeliveryMethod.EDESK:
-      return DeliveryMethodNamed.EDESK
-
-    case DeliveryMethod.CITY_ACCOUNT:
-      return DeliveryMethodNamed.CITY_ACCOUNT
-
-    case DeliveryMethod.POSTAL:
-      return DeliveryMethodNamed.POSTAL
-
-    default:
-      return null
-  }
-}

--- a/openapi-clients/city-account/api.ts
+++ b/openapi-clients/city-account/api.ts
@@ -544,7 +544,21 @@ export interface ResponseUserByBirthNumberDto {
    * Tier from cognito
    */
   cognitoAttributes?: object
+  /**
+   * Delivery method for tax documents at lock date
+   */
+  taxDeliveryMethodAtLockDate?: ResponseUserByBirthNumberDtoTaxDeliveryMethodAtLockDateEnum | null
 }
+
+export const ResponseUserByBirthNumberDtoTaxDeliveryMethodAtLockDateEnum = {
+  Edesk: 'EDESK',
+  CityAccount: 'CITY_ACCOUNT',
+  Postal: 'POSTAL',
+} as const
+
+export type ResponseUserByBirthNumberDtoTaxDeliveryMethodAtLockDateEnum =
+  (typeof ResponseUserByBirthNumberDtoTaxDeliveryMethodAtLockDateEnum)[keyof typeof ResponseUserByBirthNumberDtoTaxDeliveryMethodAtLockDateEnum]
+
 export interface ResponseUserDataBasicDto {
   /**
    * Local ID of user

--- a/openapi-clients/city-account/base.ts
+++ b/openapi-clients/city-account/base.ts
@@ -18,7 +18,7 @@ import type { Configuration } from './configuration'
 import type { AxiosPromise, AxiosInstance, RawAxiosRequestConfig } from 'axios'
 import globalAxios from 'axios'
 
-export const BASE_PATH = 'http://localhost:3300'.replace(/\/+$/, '')
+export const BASE_PATH = 'http://localhost:3000'.replace(/\/+$/, '')
 
 export const COLLECTION_FORMATS = {
   csv: ',',


### PR DESCRIPTION
https://github.com/bratislava/private-konto.bratislava.sk/issues/866

We must save `POSTAL` as `EDESK` in Noris, as it was requested by tax administrators.

No migration has to be performed, since new delivery methods will be updated next year, and there will correctly be EDESK in place of POSTAL.