### PR TITLE
fix: add missing GeneralContextProvider to mestske-sluzby/[slug] pages

### DIFF
--- a/next/src/pages/mestske-sluzby/[slug]/[id].tsx
+++ b/next/src/pages/mestske-sluzby/[slug]/[id].tsx
@@ -8,9 +8,10 @@ import { GetFormResponseDtoStateEnum } from 'openapi-clients/forms'
 
 import { formsClient } from '@/src/clients/forms'
 import { strapiClient } from '@/src/clients/graphql-strapi'
-import { FormBaseFragment } from '@/src/clients/graphql-strapi/api'
+import { FormBaseFragment, GeneralQuery } from '@/src/clients/graphql-strapi/api'
 import { makeClientFormDefinition } from '@/src/components/forms/clientFormDefinitions'
 import FormPage, { FormPageProps } from '@/src/components/forms/FormPage'
+import { GeneralContextProvider } from '@/src/components/logic/GeneralContextProvider'
 import { SsrAuthProviderHOC } from '@/src/components/logic/SsrAuthContext'
 import { environment } from '@/src/environment'
 import { amplifyGetServerSideProps } from '@/src/frontend/utils/amplifyServer'
@@ -33,7 +34,9 @@ type Params = {
   id: string
 }
 
-export const getServerSideProps = amplifyGetServerSideProps<FormPageProps & GlobalAppProps, Params>(
+type Props = FormPageProps & GlobalAppProps & { general: GeneralQuery }
+
+export const getServerSideProps = amplifyGetServerSideProps<Props, Params>(
   async ({ context, fetchAuthSession, isSignedIn }) => {
     const nonce = context.req.headers['x-nonce'] as string | undefined // TODO type
 
@@ -61,7 +64,8 @@ export const getServerSideProps = amplifyGetServerSideProps<FormPageProps & Glob
         return { notFound: true }
       }
 
-      const [{ data: files }, strapiForm] = await Promise.all([
+      const [general, { data: files }, strapiForm] = await Promise.all([
+        strapiClient.General(),
         formsClient.filesControllerGetFilesStatusByForm(formId, {
           authStrategy: 'authOrGuestWithToken',
           getSsrAuthSession: fetchAuthSession,
@@ -82,6 +86,7 @@ export const getServerSideProps = amplifyGetServerSideProps<FormPageProps & Glob
 
       return {
         props: {
+          general,
           nonce,
           formServerContext: {
             formDefinition: makeClientFormDefinition(serverFormDefinition),
@@ -139,4 +144,10 @@ export const getServerSideProps = amplifyGetServerSideProps<FormPageProps & Glob
   },
 )
 
-export default SsrAuthProviderHOC(FormPage)
+const MunicipalServicesFormDetailPage = ({ general, ...props }: Props) => (
+  <GeneralContextProvider general={general}>
+    <FormPage {...props} />
+  </GeneralContextProvider>
+)
+
+export default SsrAuthProviderHOC(MunicipalServicesFormDetailPage)

--- a/next/src/pages/mestske-sluzby/[slug]/index.tsx
+++ b/next/src/pages/mestske-sluzby/[slug]/index.tsx
@@ -3,12 +3,13 @@ import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinit
 
 import { formsClient } from '@/src/clients/forms'
 import { strapiClient } from '@/src/clients/graphql-strapi'
-import { FormWithLandingPageFragment } from '@/src/clients/graphql-strapi/api'
+import { FormWithLandingPageFragment, GeneralQuery } from '@/src/clients/graphql-strapi/api'
 import { makeClientLandingPageFormDefinition } from '@/src/components/forms/clientFormDefinitions'
 import FormCreatedSplitPage, {
   FormCreatedSplitPageProps,
 } from '@/src/components/forms/FormCreatedSplitPage'
 import { FormWithLandingPageRequiredFragment } from '@/src/components/forms/FormLandingPage'
+import { GeneralContextProvider } from '@/src/components/logic/GeneralContextProvider'
 import { SsrAuthProviderHOC } from '@/src/components/logic/SsrAuthContext'
 import { amplifyGetServerSideProps } from '@/src/frontend/utils/amplifyServer'
 import {
@@ -37,7 +38,11 @@ export const formHasLandingPage = (
   return Boolean(form?.landingPage)
 }
 
-export const getServerSideProps = amplifyGetServerSideProps<FormCreatedSplitPageProps, Params>(
+type Props = FormCreatedSplitPageProps & {
+  general: GeneralQuery
+}
+
+export const getServerSideProps = amplifyGetServerSideProps<Props, Params>(
   async ({ context, fetchAuthSession }) => {
     if (!context.params) {
       return { notFound: true }
@@ -49,10 +54,11 @@ export const getServerSideProps = amplifyGetServerSideProps<FormCreatedSplitPage
       return { notFound: true }
     }
 
-    const strapiForm = await fetchStrapiForm(slug)
+    const [general, strapiForm] = await Promise.all([strapiClient.General(), fetchStrapiForm(slug)])
     if (formHasLandingPage(strapiForm)) {
       return {
         props: {
+          general,
           type: 'landingPage',
           formDefinition: makeClientLandingPageFormDefinition(serverFormDefinition),
           strapiForm,
@@ -91,6 +97,7 @@ export const getServerSideProps = amplifyGetServerSideProps<FormCreatedSplitPage
       // requests are not able to save new guest identity cookie.
       return {
         props: {
+          general,
           type: 'redirect',
           redirectUrl: `${ROUTES.MUNICIPAL_SERVICES_FORM_WITH_ID(slug, form.formId)}${isEmbeddedPostfix}`,
           ...(await slovakServerSideTranslations()),
@@ -107,4 +114,10 @@ export const getServerSideProps = amplifyGetServerSideProps<FormCreatedSplitPage
   {},
 )
 
-export default SsrAuthProviderHOC(FormCreatedSplitPage)
+const MunicipalServicesFormSplitPage = ({ general, ...props }: Props) => (
+  <GeneralContextProvider general={general}>
+    <FormCreatedSplitPage {...props} />
+  </GeneralContextProvider>
+)
+
+export default SsrAuthProviderHOC(MunicipalServicesFormSplitPage)


### PR DESCRIPTION
## Summary
- `/mestske-sluzby/[slug]/index.tsx` and `/mestske-sluzby/[slug]/[id].tsx` were missed in #4003 ("Add Footer"), so `Footer` throws at runtime because `useGeneralContext()` has no provider.
- Fetch `general` from Strapi in `getServerSideProps`  and wrap the page in `GeneralContextProvider`, matching the pattern applied to the other pages in that PR.

## Test plan
- [ ] Open `/mestske-sluzby/<slug>` for a form with a Strapi landing page — footer renders without throwing.
- [ ] Open `/mestske-sluzby/<slug>` for a form without a landing page — client-side redirect to `/mestske-sluzby/<slug>/<id>` still works.
- [ ] Open `/mestske-sluzby/<slug>/<id>` directly — footer renders, form loads as before.
- [ ] Embedded-form query-param flow (`?externallyEmbedded=true`) still passes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)