### PR TITLE
Add type of tax enum to database

### DIFF
--- a/nest-tax-backend/prisma/migrations/20250925103129_add_tax_type_enum/migration.sql
+++ b/nest-tax-backend/prisma/migrations/20250925103129_add_tax_type_enum/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "public"."TaxType" AS ENUM ('DZN', 'KO');
+
+-- Step 1: Add the column as nullable first
+ALTER TABLE "public"."Tax"
+ADD COLUMN "type" "public"."TaxType";
+
+-- Step 2: Backfill existing rows with 'DZN'
+UPDATE "public"."Tax"
+SET "type" = 'DZN';
+
+-- Step 3: Enforce NOT NULL
+ALTER TABLE "public"."Tax"
+ALTER COLUMN "type" SET NOT NULL;

--- a/nest-tax-backend/prisma/schema.prisma
+++ b/nest-tax-backend/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Tax {
   createdAt                       DateTime             @default(now())
   updatedAt                       DateTime             @default(now()) @updatedAt
   year                            Int
+  type                            TaxType
   taxPayerId                      Int
   taxPayer                        TaxPayer             @relation(fields: [taxPayerId], references: [id], onDelete: Cascade)
   amount                          Int
@@ -174,4 +175,9 @@ enum DeliveryMethodNamed {
   EDESK
   POSTAL
   CITY_ACCOUNT
+}
+
+enum TaxType {
+  DZN // daň z nehnuteľnosti
+  KO // komumálny odpad
 }

--- a/nest-tax-backend/src/noris/subservices/noris-tax.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax.subservice.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
+import { Prisma, TaxType } from '@prisma/client'
 import { Request } from 'mssql'
 import { ResponseUserByBirthNumberDto } from 'openapi-clients/city-account'
 
@@ -376,6 +376,7 @@ export class NorisTaxSubservice {
       update: taxData,
       create: {
         ...taxData,
+        type: TaxType.DZN,
         deliveryMethod: userDataFromCityAccount?.taxDeliveryMethodAtLockDate,
       },
     })

--- a/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
+++ b/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
@@ -3,6 +3,7 @@ import {
   DeliveryMethodNamed,
   TaxDetailareaType,
   TaxDetailType,
+  TaxType,
 } from '@prisma/client'
 import { Type } from 'class-transformer'
 import {
@@ -557,6 +558,15 @@ export class ResponseTaxDto {
   @IsDate()
   @Type(() => Date)
   lastCheckedUpdates: Date
+
+  @ApiProperty({
+    description: 'Type of tax',
+    example: TaxType.DZN,
+    enumName: 'TaxType',
+    enum: TaxType,
+  })
+  @IsEnum(TaxType)
+  type: TaxType
 
   @ApiProperty({
     description: 'delivery_method',

--- a/nest-tax-backend/src/tax/tax.service.ts
+++ b/nest-tax-backend/src/tax/tax.service.ts
@@ -345,17 +345,17 @@ export class TaxService {
 
   async generatePdf(year: number, birthNumber: string): Promise<string> {
     try {
-      const tax = await this.getTaxByYear(year, birthNumber)
-      const taxDetails = taxDetailsToPdf(tax.taxDetails)
+      const user = await this.getTaxByYear(year, birthNumber)
+      const taxDetails = taxDetailsToPdf(user.taxDetails)
       const totals = taxTotalsToPdf(
-        tax,
-        tax.taxInstallments.map((data) => ({
+        user,
+        user.taxInstallments.map((data) => ({
           ...data,
           order: data.order ? +data.order : 1,
         })),
       )
       return await ejs.renderFile('public/tax-pdf.ejs', {
-        tax,
+        user,
         logo: path.resolve('public/logoBaTax.png'),
         taxDetails,
         totals,

--- a/nest-tax-backend/src/tax/tax.service.ts
+++ b/nest-tax-backend/src/tax/tax.service.ts
@@ -345,17 +345,17 @@ export class TaxService {
 
   async generatePdf(year: number, birthNumber: string): Promise<string> {
     try {
-      const user = await this.getTaxByYear(year, birthNumber)
-      const taxDetails = taxDetailsToPdf(user.taxDetails)
+      const tax = await this.getTaxByYear(year, birthNumber)
+      const taxDetails = taxDetailsToPdf(tax.taxDetails)
       const totals = taxTotalsToPdf(
-        user,
-        user.taxInstallments.map((data) => ({
+        tax,
+        tax.taxInstallments.map((data) => ({
           ...data,
           order: data.order ? +data.order : 1,
         })),
       )
       return await ejs.renderFile('public/tax-pdf.ejs', {
-        user,
+        tax,
         logo: path.resolve('public/logoBaTax.png'),
         taxDetails,
         totals,

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -686,6 +686,10 @@ export interface ResponseTaxDto {
    */
   lastCheckedUpdates: string
   /**
+   * Type of tax
+   */
+  type: TaxType
+  /**
    * delivery_method
    */
   deliveryMethod: DeliveryMethodNamed | null
@@ -900,6 +904,17 @@ export const TaxStatusEnum = {
 } as const
 
 export type TaxStatusEnum = (typeof TaxStatusEnum)[keyof typeof TaxStatusEnum]
+
+/**
+ * Type of tax
+ */
+
+export const TaxType = {
+  Dzn: 'DZN',
+  Ko: 'KO',
+} as const
+
+export type TaxType = (typeof TaxType)[keyof typeof TaxType]
 
 /**
  * AdminApi - axios parameter creator


### PR DESCRIPTION
As a preparation for multiple types of tax in database, this PR adds an enum of type of tax. So far all taxes will have type `DZN`, and nothing from the functionality changes, however this work is needed to be on the same track of development.