### PR TITLE
fix(noris): remove per-request pool close that aborted concurrent queries

### DIFF
--- a/nest-tax-backend/src/noris/subservices/__tests__/noris-connection.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/__tests__/noris-connection.subservice.spec.ts
@@ -33,23 +33,7 @@ describe('NorisConnectionSubservice', () => {
 
   const originalEnv = process.env
 
-  const buildModule = async () => {
-    module = await Test.createTestingModule({
-      providers: [
-        NorisConnectionSubservice,
-        { provide: ConfigService, useValue: configService },
-        ThrowerErrorGuard,
-        { provide: PrismaService, useValue: prismaService },
-      ],
-    }).compile()
-
-    await module.init()
-
-    service = module.get<NorisConnectionSubservice>(NorisConnectionSubservice)
-    throwerErrorGuard = module.get<ThrowerErrorGuard>(ThrowerErrorGuard)
-  }
-
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks()
 
     // Assign after clearAllMocks so we hold references to the (now-cleared) mock.
@@ -81,6 +65,18 @@ describe('NorisConnectionSubservice', () => {
     })
 
     prismaService = createMock<PrismaService>()
+
+    module = await Test.createTestingModule({
+      providers: [
+        NorisConnectionSubservice,
+        { provide: ConfigService, useValue: configService },
+        ThrowerErrorGuard,
+        { provide: PrismaService, useValue: prismaService },
+      ],
+    }).compile()
+
+    service = module.get<NorisConnectionSubservice>(NorisConnectionSubservice)
+    throwerErrorGuard = module.get<ThrowerErrorGuard>(ThrowerErrorGuard)
   })
 
   afterEach(async () => {
@@ -91,7 +87,6 @@ describe('NorisConnectionSubservice', () => {
   describe('onModuleDestroy', () => {
     it('should close the pool connection on shutdown', async () => {
       mockMssqlConnect.mockResolvedValue(mockConnectionPool)
-      await buildModule()
 
       await module.close()
 
@@ -100,16 +95,16 @@ describe('NorisConnectionSubservice', () => {
 
     it('should not throw when connect() fails during shutdown', async () => {
       mockMssqlConnect.mockRejectedValue(new Error('MSSQL unreachable'))
-      await buildModule()
+      const warnSpy = jest.spyOn(service['logger'], 'warn')
 
       await expect(module.close()).resolves.not.toThrow()
+      expect(warnSpy).toHaveBeenCalled()
     })
   })
 
   describe('withConnection', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       mockMssqlConnect.mockResolvedValue(mockConnectionPool)
-      await buildModule()
     })
 
     it('should call mssql.connect() on every invocation so the pool is always obtained or recreated', async () => {
@@ -128,9 +123,8 @@ describe('NorisConnectionSubservice', () => {
   })
 
   describe('handleDatabaseError (via withConnection)', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       mockMssqlConnect.mockResolvedValue(mockConnectionPool)
-      await buildModule()
     })
 
     const errorMessage = 'Test error message'

--- a/nest-tax-backend/src/noris/subservices/__tests__/noris-connection.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/__tests__/noris-connection.subservice.spec.ts
@@ -1,6 +1,7 @@
 import { createMock } from '@golevelup/ts-jest'
 import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
+import * as mssql from 'mssql'
 import { MSSQLError } from 'mssql'
 
 import { PrismaService } from '../../../prisma/prisma.service'
@@ -9,30 +10,51 @@ import ThrowerErrorGuard from '../../../utils/guards/errors.guard'
 import { CustomErrorNorisTypesEnum } from '../../noris.errors'
 import { NorisConnectionSubservice } from '../noris-connection.subservice'
 
-const mockConnect = jest.fn()
-jest.mock('mssql', () => {
-  const actual = jest.requireActual('mssql')
-  return {
-    ...actual,
-    connect: (...args: unknown[]) => mockConnect(...args),
-  }
-})
+// Inline jest.fn() avoids the temporal-dead-zone issue that occurs when const
+// variables declared outside the factory are referenced inside jest.mock().
+jest.mock('mssql', () => ({
+  ...jest.requireActual('mssql'),
+  connect: jest.fn(),
+}))
 
 describe('NorisConnectionSubservice', () => {
+  let module: TestingModule
   let service: NorisConnectionSubservice
   let configService: jest.Mocked<ConfigService>
   let throwerErrorGuard: ThrowerErrorGuard
   let prismaService: jest.Mocked<PrismaService>
 
+  let mockMssqlConnect: jest.Mock
+
   const mockConnectionPool = {
     connected: true,
-    close: jest.fn(),
+    close: jest.fn().mockResolvedValue(undefined),
   }
 
   const originalEnv = process.env
 
-  beforeEach(async () => {
+  const buildModule = async () => {
+    module = await Test.createTestingModule({
+      providers: [
+        NorisConnectionSubservice,
+        { provide: ConfigService, useValue: configService },
+        ThrowerErrorGuard,
+        { provide: PrismaService, useValue: prismaService },
+      ],
+    }).compile()
+
+    await module.init()
+
+    service = module.get<NorisConnectionSubservice>(NorisConnectionSubservice)
+    throwerErrorGuard = module.get<ThrowerErrorGuard>(ThrowerErrorGuard)
+  }
+
+  beforeEach(() => {
     jest.clearAllMocks()
+
+    // Assign after clearAllMocks so we hold references to the (now-cleared) mock.
+    mockMssqlConnect = mssql.connect as jest.Mock
+
     process.env = {
       ...originalEnv,
       MSSQL_HOST: 'localhost',
@@ -41,8 +63,6 @@ describe('NorisConnectionSubservice', () => {
       // eslint-disable-next-line sonarjs/no-hardcoded-passwords
       MSSQL_PASSWORD: 'pass',
     }
-
-    mockConnect.mockResolvedValue(mockConnectionPool)
 
     configService = createMock<ConfigService>({
       getOrThrow: jest.fn((key: string) => {
@@ -61,25 +81,58 @@ describe('NorisConnectionSubservice', () => {
     })
 
     prismaService = createMock<PrismaService>()
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        NorisConnectionSubservice,
-        { provide: ConfigService, useValue: configService },
-        ThrowerErrorGuard,
-        { provide: PrismaService, useValue: prismaService },
-      ],
-    }).compile()
-
-    service = module.get<NorisConnectionSubservice>(NorisConnectionSubservice)
-    throwerErrorGuard = module.get<ThrowerErrorGuard>(ThrowerErrorGuard)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     process.env = originalEnv
+    await module.close()
+  })
+
+  describe('onModuleDestroy', () => {
+    it('should close the pool connection on shutdown', async () => {
+      mockMssqlConnect.mockResolvedValue(mockConnectionPool)
+      await buildModule()
+
+      await module.close()
+
+      expect(mockConnectionPool.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not throw when connect() fails during shutdown', async () => {
+      mockMssqlConnect.mockRejectedValue(new Error('MSSQL unreachable'))
+      await buildModule()
+
+      await expect(module.close()).resolves.not.toThrow()
+    })
+  })
+
+  describe('withConnection', () => {
+    beforeEach(async () => {
+      mockMssqlConnect.mockResolvedValue(mockConnectionPool)
+      await buildModule()
+    })
+
+    it('should call mssql.connect() on every invocation so the pool is always obtained or recreated', async () => {
+      // connect() is idempotent: it resolves immediately when already connected
+      await service.withConnection(
+        async () => Promise.resolve('a' as unknown as never),
+        'err',
+      )
+      await service.withConnection(
+        async () => Promise.resolve('b' as unknown as never),
+        'err',
+      )
+
+      expect(mockMssqlConnect).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('handleDatabaseError (via withConnection)', () => {
+    beforeEach(async () => {
+      mockMssqlConnect.mockResolvedValue(mockConnectionPool)
+      await buildModule()
+    })
+
     const errorMessage = 'Test error message'
 
     it('should throw getNorisUrgentError when error is not an MSSQLError', async () => {

--- a/nest-tax-backend/src/noris/subservices/noris-connection.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-connection.subservice.ts
@@ -34,9 +34,15 @@ export class NorisConnectionSubservice implements OnModuleDestroy {
     try {
       const connection = await this.createConnection()
       await connection.close()
-    } catch (err) {
+    } catch (error) {
       this.logger.warn(
-        `Failed to close MSSQL connection on shutdown: ${(err as Error).message}`,
+        this.throwerErrorGuard.BadRequestException(
+          ErrorsEnum.BAD_REQUEST_ERROR,
+          'Failed to close MSSQL connection on shutdown',
+          undefined,
+          undefined,
+          error,
+        ),
       )
     }
   }

--- a/nest-tax-backend/src/noris/subservices/noris-connection.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-connection.subservice.ts
@@ -1,12 +1,6 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
-import {
-  config,
-  connect,
-  ConnectionError,
-  ConnectionPool,
-  MSSQLError,
-} from 'mssql'
+import { connect, ConnectionError, ConnectionPool, MSSQLError } from 'mssql'
 
 import { PrismaService } from '../../prisma/prisma.service'
 import { NORIS_SILENT_CONNECTION_ERRORS_KEY } from '../../utils/constants'
@@ -15,7 +9,9 @@ import ThrowerErrorGuard from '../../utils/guards/errors.guard'
 import { CustomErrorNorisTypesEnum } from '../noris.errors'
 
 @Injectable()
-export class NorisConnectionSubservice {
+export class NorisConnectionSubservice implements OnModuleDestroy {
+  private readonly logger = new Logger(NorisConnectionSubservice.name)
+
   constructor(
     private readonly configService: ConfigService,
     private readonly throwerErrorGuard: ThrowerErrorGuard,
@@ -34,10 +30,19 @@ export class NorisConnectionSubservice {
     }
   }
 
-  private async createConnection(
-    configOverrides?: Partial<config>,
-  ): Promise<ConnectionPool> {
-    const connection = await connect({
+  async onModuleDestroy(): Promise<void> {
+    try {
+      const connection = await this.createConnection()
+      await connection.close()
+    } catch (err) {
+      this.logger.warn(
+        `Failed to close MSSQL connection on shutdown: ${(err as Error).message}`,
+      )
+    }
+  }
+
+  private async createConnection(): Promise<ConnectionPool> {
+    return await connect({
       server: this.configService.getOrThrow<string>('MSSQL_HOST'),
       port: 1433,
       database: this.configService.getOrThrow<string>('MSSQL_DB'),
@@ -49,16 +54,6 @@ export class NorisConnectionSubservice {
         encrypt: true,
         trustServerCertificate: true,
       },
-      ...configOverrides,
-    })
-
-    return connection
-  }
-
-  private async createOptimizedConnection(): Promise<ConnectionPool> {
-    return this.createConnection({
-      connectionTimeout: 60_000,
-      requestTimeout: 180_000,
     })
   }
 
@@ -145,32 +140,30 @@ export class NorisConnectionSubservice {
   }
 
   /**
-   * Executes a function within a database connection context.
-   * Creates a connection, executes the function, and ensures proper cleanup.
+   * Executes a function using the mssql global connection pool.
    *
-   * @param operation - Function to execute within the connection context
+   * mssql.connect() is idempotent:
+   * - Pool already connected → resolves immediately (next tick via setImmediate)
+   * - Pool null or disconnected → creates a new pool
+   * Concurrent callers while a pool is being established are serialised by
+   * mssql's internal _connectStack, so only one ConnectionPool is ever created.
+   *
+   * The connection is not closed, as it is expected to be shared and used for the lifetime of the application.
+   *
+   * @param operation - Function to execute with the connection pool
    * @param errorMessage - Message passed to {@link handleDatabaseError} on failure
-   * @param useOptimized - Whether to use optimized connection settings
    * @returns Result of the operation
    */
   async withConnection<T>(
     operation: (connection: ConnectionPool) => Promise<T>,
     errorMessage: string,
-    useOptimized = false,
   ): Promise<T> {
-    let connection: ConnectionPool | undefined
-
     try {
-      connection = useOptimized
-        ? await this.createOptimizedConnection()
-        : await this.createConnection()
-
+      const connection = await this.createConnection()
       await this.waitForConnection(connection)
       return await operation(connection)
     } catch (error) {
       return await this.handleDatabaseError(error, errorMessage)
-    } finally {
-      await connection?.close()
     }
   }
 }


### PR DESCRIPTION
## Problem

Two recurring production errors were observed during cron job execution:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 error listeners added to [ConnectionPool]. MaxListeners is 10.
```

```
HttpException: Failed to get communal waste tax data from Noris
Caused by: Error: aborted
    at PendingOperation.abort (tarn/dist/PendingOperation.js:25:21)
    at tarn/dist/Pool.js:208:25
```

## Root cause

`withConnection` had a `finally { await connection?.close() }` block that ran after every database operation. The key issue: mssql's `connect()` returns a **shared global singleton** `ConnectionPool` — all concurrent callers get the same pool instance.

When any request closed the pool in its `finally` block, it destroyed the shared pool for **all other in-flight callers**. tarn responds to pool destruction by calling `PendingOperation.abort()` on every pending acquire, producing `Error: aborted`.

The `MaxListenersExceededWarning` followed from the same pattern: each concurrent call to `withConnection` added an `error` event listener to the same `ConnectionPool` instance, exceeding Node's default limit of 10.

## Fix

- **Remove the `finally` block** from `withConnection`. The global pool is intentionally shared and should live for the lifetime of the application — never closed per-request.
- **Add `OnModuleDestroy`** to close the pool exactly once on application shutdown, with a `try/catch` so a failed close does not prevent graceful teardown.
- Remove dead `createOptimizedConnection` / `configOverrides` overloads no longer called anywhere.
- Rewrite tests to properly mock the module-level `connect` export and add coverage for `onModuleDestroy` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)