### PR TITLE
1330 Fix checkboxes with description after rewrite to RAC

### DIFF
--- a/next/src/components/fields/Checkbox.tsx
+++ b/next/src/components/fields/Checkbox.tsx
@@ -1,12 +1,26 @@
+import { ReactNode } from 'react'
 import { Checkbox as RACCheckbox, CheckboxProps as RACCheckboxProps } from 'react-aria-components'
 
 import cn from '@/src/utils/cn'
 
-export interface CheckboxProps extends RACCheckboxProps {
+export interface CheckboxProps extends Omit<RACCheckboxProps, 'children'> {
   variant?: 'basic' | 'boxed'
+  description?: string
+  children: ReactNode
+  /**
+   * Whether any of the other checkboxes in the group has a description. If they do, we want to display the label in semi-bold.
+   */
+  hasDescriptionInCheckboxGroup?: boolean
 }
 
-const Checkbox = ({ variant = 'basic', children, className, ...rest }: CheckboxProps) => (
+const Checkbox = ({
+  variant = 'basic',
+  description,
+  children,
+  hasDescriptionInCheckboxGroup,
+  className,
+  ...rest
+}: CheckboxProps) => (
   <RACCheckbox
     {...rest}
     className={({ isSelected, isDisabled, isInvalid, isIndeterminate }) =>
@@ -59,7 +73,12 @@ const Checkbox = ({ variant = 'basic', children, className, ...rest }: CheckboxP
             </svg>
           ) : null}
         </div>
-        {children}
+        <span className="flex grow flex-col gap-1">
+          <span className={cn({ 'font-semibold': !!description || hasDescriptionInCheckboxGroup })}>
+            {children}
+          </span>
+          {description ? <span>{description}</span> : null}
+        </span>
       </>
     )}
   </RACCheckbox>

--- a/next/src/components/fields/Checkbox.tsx
+++ b/next/src/components/fields/Checkbox.tsx
@@ -50,8 +50,8 @@ const Checkbox = ({
             'grid size-6 shrink-0 place-content-center rounded border-2',
             'border-border-active-primary-default',
             {
-              'border-border-error': isInvalid && !isDisabled,
               'bg-background-active-primary-default': (isSelected || isIndeterminate) && !isInvalid,
+              'border-border-error': isInvalid && !isDisabled,
               'bg-background-error-default': (isSelected || isIndeterminate) && isInvalid,
               'opacity-50': isDisabled,
               'ring-2 ring-offset-2': isFocusVisible,

--- a/next/src/components/fields/Checkbox.tsx
+++ b/next/src/components/fields/Checkbox.tsx
@@ -61,14 +61,14 @@ const Checkbox = ({
           {isSelected ? (
             <svg
               viewBox="0 0 18 18"
-              aria-hidden="true"
+              aria-hidden
               className="size-4 fill-none stroke-white stroke-[3px]"
             >
               <polyline points="2 9 7 14 16 4" />
             </svg>
           ) : null}
           {isIndeterminate ? (
-            <svg viewBox="0 0 18 18" aria-hidden="true" className="size-4 fill-white stroke-none">
+            <svg viewBox="0 0 18 18" aria-hidden className="size-4 fill-white stroke-none">
               <rect x={1} y={7.5} width={16} height={3} />
             </svg>
           ) : null}

--- a/next/src/components/fields/TextAreaField.tsx
+++ b/next/src/components/fields/TextAreaField.tsx
@@ -48,7 +48,8 @@ const TextAreaField = (
         className={({ isFocused, isDisabled, isInvalid }) =>
           cn(
             'w-full rounded-lg border bg-background-passive-base text-p2 text-content-passive-secondary outline-hidden',
-            'min-h-30 resize-y',
+            'min-h-30',
+            isDisabled ? 'resize-none' : 'resize-y',
             'px-3 py-2 lg:px-4 lg:py-3',
             'placeholder:text-content-passive-tertiary',
             {

--- a/next/src/components/styleguide/showcases/CheckboxGroupShowCase.tsx
+++ b/next/src/components/styleguide/showcases/CheckboxGroupShowCase.tsx
@@ -29,6 +29,17 @@ const CheckboxGroupShowCase = () => {
     },
   ]
 
+  const mockWithMixedDescription = [
+    { value: 'one', label: 'One', description: 'Lorem Ipsum' },
+    { value: 'two', label: 'Two' },
+    { value: 'three', label: 'Three' },
+    {
+      value: 'four',
+      label: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      description: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+    },
+  ]
+
   return (
     <>
       <Wrapper direction="column" title="CheckboxGroup RAC">
@@ -63,27 +74,43 @@ const CheckboxGroupShowCase = () => {
         </div>
         <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
           <Stack direction="column">
-            <CheckboxGroup label="Label">
+            <CheckboxGroup
+              label="All with description"
+              helptext="This combination - basic variant with options with description - should not be used, I guess."
+            >
               {mockWithDescription.map((checkbox) => (
-                <Checkbox key={checkbox.value} {...checkbox}>
+                <Checkbox key={checkbox.value} {...checkbox} hasDescriptionInCheckboxGroup>
                   {checkbox.label}
                 </Checkbox>
               ))}
             </CheckboxGroup>
           </Stack>
           <Stack direction="column">
-            <CheckboxGroup label="Label">
+            <CheckboxGroup label="All with description (boxed)">
               {mockWithDescription.map((checkbox) => (
-                <Checkbox key={checkbox.value} {...checkbox} variant="boxed">
+                <Checkbox
+                  key={checkbox.value}
+                  {...checkbox}
+                  variant="boxed"
+                  hasDescriptionInCheckboxGroup
+                >
                   {checkbox.label}
                 </Checkbox>
               ))}
             </CheckboxGroup>
           </Stack>
           <Stack direction="column">
-            <CheckboxGroup label="Label" errorMessage="Error message">
-              {mockWithDescription.map((checkbox) => (
-                <Checkbox key={checkbox.value} {...checkbox} variant="boxed">
+            <CheckboxGroup
+              label="Mixed description (boxed)"
+              helptext="This showcase checks, if labels are rendered correctly with semi-bold font, even if not all options have description."
+            >
+              {mockWithMixedDescription.map((checkbox) => (
+                <Checkbox
+                  key={checkbox.value}
+                  {...checkbox}
+                  variant="boxed"
+                  hasDescriptionInCheckboxGroup
+                >
                   {checkbox.label}
                 </Checkbox>
               ))}

--- a/next/src/components/styleguide/showcases/RadioGroupShowCase.tsx
+++ b/next/src/components/styleguide/showcases/RadioGroupShowCase.tsx
@@ -18,6 +18,28 @@ const RadioGroupShowCase = () => {
     },
   ]
 
+  const mockWithDescription = [
+    { value: 'one', label: 'One', description: 'Lorem Ipsum' },
+    { value: 'two', label: 'Two', description: 'Lorem Ipsum' },
+    { value: 'three', label: 'Three', description: 'Lorem Ipsum', isDisabled: true },
+    {
+      value: 'four',
+      label: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      description: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+    },
+  ]
+
+  const mockWithMixedDescription = [
+    { value: 'one', label: 'One', description: 'Lorem Ipsum' },
+    { value: 'two', label: 'Two' },
+    { value: 'three', label: 'Three' },
+    {
+      value: 'four',
+      label: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      description: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+    },
+  ]
+
   return (
     <>
       <Wrapper direction="column" title="RadioGroup RAC">
@@ -97,6 +119,44 @@ const RadioGroupShowCase = () => {
             </Radio>
           </RadioGroup>
         </Stack>
+
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+          <Stack direction="column">
+            <RadioGroup
+              isRequired
+              label="All with description"
+              helptext="This combination - basic variant with options with description - should not be used, I guess."
+            >
+              {mockWithDescription.map((item) => (
+                <Radio key={item.value} {...item} hasDescriptionInRadioGroup>
+                  {item.label}
+                </Radio>
+              ))}
+            </RadioGroup>
+          </Stack>
+          <Stack direction="column">
+            <RadioGroup isRequired label="All with description (boxed)">
+              {mockWithDescription.map((item) => (
+                <Radio key={item.value} {...item} variant="boxed" hasDescriptionInRadioGroup>
+                  {item.label}
+                </Radio>
+              ))}
+            </RadioGroup>
+          </Stack>
+          <Stack direction="column">
+            <RadioGroup
+              isRequired
+              label="Mixed description (boxed)"
+              helptext="This showcase checks, if labels are rendered correctly with semi-bold font, even if not all options have description."
+            >
+              {mockWithMixedDescription.map((item) => (
+                <Radio key={item.value} {...item} variant="boxed" hasDescriptionInRadioGroup>
+                  {item.label}
+                </Radio>
+              ))}
+            </RadioGroup>
+          </Stack>
+        </div>
       </Wrapper>
 
       {/* TODO remove */}

--- a/next/src/components/styleguide/showcases/TextAreaFieldShowCase.tsx
+++ b/next/src/components/styleguide/showcases/TextAreaFieldShowCase.tsx
@@ -4,6 +4,9 @@ import TextAreaFieldOLD from '@/src/components/widget-components/TextAreaField/T
 import { Stack } from '../Stack'
 import { Wrapper } from '../Wrapper'
 
+const LONG_TEXT =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.'
+
 const TextAreaFieldShowCase = () => {
   return (
     <>
@@ -34,6 +37,15 @@ const TextAreaFieldShowCase = () => {
             errorMessage="Error message"
             isDisabled
           />
+        </Stack>
+      </Wrapper>
+
+      <Wrapper direction="row">
+        <Stack direction="column">
+          <TextAreaField label="Editable with long text" defaultValue={LONG_TEXT} />
+        </Stack>
+        <Stack direction="column">
+          <TextAreaField label="Disabled with long text" defaultValue={LONG_TEXT} isDisabled />
         </Stack>
       </Wrapper>
 

--- a/next/src/components/widget-wrappers/CheckboxGroupWidgetRJSF.tsx
+++ b/next/src/components/widget-wrappers/CheckboxGroupWidgetRJSF.tsx
@@ -31,6 +31,8 @@ const CheckboxGroupWidgetRJSF = (props: CheckboxGroupWidgetRJSFProps) => {
     [enumOptions, enumMetadata],
   )
 
+  const hasDescriptionInCheckboxGroup = mergedOptions.some((option) => option.description)
+
   const isOptionDisabled = (optionValue: string) => {
     return (
       isDefined(maxItems) &&
@@ -53,6 +55,8 @@ const CheckboxGroupWidgetRJSF = (props: CheckboxGroupWidgetRJSFProps) => {
             key={option.value}
             value={option.value}
             variant={variant}
+            description={option.description}
+            hasDescriptionInCheckboxGroup={hasDescriptionInCheckboxGroup}
             isDisabled={isOptionDisabled(option.value)}
             data-cy={`checkbox-${option.value}`}
           >

--- a/next/src/components/widget-wrappers/mapRjsfToReactAriaProps.tsx
+++ b/next/src/components/widget-wrappers/mapRjsfToReactAriaProps.tsx
@@ -87,7 +87,9 @@ const mapRjsfToReactAriaProps = <TValue, TFieldValue, TOptions extends WidgetUiO
       name: props.name,
       className: cn(getFieldSizeClassName(size), className),
     },
-    // TODO revisit why placeholder comes in "props", not in "options"
+    // TODO Find more generic and typesafe solutions
+    // RJSF hoists `placeholder` from options to a top-level WidgetProps prop, so we re-attach it here.
+    // https://github.com/rjsf-team/react-jsonschema-form/blob/v6.4.2/packages/core/src/components/fields/MultiSchemaField.tsx#L175
     specificOptions: { ...specificOptions, placeholder: props.placeholder },
   }
 }


### PR DESCRIPTION
- add forgotten `description` props to `Checkbox`, same as in `Radio`
- update showcases for checkbox group and radio group
- for basic variant + options with description - add at least info to showcase, that they should not be used

Additionally:
- Prevent TextAreaField resizing when disabled
- minor cleanups and added comments

<img width="600" height="238" alt="image" src="https://github.com/user-attachments/assets/2171c736-7d85-48da-b384-245090ded6db" />

<img width="600" height="238" alt="image" src="https://github.com/user-attachments/assets/5f551478-dde7-4963-8138-3a2ce1b8a796" />
