### PR TITLE
fix: If only one installment and no due date do not throw

### DIFF
--- a/nest-tax-backend/src/tax/dtos/error.dto.ts
+++ b/nest-tax-backend/src/tax/dtos/error.dto.ts
@@ -11,6 +11,7 @@ export enum CustomErrorTaxTypesEnum {
   BELOW_THRESHOLD = 'BELOW_THRESHOLD',
   TAX_TYPE_NOT_FOUND = 'TAX_TYPE_NOT_FOUND',
   TAX_IS_CANCELLED = 'TAX_IS_CANCELLED',
+  JUST_ONE_INSTALLMENT = 'JUST_ONE_INSTALLMENT',
 }
 
 export enum CustomErrorTaxTypesResponseEnum {
@@ -25,4 +26,5 @@ export enum CustomErrorTaxTypesResponseEnum {
   AFTER_DUE_DATE = 'Tax is after due date.',
   BELOW_THRESHOLD = 'Tax amount is below threshold for installment payments.',
   TAX_IS_CANCELLED = 'Tax is cancelled.',
+  JUST_ONE_INSTALLMENT = 'Tax has only one installment, no installment payments are possible.',
 }

--- a/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
+++ b/nest-tax-backend/src/tax/dtos/response.tax.dto.ts
@@ -54,6 +54,7 @@ export enum InstallmentPaymentReasonNotPossibleEnum {
   AFTER_DUE_DATE = 'AFTER_DUE_DATE',
   ALREADY_PAID = 'ALREADY_PAID',
   TAX_IS_CANCELLED = 'TAX_IS_CANCELLED',
+  JUST_ONE_INSTALLMENT = 'JUST_ONE_INSTALLMENT',
 }
 
 export enum InstallmentPaidStatusEnum {

--- a/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
+++ b/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
@@ -1179,7 +1179,7 @@ describe('UnifiedTaxUtil', () => {
           )
         })
 
-        it('single NORIS installment with tax ruling date: KO allows variable count — installment payment is possible', () => {
+        it('single NORIS installment with tax ruling date: still not possible (one row = full amount)', () => {
           const output = getTaxDetailPure({
             ...defaultInput4Installments,
             dateOfValidity: new Date('2025-01-01'),
@@ -1191,13 +1191,9 @@ describe('UnifiedTaxUtil', () => {
               },
             ],
           })
-          expect(output.installmentPayment.isPossible).toBe(true)
-          expect(output.installmentPayment.installments).toHaveLength(1)
-          expect(
-            output.installmentPayment.activeInstallment?.remainingAmount,
-          ).toBe(8000)
-          expect(output.installmentPayment.installments![0].dueDate).toEqual(
-            output.installmentPayment.activeInstallment?.dueDate,
+          expect(output.installmentPayment.isPossible).toBe(false)
+          expect(output.installmentPayment.reasonNotPossible).toBe(
+            InstallmentPaymentReasonNotPossibleEnum.JUST_ONE_INSTALLMENT,
           )
         })
 
@@ -1677,23 +1673,20 @@ describe('UnifiedTaxUtil', () => {
       )
     })
 
-    it('DZN with tax ruling but only one NORIS row: INSTALLMENT_INCORRECT_COUNT (expects 3)', () => {
-      expect(() =>
-        getTaxDetailPure({
-          ...defaultInputRealEstate,
-          installments: [
-            {
-              order: 1,
-              amount: 6600,
-              dueDate: DZN_FIXTURE_INSTALLMENT_DUE_DATES[0],
-            },
-          ],
-        }),
-      ).toThrow(
-        new ThrowerErrorGuard().InternalServerErrorException(
-          CustomErrorTaxTypesEnum.INSTALLMENT_INCORRECT_COUNT,
-          CustomErrorTaxTypesResponseEnum.INSTALLMENT_INCORRECT_COUNT,
-        ),
+    it('DZN with tax ruling but only one NORIS row: JUST_ONE_INSTALLMENT (not INSTALLMENT_INCORRECT_COUNT)', () => {
+      const output = getTaxDetailPure({
+        ...defaultInputRealEstate,
+        installments: [
+          {
+            order: 1,
+            amount: 6600,
+            dueDate: DZN_FIXTURE_INSTALLMENT_DUE_DATES[0],
+          },
+        ],
+      })
+      expect(output.installmentPayment.isPossible).toBe(false)
+      expect(output.installmentPayment.reasonNotPossible).toBe(
+        InstallmentPaymentReasonNotPossibleEnum.JUST_ONE_INSTALLMENT,
       )
     })
   })
@@ -1852,7 +1845,7 @@ describe('getTaxDetailPureForInstallmentGenerator', () => {
     )
   })
 
-  it('when one NORIS installment and tax ruling exists, KO installment generator succeeds', () => {
+  it('should throw JUST_ONE_INSTALLMENT when only one installment even with tax ruling due date (KO)', () => {
     const options = {
       taxType: TaxType.KO,
       taxId: 123,
@@ -1873,16 +1866,15 @@ describe('getTaxDetailPureForInstallmentGenerator', () => {
       isCancelled: false,
     }
 
-    const output = getTaxDetailPureForInstallmentGenerator(options)
-    expect(output).toEqual({
-      amount: 8000,
-      taxId: 123,
-      description: 'Platba 1. splatky za dane pre BA s id dane 123',
-      taxType: TaxType.KO,
-    })
+    expect(() => getTaxDetailPureForInstallmentGenerator(options)).toThrow(
+      new ThrowerErrorGuard().UnprocessableEntityException(
+        CustomErrorTaxTypesEnum.JUST_ONE_INSTALLMENT,
+        CustomErrorTaxTypesResponseEnum.JUST_ONE_INSTALLMENT,
+      ),
+    )
   })
 
-  it('DZN installment generator throws INSTALLMENT_INCORRECT_COUNT when only one NORIS row', () => {
+  it('DZN installment generator throws JUST_ONE_INSTALLMENT when only one NORIS row', () => {
     const options = {
       ...baseOptionsRealEstate,
       installments: [
@@ -1895,9 +1887,9 @@ describe('getTaxDetailPureForInstallmentGenerator', () => {
     }
 
     expect(() => getTaxDetailPureForInstallmentGenerator(options)).toThrow(
-      new ThrowerErrorGuard().InternalServerErrorException(
-        CustomErrorTaxTypesEnum.INSTALLMENT_INCORRECT_COUNT,
-        CustomErrorTaxTypesResponseEnum.INSTALLMENT_INCORRECT_COUNT,
+      new ThrowerErrorGuard().UnprocessableEntityException(
+        CustomErrorTaxTypesEnum.JUST_ONE_INSTALLMENT,
+        CustomErrorTaxTypesResponseEnum.JUST_ONE_INSTALLMENT,
       ),
     )
   })

--- a/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
+++ b/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
@@ -1161,6 +1161,46 @@ describe('UnifiedTaxUtil', () => {
           expectEqualAsJsonStringsWithDates(output, defaultOutput4Installments)
         })
 
+        it('single NORIS installment without tax ruling date: installment not possible (JUST_ONE_INSTALLMENT)', () => {
+          const output = getTaxDetailPure({
+            ...defaultInput4Installments,
+            dateOfValidity: null,
+            installments: [
+              {
+                order: 1,
+                amount: 8000,
+                dueDate: KO4_FIXTURE_INSTALLMENT_DUE_DATES[0],
+              },
+            ],
+          })
+          expect(output.installmentPayment.isPossible).toBe(false)
+          expect(output.installmentPayment.reasonNotPossible).toBe(
+            InstallmentPaymentReasonNotPossibleEnum.JUST_ONE_INSTALLMENT,
+          )
+        })
+
+        it('single NORIS installment with tax ruling date: KO allows variable count — installment payment is possible', () => {
+          const output = getTaxDetailPure({
+            ...defaultInput4Installments,
+            dateOfValidity: new Date('2025-01-01'),
+            installments: [
+              {
+                order: 1,
+                amount: 8000,
+                dueDate: KO4_FIXTURE_INSTALLMENT_DUE_DATES[0],
+              },
+            ],
+          })
+          expect(output.installmentPayment.isPossible).toBe(true)
+          expect(output.installmentPayment.installments).toHaveLength(1)
+          expect(
+            output.installmentPayment.activeInstallment?.remainingAmount,
+          ).toBe(8000)
+          expect(output.installmentPayment.installments![0].dueDate).toEqual(
+            output.installmentPayment.activeInstallment?.dueDate,
+          )
+        })
+
         it('partial first', () => {
           const output = getTaxDetailPure({
             ...defaultInput4Installments,
@@ -1636,6 +1676,26 @@ describe('UnifiedTaxUtil', () => {
         ),
       )
     })
+
+    it('DZN with tax ruling but only one NORIS row: INSTALLMENT_INCORRECT_COUNT (expects 3)', () => {
+      expect(() =>
+        getTaxDetailPure({
+          ...defaultInputRealEstate,
+          installments: [
+            {
+              order: 1,
+              amount: 6600,
+              dueDate: DZN_FIXTURE_INSTALLMENT_DUE_DATES[0],
+            },
+          ],
+        }),
+      ).toThrow(
+        new ThrowerErrorGuard().InternalServerErrorException(
+          CustomErrorTaxTypesEnum.INSTALLMENT_INCORRECT_COUNT,
+          CustomErrorTaxTypesResponseEnum.INSTALLMENT_INCORRECT_COUNT,
+        ),
+      )
+    })
   })
 })
 
@@ -1759,6 +1819,85 @@ describe('getTaxDetailPureForInstallmentGenerator', () => {
       new ThrowerErrorGuard().UnprocessableEntityException(
         CustomErrorTaxTypesEnum.BELOW_THRESHOLD,
         CustomErrorTaxTypesResponseEnum.BELOW_THRESHOLD,
+      ),
+    )
+  })
+
+  it('should throw JUST_ONE_INSTALLMENT when only one installment and no tax ruling due date', () => {
+    const options = {
+      taxType: TaxType.KO,
+      taxId: 123,
+      today: new Date('2025-01-01'),
+      overallAmount: 8000,
+      variableSymbol: '1234567890',
+      dateOfValidity: null,
+      deliveryMethod: null,
+      createdAt: new Date('2025-01-01'),
+      installments: [
+        {
+          order: 1,
+          amount: 8000,
+          dueDate: KO4_FIXTURE_INSTALLMENT_DUE_DATES[0],
+        },
+      ],
+      taxPayments: [],
+      isCancelled: false,
+    }
+
+    expect(() => getTaxDetailPureForInstallmentGenerator(options)).toThrow(
+      new ThrowerErrorGuard().UnprocessableEntityException(
+        CustomErrorTaxTypesEnum.JUST_ONE_INSTALLMENT,
+        CustomErrorTaxTypesResponseEnum.JUST_ONE_INSTALLMENT,
+      ),
+    )
+  })
+
+  it('when one NORIS installment and tax ruling exists, KO installment generator succeeds', () => {
+    const options = {
+      taxType: TaxType.KO,
+      taxId: 123,
+      today: new Date('2025-01-01'),
+      overallAmount: 8000,
+      variableSymbol: '1234567890',
+      dateOfValidity: new Date('2025-01-01'),
+      deliveryMethod: null,
+      createdAt: new Date('2025-01-01'),
+      installments: [
+        {
+          order: 1,
+          amount: 8000,
+          dueDate: KO4_FIXTURE_INSTALLMENT_DUE_DATES[0],
+        },
+      ],
+      taxPayments: [],
+      isCancelled: false,
+    }
+
+    const output = getTaxDetailPureForInstallmentGenerator(options)
+    expect(output).toEqual({
+      amount: 8000,
+      taxId: 123,
+      description: 'Platba 1. splatky za dane pre BA s id dane 123',
+      taxType: TaxType.KO,
+    })
+  })
+
+  it('DZN installment generator throws INSTALLMENT_INCORRECT_COUNT when only one NORIS row', () => {
+    const options = {
+      ...baseOptionsRealEstate,
+      installments: [
+        {
+          order: 1,
+          amount: 6600,
+          dueDate: DZN_FIXTURE_INSTALLMENT_DUE_DATES[0],
+        },
+      ],
+    }
+
+    expect(() => getTaxDetailPureForInstallmentGenerator(options)).toThrow(
+      new ThrowerErrorGuard().InternalServerErrorException(
+        CustomErrorTaxTypesEnum.INSTALLMENT_INCORRECT_COUNT,
+        CustomErrorTaxTypesResponseEnum.INSTALLMENT_INCORRECT_COUNT,
       ),
     )
   })

--- a/nest-tax-backend/src/tax/utils/unified-tax.util.ts
+++ b/nest-tax-backend/src/tax/utils/unified-tax.util.ts
@@ -438,6 +438,13 @@ const calculateInstallmentPaymentDetails = (options: {
   const dueDateLastPayment =
     installmentDueDatesParsed[installmentDueDatesParsed.length - 1]
   if (!dueDateLastPayment) {
+    if (installmentsByOrder.length === 1) {
+      return {
+        isPossible: false,
+        reasonNotPossible:
+          InstallmentPaymentReasonNotPossibleEnum.JUST_ONE_INSTALLMENT,
+      }
+    }
     throw new ThrowerErrorGuard().InternalServerErrorException(
       CustomErrorTaxTypesEnum.INSTALLMENT_UNEXPECTED_ERROR,
       CustomErrorTaxTypesResponseEnum.INSTALLMENT_UNEXPECTED_ERROR,
@@ -780,6 +787,12 @@ export const getTaxDetailPureForInstallmentGenerator = (options: {
         throw new ThrowerErrorGuard().UnprocessableEntityException(
           CustomErrorTaxTypesEnum.TAX_IS_CANCELLED,
           CustomErrorTaxTypesResponseEnum.TAX_IS_CANCELLED,
+        )
+
+      case InstallmentPaymentReasonNotPossibleEnum.JUST_ONE_INSTALLMENT:
+        throw new ThrowerErrorGuard().UnprocessableEntityException(
+          CustomErrorTaxTypesEnum.JUST_ONE_INSTALLMENT,
+          CustomErrorTaxTypesResponseEnum.JUST_ONE_INSTALLMENT,
         )
 
       case undefined:

--- a/nest-tax-backend/src/tax/utils/unified-tax.util.ts
+++ b/nest-tax-backend/src/tax/utils/unified-tax.util.ts
@@ -427,6 +427,15 @@ const calculateInstallmentPaymentDetails = (options: {
   const installmentsByOrder = [...installments].sort(
     (a, b) => a.order - b.order,
   )
+
+  if (installmentsByOrder.length === 1) {
+    return {
+      isPossible: false,
+      reasonNotPossible:
+        InstallmentPaymentReasonNotPossibleEnum.JUST_ONE_INSTALLMENT,
+    }
+  }
+
   const installmentDatesFromNoris = installmentsByOrder
     .slice(1) // Omit order 1 - this is the validity-based due date
     .map((installment) => parseInstallmentDueDate(installment.dueDate))
@@ -438,13 +447,6 @@ const calculateInstallmentPaymentDetails = (options: {
   const dueDateLastPayment =
     installmentDueDatesParsed[installmentDueDatesParsed.length - 1]
   if (!dueDateLastPayment) {
-    if (installmentsByOrder.length === 1) {
-      return {
-        isPossible: false,
-        reasonNotPossible:
-          InstallmentPaymentReasonNotPossibleEnum.JUST_ONE_INSTALLMENT,
-      }
-    }
     throw new ThrowerErrorGuard().InternalServerErrorException(
       CustomErrorTaxTypesEnum.INSTALLMENT_UNEXPECTED_ERROR,
       CustomErrorTaxTypesResponseEnum.INSTALLMENT_UNEXPECTED_ERROR,

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -608,6 +608,7 @@ export const ResponseInstallmentPaymentDetailDtoReasonNotPossibleEnum = {
   AfterDueDate: 'AFTER_DUE_DATE',
   AlreadyPaid: 'ALREADY_PAID',
   TaxIsCancelled: 'TAX_IS_CANCELLED',
+  JustOneInstallment: 'JUST_ONE_INSTALLMENT',
 } as const
 
 export type ResponseInstallmentPaymentDetailDtoReasonNotPossibleEnum =


### PR DESCRIPTION
If there is only one installment, and no due date, the app throws on this:

```ts
const dueDateLastPayment =
    installmentDueDatesParsed[installmentDueDatesParsed.length - 1]
if (!dueDateLastPayment) {
  throw new ThrowerErrorGuard().InternalServerErrorException(
    CustomErrorTaxTypesEnum.INSTALLMENT_UNEXPECTED_ERROR,
    CustomErrorTaxTypesResponseEnum.INSTALLMENT_UNEXPECTED_ERROR,
  )
}
```

However we should just disallow paying by installments in that case, since the amount of one installment = amount of the tax.