### PR TITLE
add throw in get-or-create-user when user is deceased

### DIFF
--- a/nest-city-account/src/admin/admin.service.ts
+++ b/nest-city-account/src/admin/admin.service.ts
@@ -43,9 +43,12 @@ import { AnonymizeResponse } from '../bloomreach/bloomreach.dto'
 import { UserService } from '../user/user.service'
 import { COGNITO_SYNC_CONFIG_DB_KEY } from './utils/constants'
 import { toLogfmt } from '../utils/logging'
+import { LineLoggerSubservice } from '../utils/subservices/line-logger.subservice'
 
 @Injectable()
 export class AdminService {
+  private readonly logger: LineLoggerSubservice = new LineLoggerSubservice(AdminService.name)
+
   constructor(
     private cognitoSubservice: CognitoSubservice,
     private throwerErrorGuard: ThrowerErrorGuard,
@@ -156,7 +159,11 @@ export class AdminService {
           toLogfmt(user)
         )
       }
-      await this.userService.getOrCreateUserOrLegalPerson(accountType, user.sub, user.email)
+      try {
+        await this.userService.getOrCreateUserOrLegalPerson(accountType, user.sub, user.email)
+      } catch (error) {
+        this.logger.error(error)
+      }
     }
   }
 

--- a/nest-city-account/src/user/user.error.enum.ts
+++ b/nest-city-account/src/user/user.error.enum.ts
@@ -2,10 +2,12 @@ export enum UserErrorsEnum {
   COGNITO_TYPE_ERROR = 'COGNITO_TYPE_ERROR',
   USER_NOT_FOUND = 'USER_NOT_FOUND',
   NO_EXTERNAL_ID = 'NO_EXTERNAL_ID',
+  USER_IS_DECEASED = 'USER_IS_DECEASED',
 }
 
 export enum UserErrorsResponseEnum {
   COGNITO_TYPE_ERROR = 'Unexpected Cognito User Account Type',
   USER_NOT_FOUND = 'User not found in database',
   NO_EXTERNAL_ID = 'User does not have cognito external id',
+  USER_IS_DECEASED = 'User is deceased',
 }

--- a/nest-city-account/src/user/utils/subservice/database.subservice.ts
+++ b/nest-city-account/src/user/utils/subservice/database.subservice.ts
@@ -32,6 +32,12 @@ export class DatabaseSubserviceUser {
     let user = await this.prisma.user.findUnique({
       where: { email: email },
     })
+    if (user && user.isDeceased) {
+      throw this.throwerErrorGuard.ForbiddenException(
+        UserErrorsEnum.USER_IS_DECEASED,
+        UserErrorsResponseEnum.USER_IS_DECEASED
+      )
+    }
     if (user && externalId) {
       user = await this.prisma.user.update({
         where: {


### PR DESCRIPTION
- throw error when `getOrCreateUser` is called
- catch error when syncing cognito with city-account database