### PR TITLE
Bloomreach unpaid tax installment event fixes

### DIFF
--- a/nest-tax-backend/src/bloomreach/bloomreach.types.ts
+++ b/nest-tax-backend/src/bloomreach/bloomreach.types.ts
@@ -42,4 +42,5 @@ export interface UnpaidTaxInstallmentReminderBloomreachData {
   due_date_type: INSTALLMENT_DUE_DATE_TYPE
   due_date_month: number
   due_date_day: number
+  are_installments_possible: boolean
 }

--- a/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
+++ b/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
@@ -250,7 +250,8 @@ describe('NotificationsEventsSubservice', () => {
         {
           id: 1,
           year: 2025,
-          type: TaxType.KO,
+          type: TaxType.DZN,
+          amount: 5000,
           order: 1,
           taxPayer: { birthNumber },
         } as any,
@@ -270,12 +271,13 @@ describe('NotificationsEventsSubservice', () => {
 
       const expectedPayload = {
         year: 2025,
-        tax_type: TaxType.KO,
+        tax_type: TaxType.DZN,
         order: 1,
         installment_order: 2,
         due_date_type: INSTALLMENT_DUE_DATE_TYPE.NEXT,
         due_date_month: 5,
         due_date_day: 31,
+        are_installments_possible: false, // 5000 eurocents < DZN threshold 6600
       }
       expect(
         bloomreachService.trackEventUnpaidTaxInstallmentReminder,
@@ -312,6 +314,7 @@ describe('NotificationsEventsSubservice', () => {
           id: 1,
           year: 2025,
           type: TaxType.KO,
+          amount: 10000,
           order: 1,
           taxPayer: { birthNumber },
         } as any,
@@ -337,6 +340,7 @@ describe('NotificationsEventsSubservice', () => {
         due_date_type: INSTALLMENT_DUE_DATE_TYPE.PAST,
         due_date_month: 5,
         due_date_day: 31,
+        are_installments_possible: true, // 10000 eurocents > KO threshold 0
       }
       expect(
         bloomreachService.trackEventUnpaidTaxInstallmentReminder,
@@ -373,7 +377,8 @@ describe('NotificationsEventsSubservice', () => {
         {
           id: 1,
           year: 2025,
-          type: TaxType.KO,
+          type: TaxType.DZN,
+          amount: 5000,
           order: 1,
           taxPayer: { birthNumber: birth1 },
         } as any,
@@ -381,6 +386,7 @@ describe('NotificationsEventsSubservice', () => {
           id: 2,
           year: 2025,
           type: TaxType.KO,
+          amount: 10000,
           order: 2,
           taxPayer: { birthNumber: birth2 },
         } as any,
@@ -401,16 +407,23 @@ describe('NotificationsEventsSubservice', () => {
 
       const expectedPayload1 = {
         year: 2025,
-        tax_type: TaxType.KO,
+        tax_type: TaxType.DZN,
         order: 1,
         installment_order: 2,
         due_date_type: INSTALLMENT_DUE_DATE_TYPE.NEXT,
         due_date_month: 5,
         due_date_day: 31,
+        are_installments_possible: false, // 5000 eurocents < DZN threshold 6600
       }
       const expectedPayload2 = {
-        ...expectedPayload1,
+        year: 2025,
+        tax_type: TaxType.KO,
         order: 2,
+        installment_order: 2,
+        due_date_type: INSTALLMENT_DUE_DATE_TYPE.NEXT,
+        due_date_month: 5,
+        due_date_day: 31,
+        are_installments_possible: true, // 10000 eurocents > KO threshold 0
       }
       expect(
         bloomreachService.trackEventUnpaidTaxInstallmentReminder,
@@ -443,10 +456,18 @@ describe('NotificationsEventsSubservice', () => {
       prismaMock.tax.findMany.mockResolvedValue([
         {
           id: 1,
+          year: 2025,
+          type: TaxType.KO,
+          order: 1,
+          amount: 100,
           taxPayer: { birthNumber: birth1 },
         } as any,
         {
           id: 2,
+          year: 2025,
+          type: TaxType.KO,
+          order: 2,
+          amount: 200,
           taxPayer: { birthNumber: birth2 },
         } as any,
       ])

--- a/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
+++ b/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
@@ -532,9 +532,7 @@ describe('NotificationsEventsSubservice', () => {
 
   describe('sendUnpaidTaxReminders', () => {
     it('should not do anything when there are no taxes', async () => {
-      const findManyMock = jest
-        .spyOn(service['prismaService'].tax, 'findMany')
-        .mockResolvedValue([])
+      prismaMock.$queryRaw.mockResolvedValue([])
       const trackEventUnpaidTaxReminderMock = jest.spyOn(
         service['bloomreachService'],
         'trackEventUnpaidTaxReminder',
@@ -542,24 +540,20 @@ describe('NotificationsEventsSubservice', () => {
 
       await service.sendUnpaidTaxReminders()
 
-      expect(findManyMock).toHaveBeenCalled()
+      expect(prismaMock.$queryRaw).toHaveBeenCalled()
       expect(trackEventUnpaidTaxReminderMock).not.toHaveBeenCalled()
     })
 
     it('should send payment reminder events when there are taxes', async () => {
-      const findManyMock = jest
-        .spyOn(service['prismaService'].tax, 'findMany')
-        .mockResolvedValue([
-          {
-            id: 1,
-            year: 2024,
-            type: TaxType.DZN,
-            order: 1,
-            taxPayer: {
-              birthNumber: '123456/7890',
-            },
-          },
-        ] as any)
+      prismaMock.$queryRaw.mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          birthNumber: '123456/7890',
+        },
+      ])
       const trackEventUnpaidTaxReminderMock = jest.spyOn(
         service['bloomreachService'],
         'trackEventUnpaidTaxReminder',
@@ -575,7 +569,7 @@ describe('NotificationsEventsSubservice', () => {
 
       await service.sendUnpaidTaxReminders()
 
-      expect(findManyMock).toHaveBeenCalled()
+      expect(prismaMock.$queryRaw).toHaveBeenCalled()
       expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledWith(
         {
           year: 2024,
@@ -587,37 +581,29 @@ describe('NotificationsEventsSubservice', () => {
     })
 
     it('should send payment reminder event for each tax where there is user from city account', async () => {
-      const findManyMock = jest
-        .spyOn(service['prismaService'].tax, 'findMany')
-        .mockResolvedValue([
-          {
-            id: 1,
-            year: 2024,
-            type: TaxType.DZN,
-            order: 1,
-            taxPayer: {
-              birthNumber: '123456/7890',
-            },
-          },
-          {
-            id: 2,
-            year: 2024,
-            type: TaxType.KO,
-            order: 2,
-            taxPayer: {
-              birthNumber: '123456/7891',
-            },
-          },
-          {
-            id: 3,
-            year: 2024,
-            type: TaxType.DZN,
-            order: 1,
-            taxPayer: {
-              birthNumber: '123456/7892',
-            },
-          },
-        ] as any)
+      prismaMock.$queryRaw.mockResolvedValue([
+        {
+          id: 1,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          birthNumber: '123456/7890',
+        },
+        {
+          id: 2,
+          year: 2024,
+          type: TaxType.KO,
+          order: 2,
+          birthNumber: '123456/7891',
+        },
+        {
+          id: 3,
+          year: 2024,
+          type: TaxType.DZN,
+          order: 1,
+          birthNumber: '123456/7892',
+        },
+      ])
       const trackEventUnpaidTaxReminderMock = jest.spyOn(
         service['bloomreachService'],
         'trackEventUnpaidTaxReminder',
@@ -636,7 +622,7 @@ describe('NotificationsEventsSubservice', () => {
 
       await service.sendUnpaidTaxReminders()
 
-      expect(findManyMock).toHaveBeenCalled()
+      expect(prismaMock.$queryRaw).toHaveBeenCalled()
       expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledTimes(2)
       expect(trackEventUnpaidTaxReminderMock).toHaveBeenCalledWith(
         {

--- a/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
@@ -251,8 +251,8 @@ export default class NotificationsEventsService {
 
     // Raw query so that LIMIT applies after all eligibility filters.
     // Eligibility rules:
-    //   - 2+ installments → no successful payment at all
-    //   - 1 installment   → sum of successful payments < tax amount (partial/unpaid)
+    //   - 2+ installments: no successful payment at all
+    //   - 1 installment:   sum of successful payments < tax amount (partial or unpaid)
     // need to spread this because of getUserDataAdminBatch will timeout if used on 700 records
     // 50 * 6 * 24 h = 7200 is max number of konto visitors in dayhours
     const taxes = await this.prismaService.$queryRaw<

--- a/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
@@ -1,8 +1,8 @@
 import { HttpException, Injectable } from '@nestjs/common'
 import {
-  DeliveryMethodNamed,
   PaymentStatus,
   Prisma,
+  TaxType,
   UnpaidReminderSent,
 } from '@prisma/client'
 import dayjs, { Dayjs } from 'dayjs'
@@ -248,55 +248,56 @@ export default class NotificationsEventsService {
       .tz('Europe/Bratislava')
       .subtract(DUE_DATE_OFFSET, 'day')
       .toDate()
-    const taxes = await this.prismaService.tax.findMany({
-      select: {
-        id: true,
-        year: true,
-        type: true,
-        order: true,
-        taxPayer: {
-          select: {
-            birthNumber: true,
-          },
-        },
-      },
-      where: {
-        bloomreachUnpaidTaxReminderSent: false,
-        isCancelled: false,
-        // Such taxes are not paid directly by the taxpayer. Therefore, we do not send reminders for them
-        paymentMethodIsInkaso: false,
-        taxPayments: {
-          none: {
-            status: PaymentStatus.SUCCESS,
-          },
-        },
-        OR: [
-          {
-            deliveryMethod: DeliveryMethodNamed.CITY_ACCOUNT,
-            createdAt: {
-              lte: DUE_DATE_OFFSET_DATE,
-            },
-          },
-          {
-            deliveryMethod: {
-              not: DeliveryMethodNamed.CITY_ACCOUNT,
-            },
-            dateTaxRuling: {
-              lte: DUE_DATE_OFFSET_DATE,
-            },
-          },
-          {
-            deliveryMethod: null,
-            dateTaxRuling: {
-              lte: DUE_DATE_OFFSET_DATE,
-            },
-          },
-        ],
-      },
-      // need to spread this because of getUserDataAdminBatch will timeout if used on 700 records
-      // 50 * 6 * 24 h = 7200 is max number of konto visitors in dayhours
-      take: 50,
-    })
+
+    // Raw query so that LIMIT applies after all eligibility filters.
+    // Eligibility rules:
+    //   - 2+ installments → no successful payment at all
+    //   - 1 installment   → sum of successful payments < tax amount (partial/unpaid)
+    // need to spread this because of getUserDataAdminBatch will timeout if used on 700 records
+    // 50 * 6 * 24 h = 7200 is max number of konto visitors in dayhours
+    const taxes = await this.prismaService.$queryRaw<
+      {
+        id: number
+        year: number
+        type: TaxType
+        order: number | null
+        birthNumber: string
+      }[]
+    >`
+      WITH paid AS (
+        SELECT tp."taxId", SUM(tp.amount) AS total_paid
+        FROM "TaxPayment" tp
+        WHERE tp.status = 'SUCCESS'::"PaymentStatus"
+        GROUP BY tp."taxId"
+      ),
+      installment_counts AS (
+        SELECT ti."taxId", COUNT(*) AS installment_count
+        FROM "TaxInstallment" ti
+        GROUP BY ti."taxId"
+      )
+      SELECT
+        t.id,
+        t.year,
+        t.type,
+        t."order",
+        taxp."birthNumber"
+      FROM "Tax" t
+      JOIN "TaxPayer" taxp ON taxp.id = t."taxPayerId"
+      LEFT JOIN paid p ON p."taxId" = t.id
+      LEFT JOIN installment_counts ic ON ic."taxId" = t.id
+      WHERE t."bloomreachUnpaidTaxReminderSent" = false
+        AND t."isCancelled" = false
+        AND t."paymentMethodIsInkaso" = false
+        AND (
+          (t."deliveryMethod" = 'CITY_ACCOUNT'::"DeliveryMethodNamed" AND t."createdAt" <= ${DUE_DATE_OFFSET_DATE})
+          OR (t."deliveryMethod" IS DISTINCT FROM 'CITY_ACCOUNT'::"DeliveryMethodNamed" AND t."dateTaxRuling" <= ${DUE_DATE_OFFSET_DATE})
+        )
+        AND (
+          (COALESCE(ic.installment_count, 0) >= 2 AND COALESCE(p.total_paid, 0) = 0)
+          OR (COALESCE(ic.installment_count, 0) < 2 AND COALESCE(p.total_paid, 0) < t.amount)
+        )
+      LIMIT ${UNPAID_INSTALLMENT_REMINDER_BATCH_LIMIT}
+    `
 
     if (taxes.length === 0) {
       return
@@ -311,13 +312,13 @@ export default class NotificationsEventsService {
 
     const userDataFromCityAccount =
       await this.cityAccountSubservice.getUserDataAdminBatch(
-        taxes.map((taxData) => taxData.taxPayer.birthNumber),
+        taxes.map((tax) => tax.birthNumber),
       )
 
     await Promise.all(
       taxes.map(async (tax) => {
         const userFromCityAccount =
-          userDataFromCityAccount[tax.taxPayer.birthNumber] || null
+          userDataFromCityAccount[tax.birthNumber] || null
         if (userFromCityAccount && userFromCityAccount.externalId) {
           await this.bloomreachService.trackEventUnpaidTaxReminder(
             { year: tax.year, tax_type: tax.type, order: tax.order! },

--- a/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
@@ -16,6 +16,7 @@ import {
   DUE_DATE_OFFSET,
   parseInstallmentDueDate,
 } from '../../tax/utils/unified-tax.util'
+import { getTaxDefinitionByType } from '../../tax-definitions/getTaxDefinitionByType'
 import { ErrorsEnum } from '../../utils/guards/dtos/error.dto'
 import ThrowerErrorGuard from '../../utils/guards/errors.guard'
 import { CityAccountSubservice } from '../../utils/subservices/cityaccount.subservice'
@@ -147,6 +148,11 @@ export default class NotificationsEventsService {
         }
 
         const dueDate = parseInstallmentDueDate(installmentInfo.dueDate)
+
+        const taxDefinition = getTaxDefinitionByType(tax.type)
+        const areInstallmentsPossible =
+          tax.amount > taxDefinition.paymentCalendarThreshold
+
         const eventData = {
           year: tax.year,
           tax_type: tax.type,
@@ -155,6 +161,7 @@ export default class NotificationsEventsService {
           due_date_type: dueDateType,
           due_date_month: dueDate.month() + 1,
           due_date_day: dueDate.date(),
+          are_installments_possible: areInstallmentsPossible,
         }
         try {
           const result =


### PR DESCRIPTION
Two related changes to the Bloomreach notification events service.

### 1. Add `are_installments_possible` to the installment reminder event

The `unpaid_tax_installment_reminder` Bloomreach event now includes a new `are_installments_possible` boolean field, computed from the tax amount vs. the per-type `paymentCalendarThreshold` (66 EUR for DZN, 0 for KO).

### 2. Rework unpaid tax reminder eligibility for 1-installment taxes

Previously `sendUnpaidTaxReminders` only sent reminders to taxes with **no** successful payments at all. The new logic differentiates by installment count:

| Installments | Send reminder when… |
|---|---|
| 2 or more | no successful payment exists (unchanged) |
| exactly 1 | sum of successful payments < tax amount (partial or fully unpaid) |

This means a 1-installment taxpayer who made a partial payment now receives a reminder for the remaining balance, whereas before they were silently skipped.