### PR TITLE
Switch nest backends to CloudNativePG database service

### DIFF
--- a/nest-city-account/kubernetes/base/deployment.yml
+++ b/nest-city-account/kubernetes/base/deployment.yml
@@ -65,14 +65,14 @@ spec:
         - name: RABBIT_MQ_URI
           value: amqp://$(RABBIT_MQ_USERNAME):$(RABBIT_MQ_PASSWORD)@$(RABBIT_MQ_HOST):$(RABBIT_MQ_PORT)
         - name: DATABASE_URL
-          value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@${BUILD_REPOSITORY_NAME}-database:5432/$(POSTGRES_DB)?schema=public&connection_limit=500
+          value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@${BUILD_REPOSITORY_NAME}-cnpg-rw:5432/$(POSTGRES_DB)?schema=public&connection_limit=500
         - name: REDIS_SERVICE
           value: ${BUILD_REPOSITORY_NAME}-redis
         envFrom:
         - secretRef:
             name: ${BUILD_REPOSITORY_NAME}-redis-secret
         - secretRef:
-            name: ${BUILD_REPOSITORY_NAME}-database-secret
+            name: ${BUILD_REPOSITORY_NAME}-cnpg-database-secret
         - secretRef:
             name: ${BUILD_REPOSITORY_NAME}-cognito-secret
         - secretRef:

--- a/nest-clamav-scanner/kubernetes/base/deployment.yml
+++ b/nest-clamav-scanner/kubernetes/base/deployment.yml
@@ -32,14 +32,14 @@ spec:
               memory: 64Mi
           env:
             - name: DATABASE_URL
-              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@${BUILD_REPOSITORY_NAME}-database:5432/$(POSTGRES_DB)?schema=public
+              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@${BUILD_REPOSITORY_NAME}-cnpg-rw:5432/$(POSTGRES_DB)?schema=public
           envFrom:
             - configMapRef:
                 name: ${BUILD_REPOSITORY_NAME}-env
             - configMapRef:
                 name: ${BUILD_REPOSITORY_NAME}-clamav
             - secretRef:
-                name: ${BUILD_REPOSITORY_NAME}-database-secret
+                name: ${BUILD_REPOSITORY_NAME}-cnpg-database-secret
             - secretRef:
                 name: ${BUILD_REPOSITORY_NAME}-forms-secret
             - secretRef:

--- a/nest-forms-backend/kubernetes/base/deployment.yml
+++ b/nest-forms-backend/kubernetes/base/deployment.yml
@@ -39,7 +39,7 @@ spec:
             memory: ${NEST_MEMORY_REQUESTS}
         env:
         - name: DATABASE_URL
-          value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@${BUILD_REPOSITORY_NAME}-database:5432/$(POSTGRES_DB)?schema=public
+          value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@${BUILD_REPOSITORY_NAME}-cnpg-rw:5432/$(POSTGRES_DB)?schema=public
         - name: REDIS_SERVICE
           value: ${BUILD_REPOSITORY_NAME}-redis-service
         - name: RABBIT_MQ_PASSWORD
@@ -70,7 +70,7 @@ spec:
         - secretRef:
             name: ${BUILD_REPOSITORY_NAME}-redis-secret
         - secretRef:
-            name: ${BUILD_REPOSITORY_NAME}-database-secret
+            name: ${BUILD_REPOSITORY_NAME}-cnpg-database-secret
         - secretRef:
             name: ${BUILD_REPOSITORY_NAME}-cognito-secret
         - secretRef:

--- a/nest-tax-backend/kubernetes/base/deployment.yml
+++ b/nest-tax-backend/kubernetes/base/deployment.yml
@@ -32,7 +32,7 @@ spec:
             memory: ${NEST_MEMORY_REQUESTS}
         envFrom:
         - secretRef:
-            name: database-secret
+            name: cnpg-database-secret
         - secretRef:
             name: mailgun-secret
         - secretRef:

--- a/nest-tax-backend/kubernetes/base/kustomization.yml
+++ b/nest-tax-backend/kubernetes/base/kustomization.yml
@@ -18,7 +18,7 @@ patches:
         path: /spec/template/spec/containers/0/env
         value:
         - name: DATABASE_URL
-          value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@${BUILD_REPOSITORY_NAME}-database:5432/$(POSTGRES_DB)?schema=public&connection_limit=500 
+          value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@${BUILD_REPOSITORY_NAME}-cnpg-rw:5432/$(POSTGRES_DB)?schema=public&connection_limit=500
         - name: PAYGATE_CERT_PATH
           value: ${PAYGATE_CERT_PATH}
 


### PR DESCRIPTION
## Summary
- Point DATABASE_URL host from `<service>-database` to `<service>-cnpg-rw` for `nest-forms-backend`, `nest-tax-backend`, `nest-city-account`, and `nest-clamav-scanner`.
- Swap the database secret envFrom from `<service>-database-secret` to `<service>-cnpg-database-secret` for the same services.
- Strapi remains on the legacy in-cluster StatefulSet. The legacy StatefulSet/secret/service for the switched backends is left untouched so the old database stays intact during the cutover.

## Test plan
- [x] Confirm the `<service>-cnpg-database-secret` SealedSecret exists per cluster with the expected `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` keys before merging.
- [ ] After deploy: verify each app pod connects to the CloudNativePG cluster and the legacy StatefulSet is still running but unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)