### PR TITLE
Convert `order` field in tax installments to integer

### DIFF
--- a/nest-tax-backend/prisma/migrations/20250813082922_make_installment_order_required/migration.sql
+++ b/nest-tax-backend/prisma/migrations/20250813082922_make_installment_order_required/migration.sql
@@ -12,6 +12,8 @@
 
 */
 
+BEGIN;
+
 -- Convert column type from String to Integer (NULL values convert safely)
 ALTER TABLE "TaxInstallment"
     ALTER COLUMN "order" TYPE INTEGER USING "order"::INTEGER;
@@ -29,3 +31,5 @@ SET "order" = CASE
 -- Make column required now that all rows have valid values
 ALTER TABLE "TaxInstallment"
     ALTER COLUMN "order" SET NOT NULL;
+
+COMMIT;

--- a/nest-tax-backend/prisma/migrations/20250813082922_make_installment_order_required/migration.sql
+++ b/nest-tax-backend/prisma/migrations/20250813082922_make_installment_order_required/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - The `order` column in `TaxInstallment` table is being converted from String to Integer type
+  - All existing NULL values will remain NULL during type conversion
+  - The column will be populated with order values based on installment text patterns:
+    * "prvá splátka" → 1
+    * "druhá splátka" → 2
+    * "tretia splátka" → 3
+    * Other cases → 1 (default)
+  - After data population, the column will be set to NOT NULL
+
+*/
+
+-- Convert column type from String to Integer (NULL values convert safely)
+ALTER TABLE "TaxInstallment"
+    ALTER COLUMN "order" TYPE INTEGER USING "order"::INTEGER;
+
+-- Populate order values based on Slovak installment text patterns
+UPDATE "public"."TaxInstallment"
+SET "order" = CASE
+                  WHEN "text" LIKE '%prvá splátka%' THEN 1
+                  WHEN "text" LIKE '%druhá splátka%' THEN 2
+                  WHEN "text" LIKE '%tretia splátka%' THEN 3
+    -- For texts without installment number specified, default to 1
+                  ELSE 1
+    END;
+
+-- Make column required now that all rows have valid values
+ALTER TABLE "TaxInstallment"
+    ALTER COLUMN "order" SET NOT NULL;

--- a/nest-tax-backend/prisma/schema.prisma
+++ b/nest-tax-backend/prisma/schema.prisma
@@ -88,7 +88,7 @@ model TaxInstallment {
   updatedAt DateTime @default(now()) @updatedAt
   taxId     Int
   tax       Tax      @relation(fields: [taxId], references: [id])
-  order     String?
+  order     Int
   amount    Int
   text      String?
 }

--- a/nest-tax-backend/src/admin/utils/__tests__/admin.helper.spec.ts
+++ b/nest-tax-backend/src/admin/utils/__tests__/admin.helper.spec.ts
@@ -171,6 +171,7 @@ describe('admin.helper', () => {
       expect(result[0]).toEqual({
         taxId: 1,
         amount: 10_000,
+        order: 1,
         text: 'Single Payment',
       })
     })
@@ -192,16 +193,19 @@ describe('admin.helper', () => {
         {
           taxId: 1,
           amount: 3000,
+          order: 1,
           text: 'First Payment',
         },
         {
           taxId: 1,
           amount: 5000,
+          order: 2,
           text: 'Second Payment',
         },
         {
           taxId: 1,
           amount: 2000,
+          order: 3,
           text: 'Third Payment',
         },
       ])

--- a/nest-tax-backend/src/admin/utils/admin.helper.ts
+++ b/nest-tax-backend/src/admin/utils/admin.helper.ts
@@ -69,6 +69,7 @@ export const mapNorisToTaxInstallmentsData = (
       {
         taxId,
         amount: convertCurrencyToInt(data.SPL1),
+        order: 1,
         text: data.TXTSPL1,
       },
     ]
@@ -78,16 +79,19 @@ export const mapNorisToTaxInstallmentsData = (
     {
       taxId,
       amount: convertCurrencyToInt(data.SPL4_1),
+      order: 1,
       text: data.TXTSPL4_1,
     },
     {
       taxId,
       amount: convertCurrencyToInt(data.SPL4_2),
+      order: 2,
       text: data.TXTSPL4_2,
     },
     {
       taxId,
       amount: convertCurrencyToInt(data.SPL4_3),
+      order: 3,
       text: data.TXTSPL4_3,
     },
   ]

--- a/nest-tax-backend/src/tax/tax.service.ts
+++ b/nest-tax-backend/src/tax/tax.service.ts
@@ -135,7 +135,13 @@ export class TaxService {
     }
 
     // hardcoded dates 'text' of installments because they were generated incorrectly in NORIS
-    const taxInstallments = fixInstallmentTexts(tax.taxInstallments, tax.year)
+    const taxInstallments = fixInstallmentTexts(
+      tax.taxInstallments,
+      tax.year,
+    ).map((installment) => ({
+      ...installment,
+      order: installment.order.toString(),
+    }))
 
     const paidStatus = getTaxStatus(tax.amount, paidAmount)
 
