### PR TITLE
Add reduced taxpayer details to tax summary response

### DIFF
--- a/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
+++ b/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
@@ -979,6 +979,71 @@ export class ResponseInstallmentPaymentDetailDto {
   activeInstallment?: ResponseActiveInstallmentDto
 }
 
+export class ResponseTaxPayerReducedDto {
+  @ApiProperty({
+    description: 'Permanent address of tax payer',
+    default: 'Bratislava, Hlavne námestie 1',
+  })
+  @IsString()
+  @IsOptional()
+  permanentResidenceAddress: string | null
+
+  @ApiProperty({
+    description: 'Name of taxpayer',
+    default: 'Bratislavčan Daňový',
+  })
+  @IsString()
+  @IsOptional()
+  name: string | null
+
+  @ApiProperty({
+    description: 'Text of description of name for pdf',
+    default: 'Meno daňovníka/ subjektu',
+  })
+  @IsString()
+  @IsOptional()
+  nameTxt: string | null
+
+  @ApiProperty({
+    description: 'Text of description of street for pdf',
+    default: 'Ulica trvalého pobytu',
+  })
+  @IsString()
+  @IsOptional()
+  permanentResidenceStreetTxt: string | null
+
+  @ApiProperty({
+    description: 'Street of permanent residence with number',
+    default: 'Uršulínska 6 3/6',
+  })
+  @IsString()
+  @IsOptional()
+  permanentResidenceStreet: string | null
+
+  @ApiProperty({
+    description: 'Zip of permanent residence with number',
+    default: '811 01',
+  })
+  @IsString()
+  @IsOptional()
+  permanentResidenceZip: string | null
+
+  @ApiProperty({
+    description: 'City of permanent residence with number',
+    default: 'Bratislava',
+  })
+  @IsString()
+  @IsOptional()
+  permanentResidenceCity: string | null
+
+  @ApiProperty({
+    description: 'Birth number with slash',
+    default: '920101/1111',
+  })
+  @IsString()
+  birthNumber: string
+}
+
 export class ResponseTaxSummaryDetailDto {
   @ApiProperty({ description: 'Total amount paid', example: 150 })
   @IsNumber()
@@ -1032,4 +1097,10 @@ export class ResponseTaxSummaryDetailDto {
   @Type(() => ResponseTaxAdministratorDto)
   @IsOptional()
   taxAdministrator: ResponseTaxAdministratorDto | null
+
+  @ApiProperty({
+    description: 'Tax payer data',
+    type: ResponseTaxPayerReducedDto
+  })
+  taxPayer: ResponseTaxPayerReducedDto
 }

--- a/nest-tax-backend/src/tax/tax.service.ts
+++ b/nest-tax-backend/src/tax/tax.service.ts
@@ -21,6 +21,7 @@ import {
   ResponseInstallmentPaymentDetailDto,
   ResponseOneTimePaymentDetailsDto,
   ResponseTaxDto,
+  ResponseTaxPayerReducedDto,
   ResponseTaxSummaryDetailDto,
 } from './dtos/response.tax.dto'
 import { taxDetailsToPdf, taxTotalsToPdf } from './utils/helpers/pdf.helper'
@@ -320,12 +321,23 @@ export class TaxService {
     }
 
     const { taxAdministrator } = tax.taxPayer
+    const taxPayer: ResponseTaxPayerReducedDto = {
+      birthNumber: tax.taxPayer.birthNumber,
+      name: tax.taxPayer.name,
+      nameTxt: tax.taxPayer.nameTxt,
+      permanentResidenceAddress: tax.taxPayer.permanentResidenceAddress,
+      permanentResidenceCity: tax.taxPayer.permanentResidenceCity,
+      permanentResidenceStreet: tax.taxPayer.permanentResidenceStreet,
+      permanentResidenceStreetTxt: tax.taxPayer.permanentResidenceStreetTxt,
+      permanentResidenceZip: tax.taxPayer.permanentResidenceZip,
+    }
 
     return {
       ...detailWithoutQrCode,
       oneTimePayment,
       installmentPayment,
       taxAdministrator,
+      taxPayer,
     }
   }
 

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -1018,6 +1018,61 @@ export interface ResponseTaxPayerDto {
 /**
  *
  * @export
+ * @interface ResponseTaxPayerReducedDto
+ */
+export interface ResponseTaxPayerReducedDto {
+  /**
+   * Permanent address of tax payer
+   * @type {string}
+   * @memberof ResponseTaxPayerReducedDto
+   */
+  permanentResidenceAddress: string | null
+  /**
+   * Name of taxpayer
+   * @type {string}
+   * @memberof ResponseTaxPayerReducedDto
+   */
+  name: string | null
+  /**
+   * Text of description of name for pdf
+   * @type {string}
+   * @memberof ResponseTaxPayerReducedDto
+   */
+  nameTxt: string | null
+  /**
+   * Text of description of street for pdf
+   * @type {string}
+   * @memberof ResponseTaxPayerReducedDto
+   */
+  permanentResidenceStreetTxt: string | null
+  /**
+   * Street of permanent residence with number
+   * @type {string}
+   * @memberof ResponseTaxPayerReducedDto
+   */
+  permanentResidenceStreet: string | null
+  /**
+   * Zip of permanent residence with number
+   * @type {string}
+   * @memberof ResponseTaxPayerReducedDto
+   */
+  permanentResidenceZip: string | null
+  /**
+   * City of permanent residence with number
+   * @type {string}
+   * @memberof ResponseTaxPayerReducedDto
+   */
+  permanentResidenceCity: string | null
+  /**
+   * Birth number with slash
+   * @type {string}
+   * @memberof ResponseTaxPayerReducedDto
+   */
+  birthNumber: string
+}
+/**
+ *
+ * @export
  * @interface ResponseTaxSummaryDetailDto
  */
 export interface ResponseTaxSummaryDetailDto {
@@ -1063,6 +1118,12 @@ export interface ResponseTaxSummaryDetailDto {
    * @memberof ResponseTaxSummaryDetailDto
    */
   taxAdministrator: ResponseTaxAdministratorDto | null
+  /**
+   * Tax payer data
+   * @type {ResponseTaxPayerReducedDto}
+   * @memberof ResponseTaxSummaryDetailDto
+   */
+  taxPayer: ResponseTaxPayerReducedDto
 }
 /**
  * Type of tax detail - object of tax


### PR DESCRIPTION
### Description

This pull request introduces the `ResponseTaxPayerReducedDto` to supplement `ResponseTaxSummaryDetailDto` with reduced taxpayer details. This addition improves data representation and includes extended information in tax summary responses.