### PR TITLE
1077 current delivery method to bloomreach

### DIFF
--- a/nest-city-account/prisma/migrations/20260312140018_remove_tax_delivery_method_and_date/migration.sql
+++ b/nest-city-account/prisma/migrations/20260312140018_remove_tax_delivery_method_and_date/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `taxDeliveryMethod` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `taxDeliveryMethodCityAccountDate` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "taxDeliveryMethod",
+DROP COLUMN "taxDeliveryMethodCityAccountDate";

--- a/nest-city-account/prisma/migrations/20260316144859_change_external_id_to_uuid/migration.sql
+++ b/nest-city-account/prisma/migrations/20260316144859_change_external_id_to_uuid/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "User" 
+    ALTER COLUMN "externalId" SET NOT NULL,
+    ALTER COLUMN "externalId" TYPE uuid USING "externalId"::uuid;
+ALTER TABLE "LegalPerson" 
+    ALTER COLUMN "externalId" SET NOT NULL,
+    ALTER COLUMN "externalId" TYPE uuid USING "externalId"::uuid;

--- a/nest-city-account/prisma/migrations/20260316153144_add_bloomreach_outbox/migration.sql
+++ b/nest-city-account/prisma/migrations/20260316153144_add_bloomreach_outbox/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "BloomreachOutbox" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "processedAt" TIMESTAMP(3),
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "lastError" TEXT,
+    "eventType" TEXT NOT NULL,
+    "externalId" UUID NOT NULL,
+    "phoneNumber" TEXT,
+
+    CONSTRAINT "BloomreachOutbox_pkey" PRIMARY KEY ("id")
+);

