### PR TITLE
Fix: use isAxiosError instead of comparing instances

### DIFF
--- a/nest-city-account/src/bloomreach/bloomreach.service.ts
+++ b/nest-city-account/src/bloomreach/bloomreach.service.ts
@@ -1,6 +1,6 @@
 import { HttpStatus, Injectable } from '@nestjs/common'
 
-import axios, { AxiosError } from 'axios'
+import axios, { isAxiosError } from 'axios'
 
 import {
   GdprCategory,
@@ -217,7 +217,7 @@ export class BloomreachService {
       }
       return AnonymizeResponse.SUCCESS
     } catch (error) {
-      if (error instanceof AxiosError && error.response?.status === HttpStatus.NOT_FOUND) {
+      if (isAxiosError(error) && error.response?.status === HttpStatus.NOT_FOUND) {
         // User not found in bloomreach
         return AnonymizeResponse.NOT_FOUND
       }

--- a/nest-city-account/src/magproxy/magproxy.service.ts
+++ b/nest-city-account/src/magproxy/magproxy.service.ts
@@ -1,5 +1,5 @@
 import { HttpStatus, Injectable } from '@nestjs/common'
-import axios, { AxiosError } from 'axios'
+import axios, { isAxiosError } from 'axios'
 import https from 'https'
 
 import { ResponseRfoPersonDto } from 'openapi-clients/magproxy'
@@ -142,7 +142,7 @@ export class MagproxyService {
       // TODO this validation belongs to magproxy, TODO can be nicer, i.e. don't assume the items are present - leaving like this until OpenAPI rewrite
       return this.validateRfoDataFormat(result?.data?.items)
     } catch (error) {
-      if (!(error instanceof AxiosError)) {
+      if (!isAxiosError(error)) {
         throw this.throwerErrorGuard.InternalServerErrorException(
           ErrorsEnum.INTERNAL_SERVER_ERROR,
           ErrorsResponseEnum.INTERNAL_SERVER_ERROR,

--- a/nest-city-account/src/user-verification/utils/subservice/verification.subservice.ts
+++ b/nest-city-account/src/user-verification/utils/subservice/verification.subservice.ts
@@ -143,8 +143,11 @@ export class VerificationSubservice {
     } catch (error) {
       if (error instanceof HttpException) {
         if (
-          error.getStatus() in
-          [HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.UNPROCESSABLE_ENTITY, HttpStatus.NOT_FOUND]
+          [
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            HttpStatus.UNPROCESSABLE_ENTITY,
+            HttpStatus.NOT_FOUND,
+          ].includes(error.getStatus())
         ) {
           rfoData = {
             statusCode: error.getStatus(),

--- a/nest-clamav-scanner/src/forms-client/forms-client.service.ts
+++ b/nest-clamav-scanner/src/forms-client/forms-client.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
-import { AxiosError, AxiosPromise } from 'axios'
+import { AxiosPromise, isAxiosError } from 'axios'
 import { UpdateFileStatusRequestDtoStatusEnum, UpdateFileStatusResponseDto } from 'openapi-clients/forms'
 
 import ClientsService from '../clients/clients.service'
@@ -59,7 +59,7 @@ export class FormsClientService {
         },
       )
     } catch (error) {
-      if (error instanceof AxiosError && error.response?.status === 404) {
+      if (isAxiosError(error) && error.response?.status === 404) {
         this.logger.error(
           `File not found in forms backend. Removing from DB: ${error.message}`,
         )

--- a/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
+++ b/nest-forms-backend/src/nases/utils-services/tokens.nases.service.ts
@@ -7,7 +7,7 @@ import { Stream } from 'node:stream'
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { Forms } from '@prisma/client'
-import { AxiosError } from 'axios'
+import { isAxiosError } from 'axios'
 import {
   FormDefinitionSlovenskoSk,
   isSlovenskoSkFormDefinition,
@@ -602,7 +602,7 @@ export default class NasesUtilsService {
 
       return { status: 200, data: response.data }
     } catch (error) {
-      if (error instanceof AxiosError && error.response?.data) {
+      if (isAxiosError(error) && error.response?.data) {
         return { status: error.response.status, data: error.response.data }
       }
       // TODO temp SEND_TO_NASES_ERROR log, remove


### PR DESCRIPTION
Since openapi-clients use different instances of `AxiosError`, the comparison using `instanceof` will return `false`, even though it is of type `AxiosError`, but different instance. Because of this we should use `isAxiosError` function from axios.

Also changes `in` to `includes`.