### PR TITLE
Add max form attachment limits for multi-file uploads

### DIFF
--- a/forms-shared/src/generator/functions/fileUploadMultiple.ts
+++ b/forms-shared/src/generator/functions/fileUploadMultiple.ts
@@ -2,9 +2,14 @@ import { GeneratorBaseOptions, GeneratorField } from '../generatorTypes'
 import { BaWidgetType, FileUploadUiOptions } from '../uiOptionsTypes'
 import { removeUndefinedValues } from '../helpers'
 
+type FileUploadMultipleOptions = GeneratorBaseOptions & {
+  minItems?: number
+  maxItems?: number
+}
+
 export const fileUploadMultiple = (
   property: string,
-  options: GeneratorBaseOptions,
+  options: FileUploadMultipleOptions,
   uiOptions: FileUploadUiOptions,
 ): GeneratorField => ({
   property,
@@ -16,7 +21,8 @@ export const fileUploadMultiple = (
       format: 'ba-file-uuid',
       baFile: true,
     },
-    minItems: options.required ? 1 : undefined,
+    minItems: options.minItems ?? (options.required ? 1 : undefined),
+    maxItems: options.maxItems,
     default: [],
     baUiSchema: {
       'ui:widget': BaWidgetType.FileUploadMultiple,

--- a/next/components/forms/widget-components/Upload/Upload.tsx
+++ b/next/components/forms/widget-components/Upload/Upload.tsx
@@ -11,6 +11,7 @@ import UploadFilesList from './UploadFilesList'
 type UploadProps = FieldWrapperProps & {
   type: 'button' | 'dragAndDrop'
   multiple?: boolean
+  uploadDisabled?: boolean
   value?: string | string[] | null
   sizeLimit?: number
   supportedFormats?: string[]
@@ -29,6 +30,7 @@ const Upload = forwardRef<HTMLButtonElement, UploadProps>(
       label,
       required,
       multiple,
+      uploadDisabled = false,
       value,
       helptext,
       helptextMarkdown,
@@ -72,7 +74,7 @@ const Upload = forwardRef<HTMLButtonElement, UploadProps>(
                 ref={ref}
                 sizeLimit={sizeLimit}
                 supportedFormats={supportedFormats}
-                disabled={disabled}
+                disabled={disabled || uploadDisabled}
                 onUpload={onUpload}
                 allowsMultiple={multiple}
                 errorMessage={errorMessage}
@@ -83,7 +85,7 @@ const Upload = forwardRef<HTMLButtonElement, UploadProps>(
                 ref={ref}
                 sizeLimit={sizeLimit}
                 supportedFormats={supportedFormats}
-                disabled={disabled}
+                disabled={disabled || uploadDisabled}
                 onUpload={onUpload}
                 allowsMultiple={multiple}
                 errorMessage={errorMessage}


### PR DESCRIPTION
Read maxItems from schema in the multi-upload widget and disable/limit new uploads once capacity is reached so form constraints are enforced in the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/schema constraint enforcement only; low impact, with main risk being edge cases around counting existing files vs. remaining upload capacity.
> 
> **Overview**
> Multi-file upload fields can now specify `minItems`/`maxItems` in the generated JSON schema (`fileUploadMultiple`), rather than only deriving `minItems` from `required`.
> 
> The `FileUploadMultipleWidgetRJSF` now reads `maxItems` from the schema to cap how many files are accepted per upload, adjusts whether multi-select is allowed based on remaining slots, and disables further uploads once the limit is reached via a new `uploadDisabled` flag passed into `Upload`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8de29953d4a81fe39e0724385208874c0754fe24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->