### PR TITLE
1318: refactor unpaid tax and tax installment bloomreach events

### DIFF
--- a/nest-tax-backend/src/bloomreach/bloomreach.service.ts
+++ b/nest-tax-backend/src/bloomreach/bloomreach.service.ts
@@ -9,7 +9,6 @@ import {
   TaxBloomreachData,
   TaxPaymentBloomreachData,
   UnpaidTaxInstallmentReminderBloomreachData,
-  UnpaidTaxReminderBloomreachData,
 } from './bloomreach.types'
 
 @Injectable()
@@ -112,17 +111,6 @@ export class BloomreachService {
       BloomreachEventNameEnum.TAX,
     )
     return pushEventResult
-  }
-
-  async trackEventUnpaidTaxReminder(
-    taxData: UnpaidTaxReminderBloomreachData,
-    cognitoId: string,
-  ): Promise<boolean> {
-    return this.trackEvent(
-      taxData,
-      cognitoId,
-      BloomreachEventNameEnum.UNPAID_TAX_REMINDER,
-    )
   }
 
   async trackEventUnpaidTaxInstallmentReminder(

--- a/nest-tax-backend/src/bloomreach/bloomreach.types.ts
+++ b/nest-tax-backend/src/bloomreach/bloomreach.types.ts
@@ -5,7 +5,6 @@ import { INSTALLMENT_DUE_DATE_TYPE } from '../tasks/utils/types'
 export enum BloomreachEventNameEnum {
   TAX = 'tax',
   TAX_PAYMENT = 'tax_payment',
-  UNPAID_TAX_REMINDER = 'unpaid_tax_reminder',
   UNPAID_TAX_INSTALLMENT_REMINDER = 'unpaid_tax_installment_reminder',
 }
 
@@ -25,12 +24,6 @@ export interface TaxBloomreachData {
   tax_type: TaxType
   order: number
   suppress_email: boolean
-}
-
-export interface UnpaidTaxReminderBloomreachData {
-  year: number
-  tax_type: TaxType
-  order: number
 }
 
 export interface UnpaidTaxInstallmentReminderBloomreachData {

--- a/nest-tax-backend/src/bloomreach/bloomreach.types.ts
+++ b/nest-tax-backend/src/bloomreach/bloomreach.types.ts
@@ -5,7 +5,6 @@ import { INSTALLMENT_DUE_DATE_TYPE } from '../tasks/utils/types'
 export enum BloomreachEventNameEnum {
   TAX = 'tax',
   TAX_PAYMENT = 'tax_payment',
-  UNPAID_TAX_REMINDER = 'unpaid_tax_reminder',
   UNPAID_TAX_INSTALLMENT_REMINDER = 'unpaid_tax_installment_reminder',
 }
 
@@ -26,12 +25,6 @@ export interface TaxBloomreachData {
   tax_type: TaxType
   order: number
   suppress_email: boolean
-}
-
-export interface UnpaidTaxReminderBloomreachData {
-  year: number
-  tax_type: TaxType
-  order: number
 }
 
 export interface UnpaidTaxInstallmentReminderBloomreachData {

--- a/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
+++ b/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
@@ -514,15 +514,15 @@ describe('NotificationsEventsSubservice', () => {
       const findManyMock = jest
         .spyOn(service['prismaService'].tax, 'findMany')
         .mockResolvedValue([])
-      const trackEventUnpaidTaxReminderMock = jest.spyOn(
+      const trackEventUnpaidTaxInstallmentReminderMock = jest.spyOn(
         service['bloomreachService'],
-        'trackEventUnpaidTaxReminder',
+        'trackEventUnpaidTaxInstallmentReminder',
       )
 
       await service.sendUnpaidTaxReminders()
 
       expect(findManyMock).toHaveBeenCalled()
-      expect(trackEventUnpaidTaxReminderMock).not.toHaveBeenCalled()
+      expect(trackEventUnpaidTaxInstallmentReminderMock).not.toHaveBeenCalled()
     })
 
     it('should send payment reminder events when there are taxes', async () => {
@@ -539,9 +539,9 @@ describe('NotificationsEventsSubservice', () => {
             },
           },
         ] as any)
-      const trackEventUnpaidTaxReminderMock = jest.spyOn(
+      const trackEventUnpaidTaxInstallmentReminderMock = jest.spyOn(
         service['bloomreachService'],
-        'trackEventUnpaidTaxReminder',
+        'trackEventUnpaidTaxInstallmentReminder',
       )
       jest
         .spyOn(service['cityAccountSubservice'], 'getUserDataAdminBatch')
@@ -555,7 +555,7 @@ describe('NotificationsEventsSubservice', () => {
       await service.sendUnpaidTaxReminders()
 
       expect(findManyMock).toHaveBeenCalled()
-      expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledWith(
+      expect(trackEventUnpaidTaxInstallmentReminderMock).toHaveBeenCalledWith(
         {
           year: 2024,
           tax_type: TaxType.DZN,
@@ -597,9 +597,9 @@ describe('NotificationsEventsSubservice', () => {
             },
           },
         ] as any)
-      const trackEventUnpaidTaxReminderMock = jest.spyOn(
+      const trackEventUnpaidTaxInstallmentReminderMock = jest.spyOn(
         service['bloomreachService'],
-        'trackEventUnpaidTaxReminder',
+        'trackEventUnpaidTaxInstallmentReminder',
       )
       jest
         .spyOn(service['cityAccountSubservice'], 'getUserDataAdminBatch')
@@ -616,20 +616,30 @@ describe('NotificationsEventsSubservice', () => {
       await service.sendUnpaidTaxReminders()
 
       expect(findManyMock).toHaveBeenCalled()
-      expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledTimes(2)
-      expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledWith(
+      expect(trackEventUnpaidTaxInstallmentReminderMock).toHaveBeenCalledTimes(
+        2,
+      )
+      expect(trackEventUnpaidTaxInstallmentReminderMock).toHaveBeenCalledWith(
         {
           year: 2024,
           tax_type: TaxType.DZN,
           order: 1,
+          installment_order: 1,
+          due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
+          due_date_month: 5,
+          due_date_day: 31,
         },
         'external-id-1',
       )
-      expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledWith(
+      expect(trackEventUnpaidTaxInstallmentReminderMock).toHaveBeenCalledWith(
         {
           year: 2024,
           tax_type: TaxType.KO,
           order: 2,
+          installment_order: 1,
+          due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
+          due_date_month: 5,
+          due_date_day: 31,
         },
         'external-id-2',
       )

--- a/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
+++ b/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
@@ -1,6 +1,11 @@
 import { createMock } from '@golevelup/ts-jest'
 import { Test, TestingModule } from '@nestjs/testing'
-import { PaymentStatus, TaxType, UnpaidReminderSent } from '@prisma/client'
+import {
+  DeliveryMethodNamed,
+  PaymentStatus,
+  TaxType,
+  UnpaidReminderSent,
+} from '@prisma/client'
 import dayjs, { type Dayjs } from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
@@ -537,6 +542,10 @@ describe('NotificationsEventsSubservice', () => {
             taxPayer: {
               birthNumber: '123456/7890',
             },
+            // May 16, 2024 + 15 days = May 31, 2024 (Friday, not a holiday)
+            dateTaxRuling: new Date('2024-05-16'),
+            deliveryMethod: null,
+            createdAt: new Date('2024-01-01'),
           },
         ] as any)
       const trackEventUnpaidTaxInstallmentReminderMock = jest.spyOn(
@@ -560,6 +569,10 @@ describe('NotificationsEventsSubservice', () => {
           year: 2024,
           tax_type: TaxType.DZN,
           order: 1,
+          installment_order: 1,
+          due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
+          due_date_month: 5,
+          due_date_day: 31,
         },
         'external-id-123',
       )
@@ -577,6 +590,10 @@ describe('NotificationsEventsSubservice', () => {
             taxPayer: {
               birthNumber: '123456/7890',
             },
+            // May 16, 2024 + 15 days = May 31, 2024 (Friday, not a holiday)
+            dateTaxRuling: new Date('2024-05-16'),
+            deliveryMethod: null,
+            createdAt: new Date('2024-01-01'),
           },
           {
             id: 2,
@@ -586,6 +603,9 @@ describe('NotificationsEventsSubservice', () => {
             taxPayer: {
               birthNumber: '123456/7891',
             },
+            dateTaxRuling: new Date('2024-05-16'),
+            deliveryMethod: null,
+            createdAt: new Date('2024-01-01'),
           },
           {
             id: 3,
@@ -595,6 +615,9 @@ describe('NotificationsEventsSubservice', () => {
             taxPayer: {
               birthNumber: '123456/7892',
             },
+            dateTaxRuling: new Date('2024-05-16'),
+            deliveryMethod: null,
+            createdAt: new Date('2024-01-01'),
           },
         ] as any)
       const trackEventUnpaidTaxInstallmentReminderMock = jest.spyOn(
@@ -642,6 +665,128 @@ describe('NotificationsEventsSubservice', () => {
           due_date_day: 31,
         },
         'external-id-2',
+      )
+    })
+  })
+
+  describe('sendUnpaidTaxReminders due date calculation', () => {
+    const birthNumber = '123456/7890'
+    const externalId = 'external-id-123'
+
+    beforeEach(() => {
+      jest
+        .spyOn(service['cityAccountSubservice'], 'getUserDataAdminBatch')
+        .mockResolvedValue({ [birthNumber]: { externalId } } as any)
+      jest
+        .spyOn(
+          service['bloomreachService'],
+          'trackEventUnpaidTaxInstallmentReminder',
+        )
+        .mockResolvedValue(true)
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should not send event when due date is in the future', async () => {
+      // Fix "now" at 2024-04-01; dateTaxRuling 2024-04-01 + 15 days = April 16 → still in future
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2024-04-01T12:00:00.000Z'))
+
+      jest.spyOn(service['prismaService'].tax, 'findMany').mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          taxPayer: { birthNumber },
+          dateTaxRuling: new Date('2024-04-01'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+        },
+      ] as any)
+
+      await service.sendUnpaidTaxReminders()
+
+      expect(
+        bloomreachService.trackEventUnpaidTaxInstallmentReminder,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('sends correct due_date_month/day for non-CITY_ACCOUNT using dateTaxRuling', async () => {
+      // May 16, 2024 + 15 days = May 31, 2024 (Friday, not a holiday)
+      jest.spyOn(service['prismaService'].tax, 'findMany').mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          taxPayer: { birthNumber },
+          dateTaxRuling: new Date('2024-05-16'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+        },
+      ] as any)
+
+      await service.sendUnpaidTaxReminders()
+
+      expect(
+        bloomreachService.trackEventUnpaidTaxInstallmentReminder,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ due_date_month: 5, due_date_day: 31 }),
+        externalId,
+      )
+    })
+
+    it('sends correct due_date_month/day for CITY_ACCOUNT delivery using createdAt', async () => {
+      // createdAt May 16, 2024 + 15 days = May 31, 2024 (Friday, not a holiday)
+      jest.spyOn(service['prismaService'].tax, 'findMany').mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          taxPayer: { birthNumber },
+          dateTaxRuling: null,
+          deliveryMethod: DeliveryMethodNamed.CITY_ACCOUNT,
+          createdAt: new Date('2024-05-16'),
+        },
+      ] as any)
+
+      await service.sendUnpaidTaxReminders()
+
+      expect(
+        bloomreachService.trackEventUnpaidTaxInstallmentReminder,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ due_date_month: 5, due_date_day: 31 }),
+        externalId,
+      )
+    })
+
+    it('adjusts due date to next working day when it falls on a weekend', async () => {
+      // Feb 16, 2024 (Friday) + 15 days = March 2, 2024 (Saturday)
+      // → skip Saturday and Sunday → March 4, 2024 (Monday, not a holiday)
+      jest.spyOn(service['prismaService'].tax, 'findMany').mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          taxPayer: { birthNumber },
+          dateTaxRuling: new Date('2024-02-16'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+        },
+      ] as any)
+
+      await service.sendUnpaidTaxReminders()
+
+      expect(
+        bloomreachService.trackEventUnpaidTaxInstallmentReminder,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ due_date_month: 3, due_date_day: 4 }),
+        externalId,
       )
     })
   })

--- a/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
+++ b/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
@@ -1,6 +1,11 @@
 import { createMock } from '@golevelup/ts-jest'
 import { Test, TestingModule } from '@nestjs/testing'
-import { PaymentStatus, TaxType, UnpaidReminderSent } from '@prisma/client'
+import {
+  DeliveryMethodNamed,
+  PaymentStatus,
+  TaxType,
+  UnpaidReminderSent,
+} from '@prisma/client'
 import dayjs, { type Dayjs } from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
@@ -533,7 +538,7 @@ describe('NotificationsEventsSubservice', () => {
   describe('sendUnpaidTaxReminders', () => {
     it('should not do anything when there are no taxes', async () => {
       prismaMock.$queryRaw.mockResolvedValue([])
-      const trackEventUnpaidTaxReminderMock = jest.spyOn(
+      const trackEventUnpaidTaxInstallmentReminderMock = jest.spyOn(
         service['bloomreachService'],
         'trackEventUnpaidTaxInstallmentReminder',
       )
@@ -541,7 +546,7 @@ describe('NotificationsEventsSubservice', () => {
       await service.sendUnpaidTaxReminders()
 
       expect(prismaMock.$queryRaw).toHaveBeenCalled()
-      expect(trackEventUnpaidTaxReminderMock).not.toHaveBeenCalled()
+      expect(trackEventUnpaidTaxInstallmentReminderMock).not.toHaveBeenCalled()
     })
 
     it('should send payment reminder events when there are taxes', async () => {
@@ -552,9 +557,14 @@ describe('NotificationsEventsSubservice', () => {
           type: TaxType.DZN,
           order: 1,
           birthNumber: '123456/7890',
+          // May 16, 2024 + 15 days = May 31, 2024 (Friday, not a holiday)
+          dateTaxRuling: new Date('2024-05-16'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+          amount: 5000,
         },
       ])
-      const trackEventUnpaidTaxReminderMock = jest.spyOn(
+      const trackEventUnpaidTaxInstallmentReminderMock = jest.spyOn(
         service['bloomreachService'],
         'trackEventUnpaidTaxInstallmentReminder',
       )
@@ -570,11 +580,16 @@ describe('NotificationsEventsSubservice', () => {
       await service.sendUnpaidTaxReminders()
 
       expect(prismaMock.$queryRaw).toHaveBeenCalled()
-      expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledWith(
+      expect(trackEventUnpaidTaxInstallmentReminderMock).toHaveBeenCalledWith(
         {
           year: 2024,
           tax_type: TaxType.DZN,
           order: 1,
+          installment_order: 1,
+          due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
+          due_date_month: 5,
+          due_date_day: 31,
+          are_installments_possible: false,
         },
         'external-id-123',
       )
@@ -588,6 +603,11 @@ describe('NotificationsEventsSubservice', () => {
           type: TaxType.DZN,
           order: 1,
           birthNumber: '123456/7890',
+          // May 16, 2024 + 15 days = May 31, 2024 (Friday, not a holiday)
+          dateTaxRuling: new Date('2024-05-16'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+          amount: 5000,
         },
         {
           id: 2,
@@ -595,6 +615,10 @@ describe('NotificationsEventsSubservice', () => {
           type: TaxType.KO,
           order: 2,
           birthNumber: '123456/7891',
+          dateTaxRuling: new Date('2024-05-16'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+          amount: 10000,
         },
         {
           id: 3,
@@ -602,9 +626,13 @@ describe('NotificationsEventsSubservice', () => {
           type: TaxType.DZN,
           order: 1,
           birthNumber: '123456/7892',
+          dateTaxRuling: new Date('2024-05-16'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+          amount: 5000,
         },
       ])
-      const trackEventUnpaidTaxReminderMock = jest.spyOn(
+      const trackEventUnpaidTaxInstallmentReminderMock = jest.spyOn(
         service['bloomreachService'],
         'trackEventUnpaidTaxInstallmentReminder',
       )
@@ -623,8 +651,10 @@ describe('NotificationsEventsSubservice', () => {
       await service.sendUnpaidTaxReminders()
 
       expect(prismaMock.$queryRaw).toHaveBeenCalled()
-      expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledTimes(2)
-      expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledWith(
+      expect(trackEventUnpaidTaxInstallmentReminderMock).toHaveBeenCalledTimes(
+        2,
+      )
+      expect(trackEventUnpaidTaxInstallmentReminderMock).toHaveBeenCalledWith(
         {
           year: 2024,
           tax_type: TaxType.DZN,
@@ -633,10 +663,11 @@ describe('NotificationsEventsSubservice', () => {
           due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
           due_date_month: 5,
           due_date_day: 31,
+          are_installments_possible: false,
         },
         'external-id-1',
       )
-      expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledWith(
+      expect(trackEventUnpaidTaxInstallmentReminderMock).toHaveBeenCalledWith(
         {
           year: 2024,
           tax_type: TaxType.KO,
@@ -645,8 +676,135 @@ describe('NotificationsEventsSubservice', () => {
           due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
           due_date_month: 5,
           due_date_day: 31,
+          are_installments_possible: true,
         },
         'external-id-2',
+      )
+    })
+  })
+
+  describe('sendUnpaidTaxReminders due date calculation', () => {
+    const birthNumber = '123456/7890'
+    const externalId = 'external-id-123'
+
+    beforeEach(() => {
+      jest
+        .spyOn(service['cityAccountSubservice'], 'getUserDataAdminBatch')
+        .mockResolvedValue({ [birthNumber]: { externalId } } as any)
+      jest
+        .spyOn(
+          service['bloomreachService'],
+          'trackEventUnpaidTaxInstallmentReminder',
+        )
+        .mockResolvedValue(true)
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should not send event when due date is in the future', async () => {
+      // Fix "now" at 2024-04-01; dateTaxRuling 2024-04-01 + 15 days = April 16 → still in future
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2024-04-01T12:00:00.000Z'))
+
+      prismaMock.$queryRaw.mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          birthNumber,
+          dateTaxRuling: new Date('2024-04-01'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+          amount: 5000,
+        },
+      ])
+
+      await service.sendUnpaidTaxReminders()
+
+      expect(
+        bloomreachService.trackEventUnpaidTaxInstallmentReminder,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('sends correct due_date_month/day for non-CITY_ACCOUNT using dateTaxRuling', async () => {
+      // May 16, 2024 + 15 days = May 31, 2024 (Friday, not a holiday)
+      prismaMock.$queryRaw.mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          birthNumber,
+          dateTaxRuling: new Date('2024-05-16'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+          amount: 5000,
+        },
+      ])
+
+      await service.sendUnpaidTaxReminders()
+
+      expect(
+        bloomreachService.trackEventUnpaidTaxInstallmentReminder,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ due_date_month: 5, due_date_day: 31 }),
+        externalId,
+      )
+    })
+
+    it('sends correct due_date_month/day for CITY_ACCOUNT delivery using createdAt', async () => {
+      // createdAt May 16, 2024 + 15 days = May 31, 2024 (Friday, not a holiday)
+      prismaMock.$queryRaw.mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          birthNumber,
+          dateTaxRuling: null,
+          deliveryMethod: DeliveryMethodNamed.CITY_ACCOUNT,
+          createdAt: new Date('2024-05-16'),
+          amount: 5000,
+        },
+      ])
+
+      await service.sendUnpaidTaxReminders()
+
+      expect(
+        bloomreachService.trackEventUnpaidTaxInstallmentReminder,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ due_date_month: 5, due_date_day: 31 }),
+        externalId,
+      )
+    })
+
+    it('adjusts due date to next working day when it falls on a weekend', async () => {
+      // Feb 16, 2024 (Friday) + 15 days = March 2, 2024 (Saturday)
+      // → skip Saturday and Sunday → March 4, 2024 (Monday, not a holiday)
+      prismaMock.$queryRaw.mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          birthNumber,
+          dateTaxRuling: new Date('2024-02-16'),
+          deliveryMethod: null,
+          createdAt: new Date('2024-01-01'),
+          amount: 5000,
+        },
+      ])
+
+      await service.sendUnpaidTaxReminders()
+
+      expect(
+        bloomreachService.trackEventUnpaidTaxInstallmentReminder,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ due_date_month: 3, due_date_day: 4 }),
+        externalId,
       )
     })
   })

--- a/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
+++ b/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
@@ -535,7 +535,7 @@ describe('NotificationsEventsSubservice', () => {
       prismaMock.$queryRaw.mockResolvedValue([])
       const trackEventUnpaidTaxReminderMock = jest.spyOn(
         service['bloomreachService'],
-        'trackEventUnpaidTaxReminder',
+        'trackEventUnpaidTaxInstallmentReminder',
       )
 
       await service.sendUnpaidTaxReminders()
@@ -556,7 +556,7 @@ describe('NotificationsEventsSubservice', () => {
       ])
       const trackEventUnpaidTaxReminderMock = jest.spyOn(
         service['bloomreachService'],
-        'trackEventUnpaidTaxReminder',
+        'trackEventUnpaidTaxInstallmentReminder',
       )
       jest
         .spyOn(service['cityAccountSubservice'], 'getUserDataAdminBatch')
@@ -606,7 +606,7 @@ describe('NotificationsEventsSubservice', () => {
       ])
       const trackEventUnpaidTaxReminderMock = jest.spyOn(
         service['bloomreachService'],
-        'trackEventUnpaidTaxReminder',
+        'trackEventUnpaidTaxInstallmentReminder',
       )
       jest
         .spyOn(service['cityAccountSubservice'], 'getUserDataAdminBatch')
@@ -629,6 +629,10 @@ describe('NotificationsEventsSubservice', () => {
           year: 2024,
           tax_type: TaxType.DZN,
           order: 1,
+          installment_order: 1,
+          due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
+          due_date_month: 5,
+          due_date_day: 31,
         },
         'external-id-1',
       )
@@ -637,6 +641,10 @@ describe('NotificationsEventsSubservice', () => {
           year: 2024,
           tax_type: TaxType.KO,
           order: 2,
+          installment_order: 1,
+          due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
+          due_date_month: 5,
+          due_date_day: 31,
         },
         'external-id-2',
       )

--- a/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
@@ -13,6 +13,7 @@ import { PaymentService } from '../../payment/payment.service'
 import { PrismaService } from '../../prisma/prisma.service'
 import {
   bratislavaTimeZone,
+  calculateDueDate,
   DUE_DATE_OFFSET,
   parseInstallmentDueDate,
 } from '../../tax/utils/unified-tax.util'
@@ -252,6 +253,9 @@ export default class NotificationsEventsService {
             birthNumber: true,
           },
         },
+        createdAt: true,
+        dateTaxRuling: true,
+        deliveryMethod: true,
       },
       where: {
         bloomreachUnpaidTaxReminderSent: false,
@@ -307,23 +311,44 @@ export default class NotificationsEventsService {
         taxes.map((taxData) => taxData.taxPayer.birthNumber),
       )
 
-    await Promise.all(
+    const sentResults = await Promise.all(
       taxes.map(async (tax) => {
         const userFromCityAccount =
           userDataFromCityAccount[tax.taxPayer.birthNumber] || null
         if (userFromCityAccount && userFromCityAccount.externalId) {
-          await this.bloomreachService.trackEventUnpaidTaxReminder(
-            { year: tax.year, tax_type: tax.type, order: tax.order! },
+          const dueDate = calculateDueDate(
+            dayjs(tax.dateTaxRuling),
+            tax.deliveryMethod,
+            dayjs(tax.createdAt),
+          )
+          if (!dueDate || dueDate.isAfter(dayjs().endOf('day'))) {
+            return undefined
+          }
+          await this.bloomreachService.trackEventUnpaidTaxInstallmentReminder(
+            {
+              year: tax.year,
+              tax_type: tax.type,
+              order: tax.order!,
+              installment_order: 1,
+              due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
+              due_date_month: dueDate.month() + 1,
+              due_date_day: dueDate.date(),
+            },
             userFromCityAccount.externalId,
           )
+          return tax.id
         }
+        return undefined
       }),
+    )
+    const taxIdsSent = sentResults.filter(
+      (id): id is number => id !== undefined,
     )
 
     await this.prismaService.tax.updateMany({
       where: {
         id: {
-          in: taxes.map((tax) => tax.id),
+          in: taxIdsSent,
         },
       },
       data: {

--- a/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
@@ -1,5 +1,6 @@
 import { HttpException, Injectable } from '@nestjs/common'
 import {
+  DeliveryMethodNamed,
   PaymentStatus,
   Prisma,
   TaxType,
@@ -13,6 +14,7 @@ import { PaymentService } from '../../payment/payment.service'
 import { PrismaService } from '../../prisma/prisma.service'
 import {
   bratislavaTimeZone,
+  calculateDueDate,
   DUE_DATE_OFFSET,
   parseInstallmentDueDate,
 } from '../../tax/utils/unified-tax.util'
@@ -262,6 +264,10 @@ export default class NotificationsEventsService {
         type: TaxType
         order: number | null
         birthNumber: string
+        dateTaxRuling: Date | null
+        deliveryMethod: DeliveryMethodNamed | null
+        createdAt: Date
+        amount: number
       }[]
     >`
       WITH paid AS (
@@ -280,7 +286,11 @@ export default class NotificationsEventsService {
         t.year,
         t.type,
         t."order",
-        taxp."birthNumber"
+        taxp."birthNumber",
+        t."dateTaxRuling",
+        t."deliveryMethod",
+        t."createdAt",
+        t."amount"
       FROM "Tax" t
       JOIN "TaxPayer" taxp ON taxp.id = t."taxPayerId"
       LEFT JOIN paid p ON p."taxId" = t.id
@@ -315,23 +325,48 @@ export default class NotificationsEventsService {
         taxes.map((tax) => tax.birthNumber),
       )
 
-    await Promise.all(
+    const sentResults = await Promise.all(
       taxes.map(async (tax) => {
         const userFromCityAccount =
           userDataFromCityAccount[tax.birthNumber] || null
         if (userFromCityAccount && userFromCityAccount.externalId) {
-          await this.bloomreachService.trackEventUnpaidTaxReminder(
-            { year: tax.year, tax_type: tax.type, order: tax.order! },
+          const dueDate = calculateDueDate(
+            dayjs(tax.dateTaxRuling),
+            tax.deliveryMethod,
+            dayjs(tax.createdAt),
+          )
+          if (!dueDate || dueDate.isAfter(dayjs().endOf('day'))) {
+            return undefined
+          }
+          const taxDefinition = getTaxDefinitionByType(tax.type)
+          const areInstallmentsPossible =
+            tax.amount > taxDefinition.paymentCalendarThreshold
+          await this.bloomreachService.trackEventUnpaidTaxInstallmentReminder(
+            {
+              year: tax.year,
+              tax_type: tax.type,
+              order: tax.order!,
+              installment_order: 1,
+              due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
+              due_date_month: dueDate.month() + 1,
+              due_date_day: dueDate.date(),
+              are_installments_possible: areInstallmentsPossible,
+            },
             userFromCityAccount.externalId,
           )
+          return tax.id
         }
+        return undefined
       }),
+    )
+    const taxIdsSent = sentResults.filter(
+      (id): id is number => id !== undefined,
     )
 
     await this.prismaService.tax.updateMany({
       where: {
         id: {
-          in: taxes.map((tax) => tax.id),
+          in: taxIdsSent,
         },
       },
       data: {

--- a/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
@@ -331,7 +331,7 @@ export default class NotificationsEventsService {
           userDataFromCityAccount[tax.birthNumber] || null
         if (userFromCityAccount && userFromCityAccount.externalId) {
           const dueDate = calculateDueDate(
-            dayjs(tax.dateTaxRuling),
+            tax.dateTaxRuling ? dayjs(tax.dateTaxRuling) : null,
             tax.deliveryMethod,
             dayjs(tax.createdAt),
           )

--- a/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
@@ -329,34 +329,34 @@ export default class NotificationsEventsService {
       taxes.map(async (tax) => {
         const userFromCityAccount =
           userDataFromCityAccount[tax.birthNumber] || null
-        if (userFromCityAccount && userFromCityAccount.externalId) {
-          const dueDate = calculateDueDate(
-            tax.dateTaxRuling ? dayjs(tax.dateTaxRuling) : null,
-            tax.deliveryMethod,
-            dayjs(tax.createdAt),
-          )
-          if (!dueDate || dueDate.isAfter(dayjs().endOf('day'))) {
-            return undefined
-          }
-          const taxDefinition = getTaxDefinitionByType(tax.type)
-          const areInstallmentsPossible =
-            tax.amount > taxDefinition.paymentCalendarThreshold
-          await this.bloomreachService.trackEventUnpaidTaxInstallmentReminder(
-            {
-              year: tax.year,
-              tax_type: tax.type,
-              order: tax.order!,
-              installment_order: 1,
-              due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
-              due_date_month: dueDate.month() + 1,
-              due_date_day: dueDate.date(),
-              are_installments_possible: areInstallmentsPossible,
-            },
-            userFromCityAccount.externalId,
-          )
-          return tax.id
+        if (!userFromCityAccount || !userFromCityAccount.externalId) {
+          return undefined
         }
-        return undefined
+        const dueDate = calculateDueDate(
+          tax.dateTaxRuling ? dayjs(tax.dateTaxRuling) : null,
+          tax.deliveryMethod,
+          dayjs(tax.createdAt),
+        )
+        if (!dueDate || dueDate.isAfter(dayjs().endOf('day'))) {
+          return undefined
+        }
+        const taxDefinition = getTaxDefinitionByType(tax.type)
+        const areInstallmentsPossible =
+          tax.amount > taxDefinition.paymentCalendarThreshold
+        await this.bloomreachService.trackEventUnpaidTaxInstallmentReminder(
+          {
+            year: tax.year,
+            tax_type: tax.type,
+            order: tax.order!,
+            installment_order: 1,
+            due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
+            due_date_month: dueDate.month() + 1,
+            due_date_day: dueDate.date(),
+            are_installments_possible: areInstallmentsPossible,
+          },
+          userFromCityAccount.externalId,
+        )
+        return tax.id
       }),
     )
     const taxIdsSent = sentResults.filter(

--- a/nest-tax-backend/src/tasks/subservices/tax-import.tasks.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/tax-import.tasks.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common'
-import {Prisma, TaxType} from '@prisma/client'
+import { Prisma, TaxType } from '@prisma/client'
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'

--- a/nest-tax-backend/src/tax/utils/unified-tax.util.ts
+++ b/nest-tax-backend/src/tax/utils/unified-tax.util.ts
@@ -241,7 +241,7 @@ const ensureWorkingDay = (date: Dayjs): Dayjs => {
   return workingDay
 }
 
-const calculateDueDate = (
+export const calculateDueDate = (
   dateOfValidity: Dayjs | null,
   deliveryMethod: DeliveryMethodNamed | null,
   createdAt: Dayjs,


### PR DESCRIPTION
Removes `unpaid_tax_reminder` event from bloomreach, and instead uses `unpaid_tax_installment_reminder` event, with `installment_order = 1`. This is so that the logic can be done in just one bloomreach scenario. We now also get more data into bloomreach, for example the due date of the tax.

When it comes to merging more logic on the backend side, it would result in less readable code. One idea was to drop `bloomreachUnpaidTaxReminderSent` flag from `Tax`, and use `bloomreachUnpaidReminderSent` flag in first installment, however it would add more complexity to the code. The two notification jobs also differ in logic, since we compute the due date of first installment ourselves, and get from Noris of second onward. Therefore, this has been kept as is, however, I am open for discussion.

Resolves https://github.com/bratislava/private-konto.bratislava.sk/issues/1318