### PR TITLE
Add V2 endpoint for tax list retrieval and deprecate old method

### DIFF
--- a/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
+++ b/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
@@ -653,6 +653,71 @@ export class ResponseGetTaxesDto {
   taxAdministrator: ResponseTaxAdministratorDto | null
 }
 
+export class ResponseGetTaxesListBodyDto {
+  @ApiPropertyOptional({
+    description: 'Date of tax delivery to city account',
+    default: '2024-01-01',
+  })
+  @IsDate()
+  @IsOptional()
+  @Type(() => Date)
+  createdAt?: Date
+
+  @ApiPropertyOptional({
+    description: 'Amount to be paid in cents',
+    default: 1000,
+  })
+  @IsNumber()
+  @IsOptional()
+  amountToBePaid?: number
+
+  @ApiProperty({
+    description: 'Year of tax',
+    default: 2022,
+  })
+  @IsNumber()
+  year: number
+
+  @ApiProperty({
+    description: 'Type of paid status',
+    example: TaxStatusEnum.PARTIALLY_PAID,
+    enumName: 'TaxStatusEnum',
+    enum: TaxStatusEnum,
+  })
+  @IsEnum(TaxStatusEnum)
+  status: TaxStatusEnum
+}
+
+export class ResponseGetTaxesListDto {
+  @ApiProperty({
+    description: 'Tax availability status',
+    example: TaxAvailabilityStatus.AVAILABLE,
+    enumName: 'TaxAvailabilityStatus',
+    enum: TaxAvailabilityStatus,
+  })
+  @IsEnum(TaxAvailabilityStatus)
+  availabilityStatus: TaxAvailabilityStatus
+
+  @ApiProperty({
+    isArray: true,
+    type: ResponseGetTaxesListBodyDto,
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ResponseGetTaxesListBodyDto)
+  items: ResponseGetTaxesListBodyDto[]
+
+  @ApiProperty({
+    description: 'Assigned tax administrator',
+    type: ResponseTaxAdministratorDto,
+  })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => ResponseTaxAdministratorDto)
+  @IsOptional()
+  taxAdministrator: ResponseTaxAdministratorDto | null
+}
+
 export class ResponseApartmentTaxDetailDto {
   @ApiProperty({
     description: 'Type of apartment',

--- a/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
+++ b/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
@@ -33,6 +33,20 @@ export enum TaxPaidStatusEnum {
   OVER_PAID = 'OVER_PAID',
 }
 
+export enum TaxStatusEnum {
+  NOT_PAID = 'NOT_PAID',
+  PARTIALLY_PAID = 'PARTIALLY_PAID',
+  PAID = 'PAID',
+  OVER_PAID = 'OVER_PAID',
+  AWAITING_PROCESSING = 'AWAITING_PROCESSING',
+}
+
+export enum TaxAvailabilityStatus {
+  AVAILABLE = 'AVAILABLE',
+  LOOKING_FOR_YOUR_TAX = 'LOOKING_FOR_YOUR_TAX',
+  TAX_NOT_ON_RECORD = 'TAX_NOT_ON_RECORD',
+}
+
 export enum OneTimePaymentReasonNotPossibleEnum {
   ALREADY_PAID = 'ALREADY_PAID',
 }

--- a/nest-tax-backend/src/tax/tax.controller.ts
+++ b/nest-tax-backend/src/tax/tax.controller.ts
@@ -139,6 +139,7 @@ export class TaxController {
   @HttpCode(200)
   @ApiOperation({
     summary: 'Get all taxes (paid and not paid)',
+    deprecated: true,
   })
   @ApiResponse({
     status: 200,

--- a/nest-tax-backend/src/tax/tax.v2.controller.ts
+++ b/nest-tax-backend/src/tax/tax.v2.controller.ts
@@ -23,7 +23,11 @@ import {
 
 import { BratislavaUser } from '../auth/decorators/user-info.decorator'
 import { BratislavaUserDto } from '../utils/global-dtos/city-account.dto'
-import { ResponseTaxSummaryDetailDto } from './dtos/response.tax.dto'
+import {
+  ResponseGetTaxesDto,
+  ResponseGetTaxesListDto,
+  ResponseTaxSummaryDetailDto,
+} from './dtos/response.tax.dto'
 import { TaxService } from './tax.service'
 
 @ApiTags('tax')
@@ -60,5 +64,38 @@ export class TaxControllerV2 {
     @Query('year', ParseIntPipe) year: number,
   ) {
     return this.taxService.getTaxDetail(baUser.birthNumber, year)
+  }
+
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get all taxes (paid and not paid)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Load list of taxes by limit, default value 5',
+    type: ResponseGetTaxesDto,
+  })
+  @ApiResponse({
+    status: 422,
+    description: 'Error to load tax data',
+    type: ResponseErrorDto,
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Internal server error',
+    type: ResponseInternalServerErrorDto,
+  })
+  @Tiers(CognitoTiersEnum.IDENTITY_CARD)
+  @UseGuards(TiersGuard)
+  @UseGuards(AuthenticationGuard)
+  @Get('taxes')
+  async getTaxesList(
+    @BratislavaUser() baUser: BratislavaUserDto,
+  ): Promise<ResponseGetTaxesListDto> {
+    // TODO - pagination - but it will be issue after in year 2040 :D
+    const response = await this.taxService.getListOfTaxesByBirthnumber(
+      baUser.birthNumber,
+    )
+    return response
   }
 }

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -3067,6 +3067,7 @@ export const TaxApiAxiosParamCreator = function (configuration?: Configuration) 
      *
      * @summary Get all taxes (paid and not paid)
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     taxControllerGetArchivedTaxes: async (
@@ -3194,6 +3195,44 @@ export const TaxApiAxiosParamCreator = function (configuration?: Configuration) 
         options: localVarRequestOptions,
       }
     },
+    /**
+     *
+     * @summary Get all taxes (paid and not paid)
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    taxControllerV2GetTaxesListV2: async (
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/v2/tax/taxes`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication bearer required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
   }
 }
 
@@ -3235,6 +3274,7 @@ export const TaxApiFp = function (configuration?: Configuration) {
      *
      * @summary Get all taxes (paid and not paid)
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async taxControllerGetArchivedTaxes(
@@ -3312,6 +3352,29 @@ export const TaxApiFp = function (configuration?: Configuration) {
           configuration,
         )(axios, localVarOperationServerBasePath || basePath)
     },
+    /**
+     *
+     * @summary Get all taxes (paid and not paid)
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async taxControllerV2GetTaxesListV2(
+      options?: RawAxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ResponseGetTaxesDto>> {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.taxControllerV2GetTaxesListV2(options)
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath =
+        operationServerMap['TaxApi.taxControllerV2GetTaxesListV2']?.[localVarOperationServerIndex]
+          ?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
   }
 }
 
@@ -3345,6 +3408,7 @@ export const TaxApiFactory = function (
      *
      * @summary Get all taxes (paid and not paid)
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     taxControllerGetArchivedTaxes(
@@ -3385,6 +3449,19 @@ export const TaxApiFactory = function (
         .taxControllerV2GetTaxDetailByYearV2(year, options)
         .then((request) => request(axios, basePath))
     },
+    /**
+     *
+     * @summary Get all taxes (paid and not paid)
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    taxControllerV2GetTaxesListV2(
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<ResponseGetTaxesDto> {
+      return localVarFp
+        .taxControllerV2GetTaxesListV2(options)
+        .then((request) => request(axios, basePath))
+    },
   }
 }
 
@@ -3413,6 +3490,7 @@ export class TaxApi extends BaseAPI {
    *
    * @summary Get all taxes (paid and not paid)
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof TaxApi
    */
@@ -3448,6 +3526,19 @@ export class TaxApi extends BaseAPI {
   public taxControllerV2GetTaxDetailByYearV2(year: number, options?: RawAxiosRequestConfig) {
     return TaxApiFp(this.configuration)
       .taxControllerV2GetTaxDetailByYearV2(year, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   *
+   * @summary Get all taxes (paid and not paid)
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TaxApi
+   */
+  public taxControllerV2GetTaxesListV2(options?: RawAxiosRequestConfig) {
+    return TaxApiFp(this.configuration)
+      .taxControllerV2GetTaxesListV2(options)
       .then((request) => request(this.axios, this.basePath))
   }
 }


### PR DESCRIPTION
### Description

This pull request introduces a new version (V2) endpoint for retrieving a list of taxes. The old "Get all taxes" endpoint has been marked as deprecated. The changes include the introduction of new response Data Transfer Objects (DTOs) and enums for tax statuses, along with necessary guards to ensure security.

### Changes

- **New Features**
  - Added a V2 endpoint to retrieve a list of taxes.
  - Implemented response DTOs for tax information delivery.
  - Incorporation of additional enums for tax status and availability.

- **Deprecations**
  - Marked the "Get all taxes" endpoint as deprecated.