--- a/nest-city-account/prisma/schema.prisma
+++ b/nest-city-account/prisma/schema.prisma
@@ -70,7 +70,7 @@ model User {
   createdAt                            DateTime                       @default(now())
   updatedAt                            DateTime                       @updatedAt
   registeredAt                         DateTime?
-  externalId                           String?                        @unique
+  externalId                           String                         @unique @db.Uuid
   email                                String?                        @unique
   ifo                                  String?                        @unique
   birthNumber                          String?                        @unique
@@ -163,7 +163,7 @@ model LegalPerson {
   createdAt                          DateTime                       @default(now())
   updatedAt                          DateTime                       @updatedAt
   registeredAt                       DateTime?
-  externalId                         String?                        @unique
+  externalId                         String                         @unique @db.Uuid
   email                              String?                        @unique
   ico                                String?
   birthNumber                        String?

--- a/nest-city-account/prisma/schema.prisma
+++ b/nest-city-account/prisma/schema.prisma
@@ -260,3 +260,14 @@ model OAuth2Data {
   idTokenEnc           String?
   refreshTokenEnc      String?
 }
+
+model BloomreachOutbox {
+  id          String   @id @default(uuid()) @db.Uuid
+  createdAt   DateTime @default(now())
+  processedAt DateTime?
+  attempts    Int      @default(0)
+  lastError   String?
+  eventType   String   // 'TRACK_CUSTOMER'
+  externalId  String   @db.Uuid
+  phoneNumber String?  // optional extra payload for trackCustomer
+}

--- a/nest-city-account/prisma/schema.prisma
+++ b/nest-city-account/prisma/schema.prisma
@@ -83,9 +83,7 @@ model User {
   userGdprData                         UserGdprData[]
   physicalEntity                       PhysicalEntity?
   lastTaxDeliveryMethodsUpdateYear     Int?
-  taxDeliveryMethod                    DeliveryMethodUserEnum? // User's current delivery method preference for tax documents
   taxDeliveryMethodAtLockDate          DeliveryMethodEnum? // Delivery method locked at tax season start (February 1st) - used for actual delivery
-  taxDeliveryMethodCityAccountDate     DateTime? // Date when CITY_ACCOUNT delivery method was selected by user
   taxDeliveryMethodCityAccountLockDate DateTime? // Date when CITY_ACCOUNT delivery method was selected by user before lock date
   // This is used to store the last time we tried to update the delivery methods in Noris for this user.
   lastTaxDeliveryMethodsUpdateTry      DateTime                       @default(now())

--- a/nest-city-account/src/bloomreach/bloomreach.service.ts
+++ b/nest-city-account/src/bloomreach/bloomreach.service.ts
@@ -3,7 +3,10 @@ import { HttpStatus, Injectable } from '@nestjs/common'
 import axios, { isAxiosError } from 'axios'
 import { ACTIVE_USER_FILTER, PrismaService } from '../prisma/prisma.service'
 
-import { GdprDataSubscriptionDto } from '../user/dtos/gdpr.user.dto'
+import {
+  GdprDataSubscriptionDto,
+  UserOfficialCorrespondenceChannelEnum,
+} from '../user/dtos/gdpr.user.dto'
 import {
   AnonymizeResponse,
   BloomreachConsentActionEnum,
@@ -19,14 +22,18 @@ import {
   CognitoUserAttributesEnum,
 } from '../utils/global-dtos/cognito.dto'
 import {
+  BloomreachOutbox,
   CognitoUserAttributesTierEnum,
+  DeliveryMethodEnum,
   GDPRCategoryEnum,
   GDPRSubTypeEnum,
   GDPRTypeEnum,
+  Prisma,
 } from '@prisma/client'
 import { CognitoSubservice } from '../utils/subservices/cognito.subservice'
 import ThrowerErrorGuard from '../utils/guards/errors.guard'
-import { ErrorsEnum } from '../utils/guards/dtos/error.dto'
+import { ErrorsEnum, ErrorsResponseEnum } from '../utils/guards/dtos/error.dto'
+import { DeliveryMethodActiveAndLockedDto } from 'src/user/dtos/deliveryMethod.dto'
 
 @Injectable()
 export class BloomreachService {
@@ -55,6 +62,78 @@ export class BloomreachService {
       )
     }
     this.logger = new LineLoggerSubservice(BloomreachService.name)
+  }
+
+  // TODO: Refactor - duplicate exists in user/utils/subservice/user-data.subservice.ts
+  async getOfficialCorrespondenceChannel(
+    userId: string
+  ): Promise<UserOfficialCorrespondenceChannelEnum | null> {
+    const delivery = await this.getActiveAndLockedDeliveryMethodsWithDates({ id: userId })
+    const active = delivery.active?.deliveryMethod
+    switch (active) {
+      case DeliveryMethodEnum.EDESK:
+        return UserOfficialCorrespondenceChannelEnum.EDESK
+      case DeliveryMethodEnum.CITY_ACCOUNT:
+        return UserOfficialCorrespondenceChannelEnum.EMAIL
+      case DeliveryMethodEnum.POSTAL:
+        return UserOfficialCorrespondenceChannelEnum.POSTAL
+      default:
+        return null
+    }
+  }
+
+  // TODO: Refactor - duplicate exists in user/utils/subservice/user-data.subservice.ts
+  // keeping it unchanged, even when locked data not needed, for easier refactor
+  async getActiveAndLockedDeliveryMethodsWithDates(
+    where: Prisma.UserWhereUniqueInput
+  ): Promise<DeliveryMethodActiveAndLockedDto> {
+    const user = await this.prisma.user.findUnique({
+      where,
+      include: {
+        physicalEntity: {
+          select: {
+            activeEdesk: true,
+          },
+        },
+      },
+    })
+    if (!user) {
+      throw this.throwerErrorGuard.NotFoundException(
+        ErrorsEnum.NOT_FOUND_ERROR,
+        ErrorsResponseEnum.NOT_FOUND_ERROR
+      )
+    }
+
+    const gdrpDataTaxesFormalCommunication = await this.prisma.userGdprData.findFirst({
+      take: 1,
+      where: {
+        userId: user.id,
+        category: GDPRCategoryEnum.TAXES,
+        type: GDPRTypeEnum.FORMAL_COMMUNICATION,
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    const active = user.physicalEntity?.activeEdesk
+      ? { deliveryMethod: DeliveryMethodEnum.EDESK }
+      : gdrpDataTaxesFormalCommunication
+        ? {
+            deliveryMethod:
+              gdrpDataTaxesFormalCommunication?.subType === GDPRSubTypeEnum.subscribe
+                ? DeliveryMethodEnum.CITY_ACCOUNT
+                : DeliveryMethodEnum.POSTAL,
+            date: gdrpDataTaxesFormalCommunication?.createdAt ?? undefined,
+          }
+        : undefined
+
+    const locked = user.taxDeliveryMethodAtLockDate
+      ? {
+          deliveryMethod: user.taxDeliveryMethodAtLockDate,
+          date: user.taxDeliveryMethodCityAccountLockDate ?? undefined,
+        }
+      : undefined
+
+    return { active, locked }
   }
 
   // TODO: Refactor - duplicate exists in paas-mpa/paas-mpa.service.ts
@@ -156,6 +235,13 @@ export class BloomreachService {
       if (contactId && phoneNumber) {
         await this.bloomreachContactDatabaseService.addPhone(contactId, phoneNumber)
       }
+      const dbUser = await this.prisma.user.findUnique({
+        where: { externalId: cognitoId },
+        select: { id: true },
+      })
+      const officialCorrespondenceChannel = dbUser
+        ? await this.getOfficialCorrespondenceChannel(dbUser.id)
+        : null
 
       const data = {
         customer_ids: {
@@ -172,6 +258,8 @@ export class BloomreachService {
           ...(phoneNumber && { phone: phoneNumber }),
           ...(isIdentityVerified && { is_identity_verified: isIdentityVerified }),
           ...(oAuthOriginClientName && { oauth_origin_client_name: oAuthOriginClientName }),
+          // we need null or undefined or empty string to be passed to bloomreach as value to change correspondence channel to change what was previously set
+          current_tax_correspondence_channel: officialCorrespondenceChannel,
         },
       }
       await axios.post(
@@ -290,5 +378,18 @@ export class BloomreachService {
       this.logger.error(error)
       return AnonymizeResponse.ERROR
     }
+  }
+
+  // TODO: use everywhere instead of calling trackCustomer directly
+  async enqueueTrackCustomerToBloomreachOutbox(
+    tx: Prisma.TransactionClient,
+    userExternalId: string
+  ): Promise<BloomreachOutbox> {
+    return tx.bloomreachOutbox.create({
+      data: {
+        eventType: 'TRACK_CUSTOMER',
+        externalId: userExternalId,
+      },
+    })
   }
 }

--- a/nest-city-account/src/physical-entity/physical-entity.module.ts
+++ b/nest-city-account/src/physical-entity/physical-entity.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common'
 import { PrismaModule } from '../prisma/prisma.module'
 
 import { PhysicalEntityService } from './physical-entity.service'
+import { BloomreachModule } from '../bloomreach/bloomreach.module'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, BloomreachModule],
   providers: [PhysicalEntityService],
   exports: [PhysicalEntityService],
   controllers: [],

--- a/nest-city-account/src/physical-entity/physical-entity.service.spec.ts
+++ b/nest-city-account/src/physical-entity/physical-entity.service.spec.ts
@@ -8,6 +8,7 @@ import { PhysicalEntity } from '@prisma/client'
 import { LineLoggerSubservice } from '../utils/subservices/line-logger.subservice'
 import { MagproxyService } from '../magproxy/magproxy.service'
 import { CognitoSubservice } from '../utils/subservices/cognito.subservice'
+import { BloomreachService } from '../bloomreach/bloomreach.service'
 
 const mockBirthNumber = '123456/7890'
 const mockEntityID = '11cc6139-f660-4173-92e1-0d7b9cfa7a24'
@@ -41,6 +42,7 @@ describe('PhysicalEntityService', () => {
         { provide: PrismaService, useValue: prismaMock },
         { provide: MagproxyService, useValue: MagproxyServiceMock },
         { provide: CognitoSubservice, useValue: createMock<CognitoSubservice>() },
+        { provide: BloomreachService, useValue: createMock<BloomreachService>() },
       ],
     }).compile()
     service = module.get<PhysicalEntityService>(PhysicalEntityService)
@@ -101,6 +103,19 @@ describe('PhysicalEntityService', () => {
       expect(loggerSpy).toHaveBeenCalledWith(
         `Entity with birth number ${mockBirthNumber} does not exist.`
       )
+    })
+  })
+  describe('enqueue', () => {
+    it('should update the successful active Edesk update in the database', async () => {
+      // const mockSuccessArray = [{ uri: 'https://example.com', success: true }]
+      // jest.spyOn(prismaMock.physicalEntity, 'update').mockResolvedValue({ ...mockPhysicalEntity, activeEdesk: true })
+      // jest.spyOn(BloomreachService, 'enqueueTrackCustomerToBloomreachOutbox').mockResolvedValue({ id: '123' })
+      // await service.updateSuccessfulActiveEdeskUpdateInDatabase(mockSuccessArray)
+      // expect(prismaMock.physicalEntity.update).toHaveBeenCalledWith({ where: { id: mockEntityID }, data: { activeEdesk: true } })
+      // expect(BloomreachService.enqueueTrackCustomerToBloomreachOutbox).toHaveBeenCalledWith(mockSuccessArray)
+      // if updateSuccessfulActiveEdeskUpdateInDatabase is called
+      // if update is called
+      // if enqueueTrackCustomerToBloomreachOutbox is called with the correct externalId
     })
   })
 })

--- a/nest-city-account/src/physical-entity/physical-entity.service.spec.ts
+++ b/nest-city-account/src/physical-entity/physical-entity.service.spec.ts
@@ -9,6 +9,7 @@ import { LineLoggerSubservice } from '../utils/subservices/line-logger.subservic
 import { MagproxyService } from '../magproxy/magproxy.service'
 import { CognitoSubservice } from '../utils/subservices/cognito.subservice'
 import { BloomreachService } from '../bloomreach/bloomreach.service'
+import { UpvsIdentityByUriSuccessType } from 'src/nases/nases.service'
 
 const mockBirthNumber = '123456/7890'
 const mockEntityID = '11cc6139-f660-4173-92e1-0d7b9cfa7a24'
@@ -30,6 +31,7 @@ const mockPhysicalEntity: PhysicalEntity = {
 
 describe('PhysicalEntityService', () => {
   let service: PhysicalEntityService
+  let bloomreachService: BloomreachService
   const MagproxyServiceMock = createMock<MagproxyService>()
   let consoleSpy: jest.SpyInstance
   beforeEach(async () => {
@@ -46,6 +48,7 @@ describe('PhysicalEntityService', () => {
       ],
     }).compile()
     service = module.get<PhysicalEntityService>(PhysicalEntityService)
+    bloomreachService = module.get<BloomreachService>(BloomreachService)
     consoleSpy = jest.spyOn(console, 'log')
     consoleSpy.mockImplementation(() => {})
   })
@@ -105,17 +108,64 @@ describe('PhysicalEntityService', () => {
       )
     })
   })
