### PR TITLE
fix: return early when only one installment

### DIFF
--- a/nest-tax-backend/src/tax/utils/unified-tax.util.ts
+++ b/nest-tax-backend/src/tax/utils/unified-tax.util.ts
@@ -416,6 +416,14 @@ const calculateInstallmentPaymentDetails = (options: {
     isCancelled,
   } = options
 
+  if (overallAmount < paymentCalendarThreshold) {
+    return {
+      isPossible: false,
+      reasonNotPossible:
+        InstallmentPaymentReasonNotPossibleEnum.BELOW_THRESHOLD,
+    }
+  }
+
   const installmentsByOrder = [...installments].sort(
     (a, b) => a.order - b.order,
   )
@@ -458,14 +466,6 @@ const calculateInstallmentPaymentDetails = (options: {
       isPossible: false,
       reasonNotPossible: InstallmentPaymentReasonNotPossibleEnum.AFTER_DUE_DATE,
       dueDateLastPayment: dueDateLastPayment.toDate(),
-    }
-  }
-
-  if (overallAmount < paymentCalendarThreshold) {
-    return {
-      isPossible: false,
-      reasonNotPossible:
-        InstallmentPaymentReasonNotPossibleEnum.BELOW_THRESHOLD,
     }
   }
 


### PR DESCRIPTION
In case, where there was just one installment, and no due date (new tax, with postal/edesk delivery method and amount < 66), this threw an error. We must return early.