### PR TITLE
fix: do not rethrow Noris errors as internal server error

### DIFF
--- a/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.communal-waste.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.communal-waste.subservice.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { HttpException, Injectable } from '@nestjs/common'
 import { TaxType } from '@prisma/client'
 import groupBy from 'lodash/groupBy'
 import * as mssql from 'mssql'
@@ -182,6 +182,9 @@ export class NorisTaxCommunalWasteSubservice extends AbstractNorisTaxSubservice<
     try {
       norisData = await this.getTaxDataByYearAndBirthNumber(year, birthNumbers)
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error
+      }
       throw this.throwerErrorGuard.InternalServerErrorException(
         CustomErrorNorisTypesEnum.GET_TAXES_FROM_NORIS_ERROR,
         'Failed to get taxes from Noris',

--- a/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.real-estate.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.real-estate.subservice.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { HttpException, Injectable } from '@nestjs/common'
 import { TaxType } from '@prisma/client'
 import * as mssql from 'mssql'
 
@@ -91,6 +91,9 @@ export class NorisTaxRealEstateSubservice extends AbstractNorisTaxSubservice<
     try {
       norisData = await this.getTaxDataByYearAndBirthNumber(year, birthNumbers)
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error
+      }
       throw this.throwerErrorGuard.InternalServerErrorException(
         CustomErrorNorisTypesEnum.GET_TAXES_FROM_NORIS_ERROR,
         'Failed to get taxes from Noris',


### PR DESCRIPTION
Even though we are not alerting Noris errors like timeout, connection not open etc., in few places these errors are rethrown as internal server errors, and therefore alerted.

We do not have to rethrow them, since the function has its own error handling, and therefore errors can be just passed.