### PR TITLE
79 - Refactor sendToNasesAndUpdateState

### DIFF
--- a/nest-forms-backend/src/nases-consumer/nases-consumer.module.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common'
 import UserInfoPipeModule from '../auth/decorators/user-info-pipe.module'
 import ClientsModule from '../clients/clients.module'
 import ConvertModule from '../convert/convert.module'
+import ConvertPdfModule from '../convert-pdf/convert-pdf.module'
 import FormValidatorRegistryModule from '../form-validator-registry/form-validator-registry.module'
 import FormsModule from '../forms/forms.module'
 import GinisModule from '../ginis/ginis.module'
@@ -29,6 +30,7 @@ import WebhookSubservice from './subservices/webhook.subservice'
     FormValidatorRegistryModule,
     ClientsModule,
     UserInfoPipeModule,
+    ConvertPdfModule,
   ],
   providers: [
     NasesConsumerService,

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.module.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.module.ts
@@ -3,7 +3,6 @@ import { Module } from '@nestjs/common'
 import UserInfoPipeModule from '../auth/decorators/user-info-pipe.module'
 import ClientsModule from '../clients/clients.module'
 import ConvertModule from '../convert/convert.module'
-import ConvertPdfModule from '../convert-pdf/convert-pdf.module'
 import FormValidatorRegistryModule from '../form-validator-registry/form-validator-registry.module'
 import FormsModule from '../forms/forms.module'
 import GinisModule from '../ginis/ginis.module'
@@ -26,7 +25,6 @@ import WebhookSubservice from './subservices/webhook.subservice'
     FormsModule,
     GinisModule,
     ConvertModule,
-    ConvertPdfModule,
     TaxModule,
     FormValidatorRegistryModule,
     ClientsModule,

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.module.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.module.ts
@@ -4,7 +4,6 @@ import UserInfoPipeModule from '../auth/decorators/user-info-pipe.module'
 import ClientsModule from '../clients/clients.module'
 import ConvertModule from '../convert/convert.module'
 import ConvertPdfModule from '../convert-pdf/convert-pdf.module'
-import FilesModule from '../files/files.module'
 import FormValidatorRegistryModule from '../form-validator-registry/form-validator-registry.module'
 import FormsModule from '../forms/forms.module'
 import GinisModule from '../ginis/ginis.module'
@@ -25,7 +24,6 @@ import WebhookSubservice from './subservices/webhook.subservice'
   imports: [
     RabbitmqClientModule,
     FormsModule,
-    FilesModule,
     GinisModule,
     ConvertModule,
     ConvertPdfModule,

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
@@ -10,7 +10,6 @@ import {
 import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinitionBySlug'
 
 import ConvertPdfService from '../convert-pdf/convert-pdf.service'
-import FilesService from '../files/files.service'
 import FormsService from '../forms/forms.service'
 import {
   SendMessageNasesSender,
@@ -56,7 +55,6 @@ describe('NasesConsumerService', () => {
           useValue: createMock<RabbitmqClientService>(),
         },
         { provide: FormsService, useValue: createMock<FormsService>() },
-        { provide: FilesService, useValue: createMock<FilesService>() },
         { provide: MailgunService, useValue: createMock<MailgunService>() },
         {
           provide: ConvertPdfService,

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.service.spec.ts
@@ -9,6 +9,7 @@ import {
 } from 'forms-shared/definitions/formDefinitionTypes'
 import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinitionBySlug'
 
+import ConvertPdfService from '../convert-pdf/convert-pdf.service'
 import FormsService from '../forms/forms.service'
 import NasesService from '../nases/nases.service'
 import {
@@ -66,6 +67,10 @@ describe('NasesConsumerService', () => {
         },
         { provide: PrismaService, useValue: createMock<PrismaService>() },
         { provide: NasesService, useValue: createMock<NasesService>() },
+        {
+          provide: ConvertPdfService,
+          useValue: createMock<ConvertPdfService>(),
+        },
       ],
     }).compile()
 
@@ -187,7 +192,7 @@ describe('NasesConsumerService', () => {
         .mockResolvedValue(new Nack(false))
       const sendToNasesAndUpdateStateSpy = jest
         .spyOn(nasesService, 'sendToNasesAndUpdateState')
-        .mockResolvedValue(true)
+        .mockResolvedValue()
 
       const result = await service.onQueueConsumption(mockRabbitPayloadDto)
 
@@ -211,7 +216,7 @@ describe('NasesConsumerService', () => {
         .mockResolvedValue(new Nack(false))
       const sendToNasesAndUpdateStateSpy = jest
         .spyOn(nasesService, 'sendToNasesAndUpdateState')
-        .mockResolvedValue(true)
+        .mockResolvedValue()
 
       const result = await service.onQueueConsumption(mockRabbitPayloadDto)
 
@@ -232,9 +237,7 @@ describe('NasesConsumerService', () => {
       jest
         .spyOn(service['nasesUtilsService'], 'createTechnicalAccountJwtToken')
         .mockReturnValue('mock-jwt')
-      jest
-        .spyOn(nasesService, 'sendToNasesAndUpdateState')
-        .mockResolvedValue(true)
+      jest.spyOn(nasesService, 'sendToNasesAndUpdateState').mockResolvedValue()
 
       const result = await service.onQueueConsumption(mockRabbitPayloadDto)
 
@@ -243,7 +246,6 @@ describe('NasesConsumerService', () => {
         'mock-jwt',
         mockForm,
         mockRabbitPayloadDto,
-        mockFormDefinition,
         mockSender,
       )
       expect(service['mailgunService'].sendEmail).toHaveBeenCalled()
@@ -263,7 +265,7 @@ describe('NasesConsumerService', () => {
         .mockReturnValue('mock-jwt')
       jest
         .spyOn(nasesService, 'sendToNasesAndUpdateState')
-        .mockResolvedValue(false)
+        .mockRejectedValue(new Error('Nases error'))
       jest.spyOn(service as any, 'queueDelayedForm').mockResolvedValue(null)
 
       const result = await service.onQueueConsumption(mockRabbitPayloadDto)
@@ -293,7 +295,7 @@ describe('NasesConsumerService', () => {
         .mockReturnValue('mock-jwt')
       jest
         .spyOn(nasesService, 'sendToNasesAndUpdateState')
-        .mockResolvedValue(false)
+        .mockRejectedValue(new Error('Nases error'))
       jest.spyOn(service, 'nackTrueWithWait').mockResolvedValue(new Nack(true))
 
       const result = await service.onQueueConsumption(mockPayload)

--- a/nest-forms-backend/src/nases-consumer/nases-consumer.service.ts
+++ b/nest-forms-backend/src/nases-consumer/nases-consumer.service.ts
@@ -14,7 +14,6 @@ import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinit
 import { extractFormSubjectPlain } from 'forms-shared/form-utils/formDataExtractors'
 
 import ConvertPdfService from '../convert-pdf/convert-pdf.service'
-import FilesService from '../files/files.service'
 import { FormUpdateBodyDto } from '../forms/dtos/forms.requests.dto'
 import { FormsErrorsResponseEnum } from '../forms/forms.errors.enum'
 import FormsService from '../forms/forms.service'
@@ -46,7 +45,6 @@ export default class NasesConsumerService {
     private readonly nasesUtilsService: NasesUtilsService,
     private readonly rabbitmqClientService: RabbitmqClientService,
     private readonly formsService: FormsService,
-    private readonly filesService: FilesService,
     private readonly mailgunService: MailgunService,
     private readonly convertPdfService: ConvertPdfService,
     private readonly emailFormsSubservice: EmailFormsSubservice,

--- a/nest-forms-backend/src/nases/nases.errors.enum.ts
+++ b/nest-forms-backend/src/nases/nases.errors.enum.ts
@@ -13,6 +13,8 @@ export enum NasesErrorsEnum {
   FORM_VERSION_NOT_COMPATIBLE = 'FORM_VERSION_NOT_COMPATIBLE',
   SEND_POLICY_NOT_POSSIBLE = 'SEND_POLICY_NOT_POSSIBLE',
   SEND_POLICY_NOT_ALLOWED_FOR_USER = 'SEND_POLICY_NOT_ALLOWED_FOR_USER',
+  UNABLE_SEND_FORM_TO_NASES = 'UNABLE_SEND_FORM_TO_NASES',
+  SEND_TO_GINIS_ERROR = 'SEND_TO_GINIS_ERROR',
 }
 
 export enum NasesErrorsResponseEnum {
@@ -30,6 +32,8 @@ export enum NasesErrorsResponseEnum {
   FORM_VERSION_NOT_COMPATIBLE = 'Form version is not compatible for sending.',
   SEND_POLICY_NOT_POSSIBLE = 'Sending is not possible for this form.',
   SEND_POLICY_NOT_ALLOWED_FOR_USER = 'Sending is not allowed for this user.',
+  UNABLE_SEND_FORM_TO_NASES = 'Unable to send form to NASES.',
+  SEND_TO_GINIS_ERROR = 'There was an error when sending to Ginis.',
 }
 
 export enum NasesErrorCodesEnum {

--- a/nest-forms-backend/src/nases/nases.module.ts
+++ b/nest-forms-backend/src/nases/nases.module.ts
@@ -12,7 +12,6 @@ import FormValidatorRegistryModule from '../form-validator-registry/form-validat
 import FormsHelper from '../forms/forms.helper'
 import FormsModule from '../forms/forms.module'
 import { FormsV2Module } from '../forms-v2/forms-v2.module'
-import NasesConsumerModule from '../nases-consumer/nases-consumer.module'
 import PrismaModule from '../prisma/prisma.module'
 import RabbitmqClientModule from '../rabbitmq-client/rabbitmq-client.module'
 import ScannerClientService from '../scanner-client/scanner-client.service'
@@ -30,7 +29,6 @@ import NasesUtilsService from './utils-services/tokens.nases.service'
     FormsModule,
     RabbitmqClientModule,
     FilesModule,
-    NasesConsumerModule,
     ConvertModule,
     TaxModule,
     ConvertPdfModule,

--- a/nest-forms-backend/src/nases/nases.service.spec.ts
+++ b/nest-forms-backend/src/nases/nases.service.spec.ts
@@ -332,7 +332,7 @@ describe('NasesService', () => {
       )
     })
 
-    it('should throw if sending to GINIS throws', async () => {
+    it('should just log if sending to GINIS throws', async () => {
       jest
         .spyOn(service['formsService'], 'checkFormBeforeSending')
         .mockResolvedValue({
@@ -364,12 +364,11 @@ describe('NasesService', () => {
         .spyOn(service['rabbitmqClientService'], 'publishToGinis')
         .mockRejectedValue(new Error('Ginis error'))
 
-      await expect(
-        service.sendFormEid('1', 'mock-obo-token', mockUser, authUser.user),
-      ).rejects.toThrow()
+      await service.sendFormEid('1', 'mock-obo-token', mockUser, authUser.user)
+
       expect(sendToNasesSpy).toHaveBeenCalled()
       expect(publishToGinisSpy).toHaveBeenCalled()
-      expect(service['logger'].error).not.toHaveBeenCalled() // It throws, not logs
+      expect(service['logger'].error).toHaveBeenCalled()
       expect(updateSpy).toHaveBeenCalledWith(
         '1',
         expect.objectContaining({

--- a/nest-forms-backend/src/nases/nases.service.ts
+++ b/nest-forms-backend/src/nases/nases.service.ts
@@ -262,13 +262,6 @@ export default class NasesService {
       )
     }
 
-    if (isSlovenskoSkFormDefinition(formDefinition)) {
-      await this.convertPdfService.createPdfImageInFormFiles(
-        formId,
-        formDefinition,
-      )
-    }
-
     this.checkAttachments(
       await this.filesService.areFormAttachmentsReady(formId),
     )
@@ -486,7 +479,7 @@ export default class NasesService {
         error: FormError.NASES_SEND_ERROR,
       })
 
-      // TODO temp SEND_TO_NASES_ERROR log, remove
+      // TODO temp SEND_TO_NASES_ERROR log, remove. Should this be removed?
       this.logger.log(
         `SEND_TO_NASES_ERROR: ${NasesErrorsResponseEnum.SEND_TO_NASES_ERROR} additional info - formId: ${form.id}, formSignature from db: ${JSON.stringify(
           form.formSignature,
@@ -513,6 +506,8 @@ export default class NasesService {
         throw this.throwerErrorGuard.InternalServerErrorException(
           NasesErrorsEnum.SEND_TO_GINIS_ERROR,
           `${NasesErrorsResponseEnum.SEND_TO_GINIS_ERROR} Received form id: ${data.formId}.`,
+          undefined,
+          error,
         )
       }
     }

--- a/nest-forms-backend/src/nases/nases.service.ts
+++ b/nest-forms-backend/src/nases/nases.service.ts
@@ -497,11 +497,14 @@ export default class NasesService {
           userData: data.userData,
         })
       } catch (error) {
-        throw this.throwerErrorGuard.InternalServerErrorException(
-          NasesErrorsEnum.SEND_TO_GINIS_ERROR,
-          `${NasesErrorsResponseEnum.SEND_TO_GINIS_ERROR} Received form id: ${data.formId}.`,
-          undefined,
-          error,
+        // We do not want to show the user error when the submission was already delivered to Nases. Therefore Ginis errors should only be logged for us.
+        this.logger.error(
+          this.throwerErrorGuard.InternalServerErrorException(
+            NasesErrorsEnum.SEND_TO_GINIS_ERROR,
+            `${NasesErrorsResponseEnum.SEND_TO_GINIS_ERROR} Received form id: ${data.formId}.`,
+            undefined,
+            error,
+          ),
         )
       }
     }

--- a/nest-forms-backend/src/nases/nases.service.ts
+++ b/nest-forms-backend/src/nases/nases.service.ts
@@ -473,12 +473,6 @@ export default class NasesService {
     } catch (error) {
       this.logger.error(`Error sending form to nases.`, error)
 
-      // TODO: It would be better to rewrite how sendToNasesAndUpdateState works or use a different function
-      await this.formsService.updateForm(data.formId, {
-        state: FormState.DRAFT,
-        error: FormError.NASES_SEND_ERROR,
-      })
-
       // TODO temp SEND_TO_NASES_ERROR log, remove. Should this be removed?
       this.logger.log(
         `SEND_TO_NASES_ERROR: ${NasesErrorsResponseEnum.SEND_TO_NASES_ERROR} additional info - formId: ${form.id}, formSignature from db: ${JSON.stringify(
@@ -553,6 +547,11 @@ export default class NasesService {
     )
 
     if ((sendData && sendData.status !== 200) || !sendData) {
+      await this.formsService.updateForm(data.formId, {
+        state: FormState.DRAFT,
+        error: FormError.NASES_SEND_ERROR,
+      })
+
       throw this.throwerErrorGuard.InternalServerErrorException(
         NasesErrorsEnum.UNABLE_SEND_FORM_TO_NASES,
         `${NasesErrorsResponseEnum.UNABLE_SEND_FORM_TO_NASES} Received form id: ${

--- a/nest-forms-backend/src/nases/nases.service.ts
+++ b/nest-forms-backend/src/nases/nases.service.ts
@@ -473,7 +473,7 @@ export default class NasesService {
     } catch (error) {
       this.logger.error(`Error sending form to nases.`, error)
 
-      // TODO temp SEND_TO_NASES_ERROR log, remove. Should this be removed?
+      // TODO temp SEND_TO_NASES_ERROR log, remove.
       this.logger.log(
         `SEND_TO_NASES_ERROR: ${NasesErrorsResponseEnum.SEND_TO_NASES_ERROR} additional info - formId: ${form.id}, formSignature from db: ${JSON.stringify(
           form.formSignature,

--- a/nest-forms-backend/src/nases/nases.service.ts
+++ b/nest-forms-backend/src/nases/nases.service.ts
@@ -540,6 +540,7 @@ export default class NasesService {
     sender: SendMessageNasesSender,
     additionalFormUpdates?: FormUpdateBodyDto,
   ): Promise<void> {
+    // sendMessageNases is implemented in a way that it does not throw. Therefore this is not in try-catch block.
     const sendData = await this.nasesUtilsService.sendMessageNases(
       jwt,
       form,

--- a/nest-forms-backend/src/utils/constants/error.alerts.ts
+++ b/nest-forms-backend/src/utils/constants/error.alerts.ts
@@ -23,6 +23,7 @@ export default [
   NasesErrorsEnum.UNABLE_ADD_FORM_TO_RABBIT,
   NasesErrorsEnum.CITY_ACCOUNT_USER_GET_ERROR,
   NasesErrorsEnum.SEND_TO_NASES_ERROR,
+  NasesErrorsEnum.SEND_TO_GINIS_ERROR,
   ScannerClientErrorsEnum.PROBLEM_WITH_SCANNER,
   ScannerClientErrorsEnum.FILE_HAS_WRONG_PARAMETERS,
   ScannerClientErrorsEnum.FILE_IN_SCANNER_NOT_FOUND,


### PR DESCRIPTION
https://github.com/bratislava/private-konto.bratislava.sk/issues/79

- moved `sendToNasesAndUpdateState` to NasesService instead of NasesConsumer;
- removed generating pdf and sending to Ginis from `sendToNasesAndUpdateState`, so that the function will only send to Nases and accordingly update the form;
- instead of returning boolean, it now returns nothing, and in case of an error it throws. This is for better error handling.