-  describe('enqueue', () => {
-    it('should update the successful active Edesk update in the database', async () => {
-      // const mockSuccessArray = [{ uri: 'https://example.com', success: true }]
-      // jest.spyOn(prismaMock.physicalEntity, 'update').mockResolvedValue({ ...mockPhysicalEntity, activeEdesk: true })
-      // jest.spyOn(BloomreachService, 'enqueueTrackCustomerToBloomreachOutbox').mockResolvedValue({ id: '123' })
-      // await service.updateSuccessfulActiveEdeskUpdateInDatabase(mockSuccessArray)
-      // expect(prismaMock.physicalEntity.update).toHaveBeenCalledWith({ where: { id: mockEntityID }, data: { activeEdesk: true } })
-      // expect(BloomreachService.enqueueTrackCustomerToBloomreachOutbox).toHaveBeenCalledWith(mockSuccessArray)
-      // if updateSuccessfulActiveEdeskUpdateInDatabase is called
-      // if update is called
-      // if enqueueTrackCustomerToBloomreachOutbox is called with the correct externalId
+  describe('updateSuccessfulActiveEdeskUpdateInDatabase', () => {
+    const mockSuccessArray: UpvsIdentityByUriSuccessType[] = [
+      {
+        uri: 'https://example.com',
+        physicalEntityId: mockEntityID,
+        data: { upvs: { edesk_status: 'deliverable' } } as UpvsIdentityByUriSuccessType['data'],
+      },
+    ]
+
+    it('should run a transaction, update physical entity, and enqueue Bloomreach when user has externalId', async () => {
+      const userExternalId = 'user-ext-123'
+      prismaMock.physicalEntity.findUnique.mockResolvedValue({
+        user: { externalId: userExternalId },
+      } as never)
+      ;(prismaMock.$transaction as unknown as jest.Mock).mockImplementation(
+        (callback: (tx: typeof prismaMock) => unknown) => callback(prismaMock)
+      )
+      prismaMock.physicalEntity.update.mockResolvedValue({
+        ...mockPhysicalEntity,
+        activeEdesk: true,
+      })
+
+      await service.updateSuccessfulActiveEdeskUpdateInDatabase(mockSuccessArray)
+
+      expect(prismaMock.physicalEntity.findUnique).toHaveBeenCalledWith({
+        where: { id: mockEntityID },
+        select: { user: { select: { externalId: true } } },
+      })
+      expect(prismaMock.$transaction).toHaveBeenCalled()
+      expect(prismaMock.physicalEntity.update).toHaveBeenCalledWith({
+        where: { id: mockEntityID },
+        data: expect.objectContaining({
+          activeEdesk: true,
+          activeEdeskUpdateFailedAt: null,
+          activeEdeskUpdateFailCount: 0,
+        }),
+      })
+      expect(bloomreachService.enqueueTrackCustomerToBloomreachOutbox).toHaveBeenCalledWith(
+        prismaMock,
+        userExternalId
+      )
+    })
+
+    it('should update in a transaction but not enqueue Bloomreach when user has no externalId', async () => {
+      prismaMock.physicalEntity.findUnique.mockResolvedValue({ user: null } as never)
+      ;(prismaMock.$transaction as unknown as jest.Mock).mockImplementation(
+        (callback: (tx: typeof prismaMock) => unknown) => callback(prismaMock)
+      )
+      prismaMock.physicalEntity.update.mockResolvedValue({
+        ...mockPhysicalEntity,
+        activeEdesk: true,
+      })
+
+      await service.updateSuccessfulActiveEdeskUpdateInDatabase(mockSuccessArray)
+
+      expect(prismaMock.$transaction).toHaveBeenCalled()
+      expect(prismaMock.physicalEntity.update).toHaveBeenCalled()
+      expect(bloomreachService.enqueueTrackCustomerToBloomreachOutbox).not.toHaveBeenCalled()
     })
   })
 })

--- a/nest-city-account/src/physical-entity/physical-entity.service.ts
+++ b/nest-city-account/src/physical-entity/physical-entity.service.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '../prisma/prisma.service'
 import { UpvsIdentityByUriSuccessType } from '../nases/nases.service'
 import ThrowerErrorGuard from '../utils/guards/errors.guard'
 import { LineLoggerSubservice } from '../utils/subservices/line-logger.subservice'
+import { BloomreachService } from '../bloomreach/bloomreach.service'
 
 @Injectable()
 export class PhysicalEntityService {
@@ -13,7 +14,8 @@ export class PhysicalEntityService {
 
   constructor(
     private readonly prismaService: PrismaService,
-    private readonly throwerErrorGuard: ThrowerErrorGuard
+    private readonly throwerErrorGuard: ThrowerErrorGuard,
+    private readonly bloomreachService: BloomreachService
   ) {
     this.logger = new LineLoggerSubservice(PhysicalEntityService.name)
   }
@@ -122,10 +124,22 @@ export class PhysicalEntityService {
       }
     }
 
-    const physicalEntity = await this.prismaService.physicalEntity.update({
-      where: { id: data.id },
-      data: dataWithEdeskMetadata,
+    const userExternalId = await this.prismaService.physicalEntity
+      .findUnique({
+        where: { id: data.id },
+        select: { user: { select: { externalId: true } } },
+      })
+      .then((physicalEntity) => physicalEntity?.user?.externalId)
+
+    return await this.prismaService.$transaction(async (tx) => {
+      const physicalEntity = await tx.physicalEntity.update({
+        where: { id: data.id },
+        data: dataWithEdeskMetadata,
+      })
+      if (userExternalId) {
+        await this.bloomreachService.enqueueTrackCustomerToBloomreachOutbox(tx, userExternalId)
+      }
+      return physicalEntity
     })
-    return physicalEntity
   }
 }

--- a/nest-city-account/src/tasks/subservices/bloomreach-outbox.subservice.ts
+++ b/nest-city-account/src/tasks/subservices/bloomreach-outbox.subservice.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common'
+import { LineLoggerSubservice } from '../../utils/subservices/line-logger.subservice'
+import { PrismaService } from '../../prisma/prisma.service'
+import { BloomreachService } from '../../bloomreach/bloomreach.service'
+
+@Injectable()
+export class BloomreachOutboxSubservice {
+  private readonly logger: LineLoggerSubservice
+
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly bloomreachService: BloomreachService
+  ) {
+    this.logger = new LineLoggerSubservice(BloomreachOutboxSubservice.name)
+  }
+
+  async processBloomreachOutbox(): Promise<void> {
+    const pending = await this.prismaService.bloomreachOutbox.findMany({
+      where: {
+        processedAt: null,
+        attempts: { lt: 120 }, // give up after 120 attempts
+      },
+      orderBy: { createdAt: 'asc' },
+      take: 50,
+    })
+
+    for (const event of pending) {
+      let success: boolean | undefined = false
+      try {
+        const externalId = event.externalId
+        if (event.eventType === 'TRACK_CUSTOMER') {
+          success = await this.bloomreachService.trackCustomer(
+            externalId,
+            event.phoneNumber ?? undefined
+          )
+        }
+        if (!success) {
+          await this.prismaService.bloomreachOutbox.update({
+            where: { id: event.id },
+            data: {
+              attempts: { increment: 1 },
+              lastError: 'Failed to track customer',
+            },
+          })
+          return
+        }
+
+        await this.prismaService.bloomreachOutbox.update({
+          where: { id: event.id },
+          data: { processedAt: new Date() },
+        })
+      } catch (error) {
+        await this.prismaService.bloomreachOutbox.update({
+          where: { id: event.id },
+          data: {
+            attempts: { increment: 1 },
+            lastError: String(error),
+          },
+        })
+      }
+    }
+  }
+}

--- a/nest-city-account/src/tasks/tasks.module.ts
+++ b/nest-city-account/src/tasks/tasks.module.ts
@@ -11,6 +11,8 @@ import { EdeskTasksSubservice } from './subservices/edesk-tasks.subservice'
 import { TaxDeliveryMethodsTasksSubservice } from './subservices/tax-delivery-methods-tasks.subservice'
 import { UpvsQueueModule } from '../upvs-queue/upvs-queue.module'
 import { NorisModule } from '../noris/noris.module'
+import { BloomreachModule } from '../bloomreach/bloomreach.module'
+import { BloomreachOutboxSubservice } from './subservices/bloomreach-outbox.subservice'
 
 @Module({
   imports: [
@@ -21,12 +23,14 @@ import { NorisModule } from '../noris/noris.module'
     PdfGeneratorModule,
     UpvsQueueModule,
     NorisModule,
+    BloomreachModule,
   ],
   providers: [
     TaxSubservice,
     CleanupTasksSubservice,
     EdeskTasksSubservice,
     TaxDeliveryMethodsTasksSubservice,
+    BloomreachOutboxSubservice,
     TasksService,
   ],
   exports: [],

--- a/nest-city-account/src/tasks/tasks.service.ts
+++ b/nest-city-account/src/tasks/tasks.service.ts
@@ -4,6 +4,7 @@ import HandleErrors from '../utils/decorators/errorHandler.decorators'
 import { CleanupTasksSubservice } from './subservices/cleanup-tasks.subservice'
 import { EdeskTasksSubservice } from './subservices/edesk-tasks.subservice'
 import { TaxDeliveryMethodsTasksSubservice } from './subservices/tax-delivery-methods-tasks.subservice'
+import { BloomreachOutboxSubservice } from './subservices/bloomreach-outbox.subservice'
 
 const bratislavaTimezone = 'Europe/Bratislava'
 
@@ -16,7 +17,8 @@ export class TasksService {
   constructor(
     private readonly cleanupTasksSubservice: CleanupTasksSubservice,
     private readonly edeskTasksSubservice: EdeskTasksSubservice,
-    private readonly taxDeliveryMethodsTasksSubservice: TaxDeliveryMethodsTasksSubservice
+    private readonly taxDeliveryMethodsTasksSubservice: TaxDeliveryMethodsTasksSubservice,
+    private readonly bloomreachOutboxSubservice: BloomreachOutboxSubservice
   ) {}
 
   /**
@@ -123,5 +125,15 @@ export class TasksService {
   @HandleErrors('Cron')
   async sendDailyDeliveryMethodSummaries() {
     return this.taxDeliveryMethodsTasksSubservice.sendDailyDeliveryMethodSummaries()
+  }
+
+  /**
+   * Processes the bloomreach outbox.
+   * Runs every minute.
+   */
+  @Cron(CronExpression.EVERY_MINUTE)
+  @HandleErrors('CronError')
+  async processBloomreachOutbox(): Promise<void> {
+    return this.bloomreachOutboxSubservice.processBloomreachOutbox()
   }
 }

--- a/nest-city-account/src/user/user.controller.ts
+++ b/nest-city-account/src/user/user.controller.ts
@@ -201,7 +201,7 @@ export class UserController {
     if (
       user[CognitoUserAttributesEnum.ACCOUNT_TYPE] === CognitoUserAccountTypesEnum.PHYSICAL_ENTITY
     ) {
-      const result: ResponseUserDataDto = await this.userService.subUnsubUser(
+      const result = await this.userService.subUnsubUser(
         user,
         GDPRSubTypeEnum.subscribe,
         data.gdprData
@@ -214,7 +214,7 @@ export class UserController {
       user[CognitoUserAttributesEnum.ACCOUNT_TYPE] ===
         CognitoUserAccountTypesEnum.SELF_EMPLOYED_ENTITY
     ) {
-      const result: ResponseLegalPersonDataDto = await this.userService.subUnsubLegalPerson(
+      const result = await this.userService.subUnsubLegalPerson(
         user,
         GDPRSubTypeEnum.subscribe,
         data.gdprData
@@ -228,6 +228,7 @@ export class UserController {
     )
   }
 
+  // TODO: same as endpoint /subscribe -> refactor
   @HttpCode(200)
   @ApiOperation({
     summary: 'Unsubscribe logged user',
@@ -253,7 +254,7 @@ export class UserController {
     if (
       user[CognitoUserAttributesEnum.ACCOUNT_TYPE] === CognitoUserAccountTypesEnum.PHYSICAL_ENTITY
     ) {
-      const result: ResponseUserDataDto = await this.userService.subUnsubUser(
+      const result = await this.userService.subUnsubUser(
         user,
         GDPRSubTypeEnum.unsubscribe,
         data.gdprData
@@ -266,7 +267,7 @@ export class UserController {
       user[CognitoUserAttributesEnum.ACCOUNT_TYPE] ===
         CognitoUserAccountTypesEnum.SELF_EMPLOYED_ENTITY
     ) {
-      const result: ResponseLegalPersonDataDto = await this.userService.subUnsubLegalPerson(
+      const result = await this.userService.subUnsubLegalPerson(
         user,
         GDPRSubTypeEnum.unsubscribe,
         data.gdprData

--- a/nest-city-account/src/user/user.service.spec.ts
+++ b/nest-city-account/src/user/user.service.spec.ts
@@ -6,11 +6,14 @@ import { PrismaService } from '../prisma/prisma.service'
 import ThrowerErrorGuard from '../utils/guards/errors.guard'
 import { BloomreachService } from '../bloomreach/bloomreach.service'
 import { CognitoSubservice } from '../utils/subservices/cognito.subservice'
-import { DeliveryMethodEnum } from '@prisma/client'
+import { DeliveryMethodEnum, GDPRCategoryEnum, GDPRSubTypeEnum, GDPRTypeEnum } from '@prisma/client'
 import prismaMock from '../../test/singleton'
 import { getTaxDeadlineDate } from '../utils/constants/tax-deadline'
 import { UserTierService } from './user-tier.service'
 import { TaxSubservice } from '../utils/subservices/tax.subservice'
+import { GdprDataDto, UserOfficialCorrespondenceChannelEnum } from './dtos/gdpr.user.dto'
+import { CognitoGetUserData, CognitoUserAttributesEnum } from '../utils/global-dtos/cognito.dto'
+import { User } from '@prisma/client'
 
 jest.mock('../utils/constants/tax-deadline')
 
@@ -56,6 +59,67 @@ describe('UserService', () => {
 
   afterEach(() => {
     jest.clearAllMocks()
+  })
+
+  describe('subUnsubUser', () => {
+    const mockCognitoUserData = {
+      [CognitoUserAttributesEnum.ACCOUNT_TYPE]: 'PHYSICAL_ENTITY',
+      idUser: 'cognito-ext-123',
+      email: 'test@bratislava.sk',
+      UserCreateDate: new Date('2024-01-01'),
+    } as unknown as CognitoGetUserData
+
+    const gdprDataTaxFormalCommunication: GdprDataDto[] = [
+      {
+        category: GDPRCategoryEnum.TAXES,
+        type: GDPRTypeEnum.FORMAL_COMMUNICATION,
+      },
+    ]
+
+    it.each([
+      [UserOfficialCorrespondenceChannelEnum.EMAIL, GDPRSubTypeEnum.subscribe],
+      [UserOfficialCorrespondenceChannelEnum.POSTAL, GDPRSubTypeEnum.unsubscribe],
+    ] as const)(
+      'should return officialCorrespondenceChannel %s when called with GDPRSubTypeEnum.%s',
+      async (expectedChannel, gdprSubType) => {
+        const mockUser = {
+          id: 'user-1',
+          externalId: 'cognito-ext-123',
+          email: 'test@bratislava.sk',
+          birthNumber: '9909090000',
+          isDeceased: false,
+          taxDeliveryMethodAtLockDate: null,
+          taxDeliveryMethodCityAccountLockDate: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }
+        userDataSubservice.getOrCreateUser.mockResolvedValue(mockUser as User)
+        userDataSubservice.getOfficialCorrespondenceChannel.mockResolvedValue(expectedChannel)
+        userDataSubservice.getShowEmailCommunicationBanner.mockResolvedValue(false)
+        userDataSubservice.getUserGdprData.mockResolvedValue([])
+
+        const result = await service.subUnsubUser(
+          mockCognitoUserData,
+          gdprSubType,
+          gdprDataTaxFormalCommunication
+        )
+
+        expect(userDataSubservice.getOfficialCorrespondenceChannel).toHaveBeenCalledWith(
+          mockUser.id
+        )
+        expect(result.officialCorrespondenceChannel).toBe(expectedChannel)
+        expect(userDataSubservice.changeUserGdprData).toHaveBeenCalledWith(
+          mockUser.id,
+          expect.arrayContaining([
+            expect.objectContaining({
+              category: GDPRCategoryEnum.TAXES,
+              type: GDPRTypeEnum.FORMAL_COMMUNICATION,
+              subType: gdprSubType,
+            }),
+          ])
+        )
+      }
+    )
   })
 
   describe('hasChangedDeliveryMethodAfterDeadline', () => {

--- a/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
+++ b/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
@@ -9,7 +9,8 @@ import { UserOfficialCorrespondenceChannelEnum } from '../../dtos/gdpr.user.dto'
 import prismaMock from '../../../../test/singleton'
 
 describe('UserDataSubservice', () => {
-  let subservice: UserDataSubservice
+  let userDataSubservice: UserDataSubservice
+  let bloomreachSubservice: BloomreachService
   let prisma: typeof prismaMock
 
   const userId = 'user-123'
@@ -44,7 +45,8 @@ describe('UserDataSubservice', () => {
       ],
     }).compile()
 
-    subservice = module.get<UserDataSubservice>(UserDataSubservice)
+    userDataSubservice = module.get<UserDataSubservice>(UserDataSubservice)
+    bloomreachSubservice = module.get<BloomreachService>(BloomreachService)
     prisma = module.get(PrismaService)
   })
 
@@ -67,7 +69,7 @@ describe('UserDataSubservice', () => {
           createdAt: new Date(),
         } as unknown as UserGdprData)
 
-        const result = await subservice.getOfficialCorrespondenceChannel(userId)
+        const result = await userDataSubservice.getOfficialCorrespondenceChannel(userId)
 
         expect(result).toBe(expectedChannel)
       }
@@ -81,14 +83,14 @@ describe('UserDataSubservice', () => {
       }
       prisma.user.findUnique.mockResolvedValue(userWithEdesk as unknown as User)
 
-      const result = await subservice.getOfficialCorrespondenceChannel(userId)
+      const result = await userDataSubservice.getOfficialCorrespondenceChannel(userId)
 
       expect(result).toBe(UserOfficialCorrespondenceChannelEnum.EDESK)
     })
   })
 
   describe('changeUserGdprData', () => {
-    it('should call processDeliveryMethodMayHaveChanged when gdprData contains tax delivery data (category TAXES, type FORMAL_COMMUNICATION)', async () => {
+    it('should call enqueueTrackCustomerToBloomreachOutbox when gdprData contains tax delivery data (category TAXES, type FORMAL_COMMUNICATION)', async () => {
       const gdprData = [
         {
           ...gdprParams,
@@ -102,11 +104,11 @@ describe('UserDataSubservice', () => {
       prisma.userGdprData.createMany.mockResolvedValue({ count: 1 })
 
       const processDeliverySpy = jest.spyOn(
-        subservice,
-        'processDeliveryMethodMayHaveChanged'
+        bloomreachSubservice,
+        'enqueueTrackCustomerToBloomreachOutbox'
       )
 
-      await subservice.changeUserGdprData(userId, gdprData)
+      await userDataSubservice.changeUserGdprData(userId, gdprData)
 
       expect(processDeliverySpy).toHaveBeenCalledWith(userId)
     })

--- a/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
+++ b/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
@@ -57,7 +57,7 @@ describe('UserDataSubservice', () => {
       [UserOfficialCorrespondenceChannelEnum.EMAIL, GDPRSubTypeEnum.subscribe],
       [UserOfficialCorrespondenceChannelEnum.POSTAL, GDPRSubTypeEnum.unsubscribe],
     ] as const)(
-      'should return %s when subtype is %s (as in subUnsubUser with gdprData category TAXES, type FORMAL_COMMUNICATION)',
+      'should return %s when subtype is %s (with gdprData category TAXES, type FORMAL_COMMUNICATION)',
       async (expectedChannel, subtype) => {
         prisma.user.findUnique.mockResolvedValue(mockUser as unknown as User)
         prisma.userGdprData.findFirst.mockResolvedValue({
@@ -84,6 +84,31 @@ describe('UserDataSubservice', () => {
       const result = await subservice.getOfficialCorrespondenceChannel(userId)
 
       expect(result).toBe(UserOfficialCorrespondenceChannelEnum.EDESK)
+    })
+  })
+
+  describe('changeUserGdprData', () => {
+    it('should call processDeliveryMethodMayHaveChanged when gdprData contains tax delivery data (category TAXES, type FORMAL_COMMUNICATION)', async () => {
+      const gdprData = [
+        {
+          ...gdprParams,
+          subType: GDPRSubTypeEnum.subscribe,
+        },
+      ]
+      prisma.user.findUnique.mockResolvedValue({
+        id: userId,
+        externalId: 'ext-123',
+      } as unknown as User)
+      prisma.userGdprData.createMany.mockResolvedValue({ count: 1 })
+
+      const processDeliverySpy = jest.spyOn(
+        subservice,
+        'processDeliveryMethodMayHaveChanged'
+      )
+
+      await subservice.changeUserGdprData(userId, gdprData)
+
+      expect(processDeliverySpy).toHaveBeenCalledWith(userId)
     })
   })
 })

--- a/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
+++ b/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
@@ -14,6 +14,7 @@ describe('UserDataSubservice', () => {
   let prisma: typeof prismaMock
 
   const userId = 'user-123'
+  const userExternalId = 'ext-123'
   const gdprParams = {
     category: GDPRCategoryEnum.TAXES,
     type: GDPRTypeEnum.FORMAL_COMMUNICATION,
@@ -99,7 +100,7 @@ describe('UserDataSubservice', () => {
       ]
       prisma.user.findUnique.mockResolvedValue({
         id: userId,
-        externalId: 'ext-123',
+        externalId: userExternalId,
       } as unknown as User)
       prisma.userGdprData.createMany.mockResolvedValue({ count: 1 })
 
@@ -110,7 +111,7 @@ describe('UserDataSubservice', () => {
 
       await userDataSubservice.changeUserGdprData(userId, gdprData)
 
-      expect(processDeliverySpy).toHaveBeenCalledWith(userId)
+      expect(processDeliverySpy).toHaveBeenCalledWith(userExternalId)
     })
   })
 })

--- a/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
+++ b/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
@@ -10,8 +10,8 @@ import prismaMock from '../../../../test/singleton'
 
 describe('UserDataSubservice', () => {
   let userDataSubservice: UserDataSubservice
-  let bloomreachSubservice: BloomreachService
   let prisma: typeof prismaMock
+  let bloomreachService: BloomreachService
 
   const userId = 'user-123'
   const userExternalId = 'ext-123'
@@ -47,8 +47,8 @@ describe('UserDataSubservice', () => {
     }).compile()
 
     userDataSubservice = module.get<UserDataSubservice>(UserDataSubservice)
-    bloomreachSubservice = module.get<BloomreachService>(BloomreachService)
     prisma = module.get(PrismaService)
+    bloomreachService = module.get(BloomreachService)
   })
 
   afterEach(() => {
@@ -91,7 +91,7 @@ describe('UserDataSubservice', () => {
   })
 
   describe('changeUserGdprData', () => {
-    it('should call enqueueTrackCustomerToBloomreachOutbox when gdprData contains tax delivery data (category TAXES, type FORMAL_COMMUNICATION)', async () => {
+    it('should call transaction or enqueueTrackCustomerToBloomreachOutbox when gdprData contains tax delivery data (category TAXES, type FORMAL_COMMUNICATION)', async () => {
       const gdprData = [
         {
           ...gdprParams,
@@ -102,16 +102,17 @@ describe('UserDataSubservice', () => {
         id: userId,
         externalId: userExternalId,
       } as unknown as User)
-      prisma.userGdprData.createMany.mockResolvedValue({ count: 1 })
-
-      const processDeliverySpy = jest.spyOn(
-        bloomreachSubservice,
-        'enqueueTrackCustomerToBloomreachOutbox'
+      ;(prisma.$transaction as unknown as jest.Mock).mockImplementation(
+        (callback: (tx: typeof prismaMock) => unknown) => callback(prismaMock)
       )
+      prisma.userGdprData.createMany.mockResolvedValue({ count: 1 } as never)
 
       await userDataSubservice.changeUserGdprData(userId, gdprData)
-
-      expect(processDeliverySpy).toHaveBeenCalledWith(userExternalId)
+      expect(prisma.$transaction).toHaveBeenCalled()
+      expect(bloomreachService.enqueueTrackCustomerToBloomreachOutbox).toHaveBeenCalledWith(
+        prismaMock,
+        userExternalId
+      )
     })
   })
 })

--- a/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
+++ b/nest-city-account/src/user/utils/subservice/user-data.subservice.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { createMock } from '@golevelup/ts-jest'
+import { UserDataSubservice } from './user-data.subservice'
+import { PrismaService } from '../../../prisma/prisma.service'
+import ThrowerErrorGuard from '../../../utils/guards/errors.guard'
+import { BloomreachService } from '../../../bloomreach/bloomreach.service'
+import { GDPRCategoryEnum, GDPRSubTypeEnum, GDPRTypeEnum, User, UserGdprData } from '@prisma/client'
+import { UserOfficialCorrespondenceChannelEnum } from '../../dtos/gdpr.user.dto'
+import prismaMock from '../../../../test/singleton'
+
+describe('UserDataSubservice', () => {
+  let subservice: UserDataSubservice
+  let prisma: typeof prismaMock
+
+  const userId = 'user-123'
+  const gdprParams = {
+    category: GDPRCategoryEnum.TAXES,
+    type: GDPRTypeEnum.FORMAL_COMMUNICATION,
+  }
+
+  const mockUser = {
+    id: userId,
+    physicalEntity: { activeEdesk: false },
+    taxDeliveryMethodAtLockDate: null,
+    taxDeliveryMethodCityAccountLockDate: null,
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserDataSubservice,
+        {
+          provide: PrismaService,
+          useValue: prismaMock,
+        },
+        {
+          provide: ThrowerErrorGuard,
+          useValue: createMock<ThrowerErrorGuard>(),
+        },
+        {
+          provide: BloomreachService,
+          useValue: createMock<BloomreachService>(),
+        },
+      ],
+    }).compile()
+
+    subservice = module.get<UserDataSubservice>(UserDataSubservice)
+    prisma = module.get(PrismaService)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getOfficialCorrespondenceChannel', () => {
+    it.each([
+      [UserOfficialCorrespondenceChannelEnum.EMAIL, GDPRSubTypeEnum.subscribe],
+      [UserOfficialCorrespondenceChannelEnum.POSTAL, GDPRSubTypeEnum.unsubscribe],
+    ] as const)(
+      'should return %s when subtype is %s (as in subUnsubUser with gdprData category TAXES, type FORMAL_COMMUNICATION)',
+      async (expectedChannel, subtype) => {
+        prisma.user.findUnique.mockResolvedValue(mockUser as unknown as User)
+        prisma.userGdprData.findFirst.mockResolvedValue({
+          userId,
+          ...gdprParams,
+          subType: subtype,
+          createdAt: new Date(),
+        } as unknown as UserGdprData)
+
+        const result = await subservice.getOfficialCorrespondenceChannel(userId)
+
+        expect(result).toBe(expectedChannel)
+      }
+    )
+    it('should return EDESK when user has activeEdesk = true', async () => {
+      const userWithEdesk = {
+        id: userId,
+        physicalEntity: { activeEdesk: true },
+        taxDeliveryMethodAtLockDate: null,
+        taxDeliveryMethodCityAccountLockDate: null,
+      }
+      prisma.user.findUnique.mockResolvedValue(userWithEdesk as unknown as User)
+
+      const result = await subservice.getOfficialCorrespondenceChannel(userId)
+
+      expect(result).toBe(UserOfficialCorrespondenceChannelEnum.EDESK)
+    })
+  })
+})

--- a/nest-city-account/src/user/utils/subservice/user-data.subservice.ts
+++ b/nest-city-account/src/user/utils/subservice/user-data.subservice.ts
@@ -15,6 +15,7 @@ import { LineLoggerSubservice } from '../../../utils/subservices/line-logger.sub
 import { BloomreachService } from '../../../bloomreach/bloomreach.service'
 import { UserErrorsEnum, UserErrorsResponseEnum } from '../../user.error.enum'
 import {
+  BloomreachOutbox,
   DeliveryMethodEnum,
   DeliveryMethodUserEnum,
   GDPRCategoryEnum,
@@ -99,7 +100,7 @@ export class UserDataSubservice {
     return this.postprocessUser(userData.externalId, user)
   }
 
-  async postprocessUser(externalId: string, user: User, changeGdprData: boolean = false) {
+  async postprocessUser(externalId: string, user: User, changeGdprData = false) {
     if (changeGdprData) {
       await this.changeUserGdprData(user.id, [
         {
@@ -482,17 +483,24 @@ export class UserDataSubservice {
         'Delivery method set more than once at the same time'
       )
     }
-    if (taxDeliveryData.length > 0) {
-      await this.processDeliveryMethodMayHaveChanged(userId)
-    }
 
-    await this.prisma.userGdprData.createMany({
-      data: gdprData.map((elem) => ({
-        type: elem.type,
-        category: elem.category,
-        subType: elem.subType,
-        userId: user.id,
-      })),
+    await this.prisma.$transaction(async (tx) => {
+      const userGdprData = await tx.userGdprData.createMany({
+        data: gdprData.map((elem) => ({
+          type: elem.type,
+          category: elem.category,
+          subType: elem.subType,
+          userId: user.id,
+        })),
+      })
+      let bloomreachOutbox: BloomreachOutbox | undefined
+      if (taxDeliveryData.length > 0 && user.externalId) {
+        bloomreachOutbox = await this.bloomreachService.enqueueTrackCustomerToBloomreachOutbox(
+          tx,
+          user.externalId
+        )
+      }
+      return { userGdprData, bloomreachOutbox }
     })
 
     await this.bloomreachService.trackEventConsents(gdprData, user.externalId, user.id, false)
@@ -633,16 +641,5 @@ export class UserDataSubservice {
           return !!userLoginListItem.id
         })
     )
-  }
-
-  async processDeliveryMethodMayHaveChanged(userId: string): Promise<boolean> {
-    const user = await this.prisma.user.findUnique({
-      where: { id: userId },
-      select: { externalId: true },
-    })
-    if (user?.externalId) {
-      return (await this.bloomreachService.trackCustomer(user.externalId)) ?? false
-    }
-    return false
   }
 }

--- a/nest-city-account/src/user/utils/subservice/user-data.subservice.ts
+++ b/nest-city-account/src/user/utils/subservice/user-data.subservice.ts
@@ -482,6 +482,9 @@ export class UserDataSubservice {
         'Delivery method set more than once at the same time'
       )
     }
+    if (taxDeliveryData.length > 0) {
+      await this.processDeliveryMethodMayHaveChanged(userId)
+    }
 
     await this.prisma.userGdprData.createMany({
       data: gdprData.map((elem) => ({
@@ -630,5 +633,16 @@ export class UserDataSubservice {
           return !!userLoginListItem.id
         })
     )
+  }
+
+  async processDeliveryMethodMayHaveChanged(userId: string): Promise<boolean> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { externalId: true },
+    })
+    if (user?.externalId) {
+      return (await this.bloomreachService.trackCustomer(user.externalId)) ?? false
+    }
+    return false
   }
 }

--- a/nest-city-account/src/user/utils/subservice/user-data.subservice.ts
+++ b/nest-city-account/src/user/utils/subservice/user-data.subservice.ts
@@ -371,12 +371,25 @@ export class UserDataSubservice {
       )
     }
 
+    const gdrpDataTaxesFormalCommunication = await this.prisma.userGdprData.findFirst({
+      take: 1,
+      where: {
+        userId: user.id,
+        category: GDPRCategoryEnum.TAXES,
+        type: GDPRTypeEnum.FORMAL_COMMUNICATION,
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+
     const active = user.physicalEntity?.activeEdesk
       ? { deliveryMethod: DeliveryMethodEnum.EDESK }
-      : user.taxDeliveryMethod
+      : gdrpDataTaxesFormalCommunication
         ? {
-            deliveryMethod: user.taxDeliveryMethod,
-            date: user.taxDeliveryMethodCityAccountDate ?? undefined,
+            deliveryMethod:
+              gdrpDataTaxesFormalCommunication?.subType === GDPRSubTypeEnum.subscribe
+                ? DeliveryMethodEnum.CITY_ACCOUNT
+                : DeliveryMethodEnum.POSTAL,
+            date: gdrpDataTaxesFormalCommunication?.createdAt ?? undefined,
           }
         : undefined
 
@@ -402,7 +415,16 @@ export class UserDataSubservice {
         id: userId,
       },
       select: {
-        taxDeliveryMethod: true,
+        userGdprData: {
+          take: 1,
+          where: {
+            userId: userId,
+            category: GDPRCategoryEnum.TAXES,
+            type: GDPRTypeEnum.FORMAL_COMMUNICATION,
+          },
+          // not needed, but to be consistent
+          orderBy: { createdAt: 'desc' },
+        },
       },
     })
     const hasEdesk = await this.prisma.physicalEntity.findUnique({
@@ -410,7 +432,9 @@ export class UserDataSubservice {
         userId,
       },
     })
-    return !(user?.taxDeliveryMethod || hasEdesk?.activeEdesk)
+
+    const gdrpDataTaxesFormalCommunication = user?.userGdprData && user?.userGdprData?.length > 0
+    return !(gdrpDataTaxesFormalCommunication || hasEdesk?.activeEdesk)
   }
 
   private isTaxDeliveryData(elem: ResponseGdprUserDataDto): boolean {
@@ -457,18 +481,6 @@ export class UserDataSubservice {
         ErrorsResponseEnum.INTERNAL_SERVER_ERROR,
         'Delivery method set more than once at the same time'
       )
-    }
-
-    if (taxDeliveryData.length > 0) {
-      await this.prisma.user.update({
-        where: { id: userId },
-        data: {
-          taxDeliveryMethod: taxDeliveryData[0],
-          ...(taxDeliveryData[0] === DeliveryMethodUserEnum.CITY_ACCOUNT && {
-            taxDeliveryMethodCityAccountDate: new Date(),
-          }),
-        },
-      })
     }
 
     await this.prisma.userGdprData.createMany({

--- a/nest-tax-backend/README.md
+++ b/nest-tax-backend/README.md
@@ -36,7 +36,7 @@ npx prisma
 
 - Migrate database and generate prisma files
 
-```
+```bash
 npx prisma migrate dev
 npx prisma generate
 ```


### PR DESCRIPTION
- remove duplicated data stored in table `User` columns `taxDeliveryMethod`, `taxDeliveryMethodCityAccountDate`
- change logic off getting lastDeliveryMethod
- add `BloomreachOutbox` to properly process requests to third party service
- add tests

Closes https://github.com/bratislava/private-konto.bratislava.sk/issues/1077