### PR TITLE
1440: add is_fully_paid flag to tax payment BR event

### DIFF
--- a/nest-tax-backend/src/bloomreach/bloomreach.types.ts
+++ b/nest-tax-backend/src/bloomreach/bloomreach.types.ts
@@ -16,6 +16,7 @@ export interface TaxPaymentBloomreachData {
   tax_type: TaxType
   order: number
   suppress_email: boolean
+  is_fully_paid: boolean
 }
 
 export interface TaxBloomreachData {

--- a/nest-tax-backend/src/noris/subservices/__tests__/noris-payment.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/__tests__/noris-payment.subservice.spec.ts
@@ -703,6 +703,7 @@ describe('NorisPaymentSubservice', () => {
     })
 
     it.each([
+      // paidFromNoris = uhrazeno * 100 (via currency.js mock)
       {
         uhrazeno: 2000,
         alreadyPaid: 0,
@@ -711,14 +712,43 @@ describe('NorisPaymentSubservice', () => {
         expectedIsFullyPaid: true,
       },
       {
+        uhrazeno: 2001,
+        alreadyPaid: 0,
+        taxAmount: 200_000,
+        expectedCreatedAmount: 200_100,
+        expectedIsFullyPaid: true,
+      },
+      {
+        uhrazeno: 1999,
+        alreadyPaid: 0,
+        taxAmount: 200_000,
+        expectedCreatedAmount: 199_900,
+        expectedIsFullyPaid: false,
+      },
+      {
         uhrazeno: 1000,
         alreadyPaid: 0,
         taxAmount: 200_000,
         expectedCreatedAmount: 100_000,
         expectedIsFullyPaid: false,
       },
+      // alreadyPaid > 0: is_fully_paid is based on cumulative paidFromNoris, not the new payment amount
+      {
+        uhrazeno: 2000,
+        alreadyPaid: 100_000,
+        taxAmount: 200_000,
+        expectedCreatedAmount: 100_000,
+        expectedIsFullyPaid: true,
+      },
+      {
+        uhrazeno: 1500,
+        alreadyPaid: 100_000,
+        taxAmount: 200_000,
+        expectedCreatedAmount: 50_000,
+        expectedIsFullyPaid: false,
+      },
     ])(
-      'should pass is_fully_paid: $expectedIsFullyPaid when paidFromNoris=$expectedCreatedAmount and taxAmount=$taxAmount',
+      'should pass is_fully_paid: $expectedIsFullyPaid when uhrazeno=$uhrazeno, alreadyPaid=$alreadyPaid, taxAmount=$taxAmount',
       async ({
         uhrazeno,
         alreadyPaid,

--- a/nest-tax-backend/src/noris/subservices/__tests__/noris-payment.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/__tests__/noris-payment.subservice.spec.ts
@@ -1,6 +1,6 @@
 import { createMock } from '@golevelup/ts-jest'
 import { Test, TestingModule } from '@nestjs/testing'
-import { PaymentStatus, Tax } from '@prisma/client'
+import { PaymentStatus, Tax, TaxType } from '@prisma/client'
 import * as mssql from 'mssql'
 
 import prismaMock from '../../../../test/singleton'
@@ -624,6 +624,8 @@ describe('NorisPaymentSubservice', () => {
         id: 1,
         year: 2024,
         amount: 1500,
+        type: TaxType.DZN,
+        order: 1,
         taxPayer: {
           id: 1,
           birthNumber: '123456/7890',
@@ -685,16 +687,107 @@ describe('NorisPaymentSubservice', () => {
           bloomreachEventSent: true,
         },
       })
+      // paidFromNoris = currency(1500).intValue = 150_000; taxData.amount = 1500 → is_fully_paid = true
       expect(trackEventTaxPaymentMock).toHaveBeenCalledWith(
         {
           amount: 50_000,
           payment_source: 'BANK_ACCOUNT',
           year: 2024,
+          tax_type: TaxType.DZN,
+          order: 1,
           suppress_email: false,
+          is_fully_paid: true,
         },
         'external-123',
       )
     })
+
+    it.each([
+      {
+        uhrazeno: 2000,
+        alreadyPaid: 0,
+        taxAmount: 200_000,
+        expectedCreatedAmount: 200_000,
+        expectedIsFullyPaid: true,
+      },
+      {
+        uhrazeno: 1000,
+        alreadyPaid: 0,
+        taxAmount: 200_000,
+        expectedCreatedAmount: 100_000,
+        expectedIsFullyPaid: false,
+      },
+    ])(
+      'should pass is_fully_paid: $expectedIsFullyPaid when paidFromNoris=$expectedCreatedAmount and taxAmount=$taxAmount',
+      async ({
+        uhrazeno,
+        alreadyPaid,
+        taxAmount,
+        expectedCreatedAmount,
+        expectedIsFullyPaid,
+      }) => {
+        const mockNorisPayment: NorisTaxPayment = {
+          variabilny_symbol: '1234567890',
+          uhrazeno,
+        }
+
+        const mockTaxData: TaxWithTaxPayer = {
+          id: 1,
+          year: 2024,
+          amount: taxAmount,
+          taxPayer: { id: 1, birthNumber: '123456/7890' },
+        } as TaxWithTaxPayer
+
+        const taxesDataByVsMap = new Map<string, TaxWithTaxPayer>()
+        taxesDataByVsMap.set('1234567890', mockTaxData)
+
+        const userDataFromCityAccount = {
+          '123456/7890': {
+            externalId: 'external-123',
+            birthNumber: '123456/7890',
+            email: 'test@example.com',
+            userAttribute: {},
+          },
+        }
+
+        const mockTransaction = jest.fn().mockImplementation((callback) =>
+          callback({
+            $queryRaw: jest.fn().mockResolvedValue([]),
+            taxPayment: {
+              aggregate: jest
+                .fn()
+                .mockResolvedValue({ _sum: { amount: alreadyPaid } }),
+              create: jest.fn().mockResolvedValue({
+                id: 1,
+                amount: expectedCreatedAmount,
+                source: 'BANK_ACCOUNT',
+                taxId: 1,
+                status: PaymentStatus.SUCCESS,
+              }),
+            },
+          }),
+        )
+
+        jest
+          .spyOn(prismaMock, '$transaction')
+          .mockImplementation(mockTransaction)
+
+        const trackEventMock = jest
+          .spyOn(bloomreachService, 'trackEventTaxPayment')
+          .mockResolvedValue(true)
+
+        await service['processIndividualPayment'](
+          mockNorisPayment,
+          taxesDataByVsMap,
+          userDataFromCityAccount,
+        )
+
+        expect(trackEventMock).toHaveBeenCalledWith(
+          expect.objectContaining({ is_fully_paid: expectedIsFullyPaid }),
+          'external-123',
+        )
+      },
+    )
 
     it('should handle case when no existing payments exist', async () => {
       const mockNorisPayment: NorisTaxPayment = {

--- a/nest-tax-backend/src/noris/subservices/noris-payment.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-payment.subservice.ts
@@ -295,9 +295,12 @@ export class NorisPaymentSubservice {
           },
         })
 
+        const isFullyPaid = paidFromNoris >= taxData.amount
+
         await this.trackPaymentIfNeeded(
           taxData,
           createdTaxPayment,
+          isFullyPaid,
           userDataFromCityAccount,
           bloomreachSettings,
         )
@@ -324,6 +327,7 @@ export class NorisPaymentSubservice {
   private async trackPaymentIfNeeded(
     taxData: TaxWithTaxPayer,
     createdTaxPayment: TaxPayment,
+    isFullyPaid: boolean,
     userDataFromCityAccount: Partial<
       Record<string, ResponseUserByBirthNumberDto>
     >,
@@ -344,6 +348,7 @@ export class NorisPaymentSubservice {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- non-null by DB trigger and constraint
           order: taxData.order!,
           suppress_email: bloomreachSettings?.suppressEmail ?? false,
+          is_fully_paid: isFullyPaid,
         },
         userFromCityAccount.externalId,
       )

--- a/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
+++ b/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
@@ -106,6 +106,12 @@ describe('PaymentService', () => {
         const mockTx = {
           taxPayment: {
             update: mockUpdate,
+            aggregate: jest
+              .fn()
+              .mockResolvedValue({ _sum: { amount: 150_000 } }),
+          },
+          tax: {
+            findUnique: jest.fn().mockResolvedValue({ amount: 150_000 }),
           },
         }
         return callback(mockTx)
@@ -132,6 +138,7 @@ describe('PaymentService', () => {
           suppress_email: false,
           tax_type: mockTaxPayment.tax.type,
           order: mockTaxPayment.tax.order,
+          is_fully_paid: true,
         },
         externalId,
       )
@@ -148,6 +155,12 @@ describe('PaymentService', () => {
         const mockTx = {
           taxPayment: {
             update: jest.fn(),
+            aggregate: jest
+              .fn()
+              .mockResolvedValue({ _sum: { amount: 150_000 } }),
+          },
+          tax: {
+            findUnique: jest.fn().mockResolvedValue({ amount: 150_000 }),
           },
         }
         return callback(mockTx)
@@ -171,6 +184,7 @@ describe('PaymentService', () => {
           suppress_email: false,
           tax_type: mockTaxPayment.tax.type,
           order: mockTaxPayment.tax.order,
+          is_fully_paid: true,
         },
         externalId,
       )
@@ -207,6 +221,12 @@ describe('PaymentService', () => {
         const mockTx = {
           taxPayment: {
             update: jest.fn(),
+            aggregate: jest
+              .fn()
+              .mockResolvedValue({ _sum: { amount: 150_000 } }),
+          },
+          tax: {
+            findUnique: jest.fn().mockResolvedValue({ amount: 150_000 }),
           },
         }
         return callback(mockTx)
@@ -234,6 +254,12 @@ describe('PaymentService', () => {
         const mockTx = {
           taxPayment: {
             update: jest.fn(),
+            aggregate: jest
+              .fn()
+              .mockResolvedValue({ _sum: { amount: 150_000 } }),
+          },
+          tax: {
+            findUnique: jest.fn().mockResolvedValue({ amount: 150_000 }),
           },
         }
         try {
@@ -262,6 +288,73 @@ describe('PaymentService', () => {
       expect(mockTransaction).toHaveBeenCalled()
       expect(transactionThrow).toBe(true)
     })
+
+    it('should throw NotFoundException when tax is not found', async () => {
+      const externalId = 'external-id-123'
+      const mockNotFoundException = new Error('Not Found')
+      const mockTransaction = jest.fn().mockImplementation((callback) => {
+        const mockTx = {
+          taxPayment: {
+            update: jest.fn(),
+            aggregate: jest.fn(),
+          },
+          tax: {
+            findUnique: jest.fn().mockResolvedValue(null),
+          },
+        }
+        return callback(mockTx)
+      })
+
+      jest.spyOn(prismaMock, '$transaction').mockImplementation(mockTransaction)
+      jest
+        .spyOn(throwerErrorGuard, 'NotFoundException')
+        .mockReturnValue(mockNotFoundException as any)
+
+      await expect(
+        service.trackPaymentInBloomreach(mockTaxPayment, externalId),
+      ).rejects.toThrow(mockNotFoundException)
+
+      expect(throwerErrorGuard.NotFoundException).toHaveBeenCalled()
+      expect(bloomreachService.trackEventTaxPayment).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      { totalPaid: 150_000, taxAmount: 150_000, expectedIsFullyPaid: true },
+      { totalPaid: 200_000, taxAmount: 150_000, expectedIsFullyPaid: true },
+      { totalPaid: 100_000, taxAmount: 150_000, expectedIsFullyPaid: false },
+    ])(
+      'should pass is_fully_paid: $expectedIsFullyPaid when totalPaid=$totalPaid and taxAmount=$taxAmount',
+      async ({ totalPaid, taxAmount, expectedIsFullyPaid }) => {
+        const externalId = 'external-id-123'
+        const mockTransaction = jest.fn().mockImplementation((callback) =>
+          callback({
+            taxPayment: {
+              update: jest.fn(),
+              aggregate: jest
+                .fn()
+                .mockResolvedValue({ _sum: { amount: totalPaid } }),
+            },
+            tax: {
+              findUnique: jest.fn().mockResolvedValue({ amount: taxAmount }),
+            },
+          }),
+        )
+
+        jest
+          .spyOn(prismaMock, '$transaction')
+          .mockImplementation(mockTransaction)
+        jest
+          .spyOn(bloomreachService, 'trackEventTaxPayment')
+          .mockResolvedValue(true)
+
+        await service.trackPaymentInBloomreach(mockTaxPayment, externalId)
+
+        expect(bloomreachService.trackEventTaxPayment).toHaveBeenCalledWith(
+          expect.objectContaining({ is_fully_paid: expectedIsFullyPaid }),
+          externalId,
+        )
+      },
+    )
   })
 
   describe('processPaymentResponse', () => {

--- a/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
+++ b/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
@@ -320,8 +320,11 @@ describe('PaymentService', () => {
 
     it.each([
       { totalPaid: 150_000, taxAmount: 150_000, expectedIsFullyPaid: true },
+      { totalPaid: 150_001, taxAmount: 150_000, expectedIsFullyPaid: true },
       { totalPaid: 200_000, taxAmount: 150_000, expectedIsFullyPaid: true },
+      { totalPaid: 149_999, taxAmount: 150_000, expectedIsFullyPaid: false },
       { totalPaid: 100_000, taxAmount: 150_000, expectedIsFullyPaid: false },
+      { totalPaid: null, taxAmount: 150_000, expectedIsFullyPaid: false },
     ])(
       'should pass is_fully_paid: $expectedIsFullyPaid when totalPaid=$totalPaid and taxAmount=$taxAmount',
       async ({ totalPaid, taxAmount, expectedIsFullyPaid }) => {

--- a/nest-tax-backend/src/payment/payment.service.ts
+++ b/nest-tax-backend/src/payment/payment.service.ts
@@ -188,6 +188,22 @@ export class PaymentService {
         return
       }
 
+      const taxData = await tx.tax.findUnique({
+        where: { id: taxPayment.taxId },
+        select: { amount: true },
+      })
+      if (!taxData) {
+        throw this.throwerErrorGuard.NotFoundException(
+          ErrorsEnum.NOT_FOUND_ERROR,
+          `Tax with id ${taxPayment.taxId} not found.`,
+        )
+      }
+      const totalPaid = await tx.taxPayment.aggregate({
+        where: { taxId: taxPayment.taxId, status: PaymentStatus.SUCCESS },
+        _sum: { amount: true },
+      })
+      const isFullyPaid = (totalPaid._sum.amount ?? 0) >= taxData.amount
+
       const result = await this.bloomreachService.trackEventTaxPayment(
         {
           amount: taxPayment.amount,
@@ -196,6 +212,7 @@ export class PaymentService {
           tax_type: taxPayment.tax.type,
           order: taxPayment.tax.order!, // non-null by DB trigger and constraint
           suppress_email: false,
+          is_fully_paid: isFullyPaid,
         },
         externalId,
       )


### PR DESCRIPTION
We are moving logic from Bloomreach scenarious to our backend. Therefore a new flag `is_fully_paid` was created, as amount will be removed from bloomreach, so we have to compute this logic ourselves. This flag is true if the sum of successful payments is greater than or equal to the tax amount.

Resolves https://github.com/bratislava/private-konto.bratislava.sk/issues/1440