@@ -236,7 +242,13 @@ export class TaxService {
     try {
       const user = await this.getTaxByYear(year, birthNumber)
       const taxDetails = taxDetailsToPdf(user.taxDetails)
-      const totals = taxTotalsToPdf(user, user.taxInstallments)
+      const totals = taxTotalsToPdf(
+        user,
+        user.taxInstallments.map((data) => ({
+          ...data,
+          order: data.order ? +data.order : 1,
+        })),
+      )
       return await ejs.renderFile('public/tax-pdf.ejs', {
         user,
         logo: path.resolve('public/logoBaTax.png'),

--- a/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
+++ b/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
@@ -28,9 +28,9 @@ const defaultInput = {
   variableSymbol: '1234567890',
   dateOfValidity: new Date('2025-01-01'),
   installments: [
-    { order: '1', amount: 2200 },
-    { order: '2', amount: 2200 },
-    { order: '3', amount: 2200 },
+    { order: 1, amount: 2200 },
+    { order: 2, amount: 2200 },
+    { order: 3, amount: 2200 },
   ],
   taxDetails: [
     {
@@ -590,9 +590,9 @@ describe('getTaxDetailPureForInstallmentGenerator', () => {
     variableSymbol: '1234567890',
     dateOfValidity: new Date('2025-01-01'),
     installments: [
-      { order: '1', amount: 2200 },
-      { order: '2', amount: 2200 },
-      { order: '3', amount: 2200 },
+      { order: 1, amount: 2200 },
+      { order: 2, amount: 2200 },
+      { order: 3, amount: 2200 },
     ],
     specificSymbol: '2025200000',
     taxPayments: [],

--- a/nest-tax-backend/src/tax/utils/unified-tax.util.ts
+++ b/nest-tax-backend/src/tax/utils/unified-tax.util.ts
@@ -174,9 +174,7 @@ const calculateInstallmentAmounts = (
   }
 
   const amounts = [1, 2, 3].map((order) => {
-    const installment = installments.find(
-      (item) => item.order === order,
-    )
+    const installment = installments.find((item) => item.order === order)
     if (!installment) {
       throw new ThrowerErrorGuard().InternalServerErrorException(
         CustomErrorTaxTypesEnum.MISSING_INSTALLMENT_AMOUNTS,

--- a/nest-tax-backend/src/tax/utils/unified-tax.util.ts
+++ b/nest-tax-backend/src/tax/utils/unified-tax.util.ts
@@ -163,7 +163,7 @@ const calculateDueDate = (dateOfValidity: Dayjs | null): Dayjs | undefined => {
 }
 
 const calculateInstallmentAmounts = (
-  installments: { order: string | null; amount: number }[],
+  installments: { order: number; amount: number }[],
   overallPaid: number,
 ): { toPay: number; paid: number; status: InstallmentPaidStatusEnum }[] => {
   if (installments.length !== 3) {
@@ -175,7 +175,7 @@ const calculateInstallmentAmounts = (
 
   const amounts = [1, 2, 3].map((order) => {
     const installment = installments.find(
-      (item) => item.order === order.toString(),
+      (item) => item.order === order,
     )
     if (!installment) {
       throw new ThrowerErrorGuard().InternalServerErrorException(
@@ -220,7 +220,7 @@ const calculateInstallmentPaymentDetails = (options: {
   taxYear: number
   paymentCalendarThreshold: number
   dueDate?: Dayjs
-  installments: { order: string | null; amount: number }[]
+  installments: { order: number; amount: number }[]
   variableSymbol: string
   specificSymbol: any
 }): Omit<ResponseInstallmentPaymentDetailDto, 'activeInstallment'> & {
@@ -400,7 +400,7 @@ export const getTaxDetailPure = (options: {
   paymentCalendarThreshold: number // splátková hranica (66 Eur)
   variableSymbol: string
   dateOfValidity: Date | null // dátum právoplatnosti
-  installments: { order: string | null; amount: number }[]
+  installments: { order: number; amount: number }[]
   taxDetails: TaxDetail[]
   taxConstructions: number
   taxFlat: number
@@ -521,7 +521,7 @@ export const getTaxDetailPureForInstallmentGenerator = (options: {
   paymentCalendarThreshold: number
   variableSymbol: string
   dateOfValidity: Date | null
-  installments: { order: string | null; amount: number }[]
+  installments: { order: number; amount: number }[]
   specificSymbol: string
   taxPayments: {
     amount: number


### PR DESCRIPTION
### Description of Changes

This pull request involves:
- Changing the `order` field type from optional `String` to `Integer` in the `TaxInstallment` table.
- Modifying related logic and method calls to accommodate the type change.
- Adding and populating the `order` property within the system based on identifiable text patterns for tax installments.
