### PR TITLE
Fix order of user identity verification from DCOM data

### DIFF
--- a/nest-city-account/src/user-verification/utils/subservice/verification.subservice.ts
+++ b/nest-city-account/src/user-verification/utils/subservice/verification.subservice.ts
@@ -276,6 +276,15 @@ export class VerificationSubservice {
       return rfoDataDcom
     }
 
+    if (!rfoDataDcom.data.rodneCislo) {
+      return { success: false, reason: VerificationErrorsEnum.BIRTH_NUMBER_NOT_EXISTS }
+    }
+
+    const rfoCheckDcom = this.checkIdentityCard(rfoDataDcom.data, data.identityCard)
+    if (!rfoCheckDcom.success) {
+      return rfoCheckDcom
+    }
+
     // For physical person, require Cognito given_name + family_name match to RFO
     if (!ico && !this.validatePersonName(rfoDataDcom.data, user.given_name, user.family_name)) {
       this.logger.warn('We refused validation based on names not matching.', {
@@ -283,16 +292,6 @@ export class VerificationSubservice {
         providedName: { name: user.given_name, surname: user.family_name },
       })
       return { success: false, reason: VerificationErrorsEnum.NAMES_NOT_MATCHING }
-    }
-
-    if (!rfoDataDcom.data.rodneCislo) {
-      return { success: false, reason: VerificationErrorsEnum.BIRTH_NUMBER_NOT_EXISTS }
-    }
-
-    const rfoCheckDcom = this.checkIdentityCard(rfoDataDcom.data, data.identityCard)
-
-    if (!rfoCheckDcom.success) {
-      return rfoCheckDcom
     }
 
     const birthNumber = rfoDataDcom.data.rodneCislo.replaceAll('/', '')


### PR DESCRIPTION
When verifying against RFO data, the order of verification is 
1. birth number match
2. identity card match
3. name match

Using data from DCOM we evaluated name match first causing very confusing logs and falsely marking name mismatch as a culprit of failed verification when ID card was wrong.

I perceive the RFO verification order to be sorted by importance, and I changed the DCOM verification order to be the same.