### PR TITLE
Disable autocorrect in RegisterForm fields

### DIFF
--- a/next/src/components/auth-forms/RegisterForm.tsx
+++ b/next/src/components/auth-forms/RegisterForm.tsx
@@ -213,6 +213,7 @@ const RegisterForm = ({ onSubmit, error, lastEmail, disablePO }: Props) => {
             label={t('auth.fields.email_label')}
             autoComplete="username"
             autoCapitalize="none"
+            autoCorrect="off"
             // TODO consider adding autoCorrect="off" and spellCheck={false}
             {...field}
             errorMessage={errors.email}
@@ -230,6 +231,7 @@ const RegisterForm = ({ onSubmit, error, lastEmail, disablePO }: Props) => {
                 label={t('auth.fields.given_name_label')}
                 helptext={t('auth.fields.given_name_helptext')}
                 autoComplete="given-name"
+                autoCorrect="off"
                 capitalize
                 {...field}
                 errorMessage={errors.given_name}
@@ -245,6 +247,7 @@ const RegisterForm = ({ onSubmit, error, lastEmail, disablePO }: Props) => {
                 label={t('auth.fields.family_name_label')}
                 helptext={t('auth.fields.family_name_helptext')}
                 autoComplete="family-name"
+                autoCorrect="off"
                 capitalize
                 {...field}
                 errorMessage={errors.family_name}
@@ -261,6 +264,7 @@ const RegisterForm = ({ onSubmit, error, lastEmail, disablePO }: Props) => {
             <InputField
               isRequired
               label={t('auth.fields.business_name_label')}
+              autoCorrect="off"
               capitalize
               {...field}
               errorMessage={errors.name}

--- a/next/src/components/widget-components/InputField/InputField.tsx
+++ b/next/src/components/widget-components/InputField/InputField.tsx
@@ -17,6 +17,7 @@ export type InputFieldProps = FieldWrapperProps & {
   endIcon?: ReactNode
   autoComplete?: string
   autoCapitalize?: AriaTextFieldOptions<'input'>['autoCapitalize']
+  autoCorrect?: AriaTextFieldOptions<'input'>['autoCorrect']
   placeholder?: string
   className?: string
 }
@@ -32,6 +33,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       endIcon,
       autoComplete,
       autoCapitalize,
+      autoCorrect,
       placeholder,
       className,
       ...rest
@@ -70,6 +72,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
         },
         autoComplete,
         autoCapitalize,
+        autoCorrect,
       },
       ref,
     )


### PR DESCRIPTION
Hotfix - disable autoCorrect on register form fields (mainly name and surname) to fix problem with registration on ios devices, when the last character is not sent.

This will be addressed properly in #4015 