### PR TITLE
1329 Add Reset button in RadioGroup after rewrite to RAC

### DIFF
--- a/next/src/components/fields/RadioGroup.tsx
+++ b/next/src/components/fields/RadioGroup.tsx
@@ -1,7 +1,10 @@
-import { ReactNode } from 'react'
+import { Button } from '@bratislava/component-library'
+import { useTranslation } from 'next-i18next/pages'
+import { ReactNode, useContext } from 'react'
 import {
   RadioGroup as RACRadioGroup,
   RadioGroupProps as RACRadioGroupProps,
+  RadioGroupStateContext,
 } from 'react-aria-components'
 
 import cn from '@/src/utils/cn'
@@ -12,6 +15,27 @@ import { FieldBaseProps } from './_shared/types'
 export interface RadioGroupProps extends Omit<RACRadioGroupProps, 'orientation'>, FieldBaseProps {
   orientation?: 'vertical' | 'horizontal'
   children: ReactNode
+}
+
+// Must be rendered as a descendant of RACRadioGroup to access RadioGroupStateContext.
+// Calling setSelectedValue(null) on the shared state reliably clears the selection
+// (natively typed to accept null), unlike calling the group's onChange prop with null.
+const ResetButton = () => {
+  const state = useContext(RadioGroupStateContext)
+  const { t } = useTranslation('account')
+
+  if (!state) return null
+
+  return (
+    <Button
+      variant="plain"
+      size="small"
+      className="self-end font-medium"
+      onPress={() => state.setSelectedValue(null)}
+    >
+      {t('RadioGroup.resetChoice')}
+    </Button>
+  )
 }
 
 const RadioGroup = ({
@@ -41,13 +65,20 @@ const RadioGroup = ({
       helptextFooter={helptextFooter}
       errorMessage={errorMessage}
     >
-      <div
-        className={cn('flex', {
-          'flex-col gap-3': orientation === 'vertical',
-          'flex-row gap-6': orientation === 'horizontal',
-        })}
-      >
-        {children}
+      <div className="flex flex-col gap-2">
+        <div
+          className={cn('flex', {
+            'flex-col gap-3': orientation === 'vertical',
+            'flex-row gap-6': orientation === 'horizontal',
+          })}
+        >
+          {children}
+        </div>
+
+        {/* RadioGroup should usually be used as required. If it is not, consider another UI such as Select,
+            or provide "None of above" option and make the group required.
+            But in case it is optional, reset button is present. */}
+        {rest.isRequired ? null : <ResetButton />}
       </div>
     </FieldWrapper>
   </RACRadioGroup>


### PR DESCRIPTION
## Summary
- Restore Reset button for optional RadioGroups after the rewrite to react-aria-components
- Use `RadioGroupStateContext` + `state.setSelectedValue(null)` instead of calling the group's `onChange` with a null cast — `setSelectedValue` is natively typed `string | null` and reliably clears the selection in both controlled and uncontrolled usage
- Reset button only rendered when the group is optional (`!isRequired`)

## Test plan
- [ ] Optional RadioGroup: select an option, press "Reset", selection clears
- [ ] Required RadioGroup: no Reset button shown
- [ ] RJSF usage (forms): reset propagates back to the form state (value becomes undefined)
- [ ] Horizontal + vertical orientations still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="398" height="347" alt="image" src="https://github.com/user-attachments/assets/e8e3f740-3fbd-4891-9ced-850e7584f39a" />
