### PR TITLE
823 Use locks for race conditions in delivery methods instead of alerts

### DIFF
--- a/nest-city-account/src/tasks/subservices/__tests__/tax-delivery-methods-tasks.subservice.spec.ts
+++ b/nest-city-account/src/tasks/subservices/__tests__/tax-delivery-methods-tasks.subservice.spec.ts
@@ -64,8 +64,8 @@ describe('TaxDeliveryMethodsTasksSubservice', () => {
       if (typeof fn === 'function') return fn(prismaMock)
       return Promise.all(fn)
     })
-    // $queryRaw is used for pg_advisory_xact_lock — no-op in tests.
-    ;(prismaMock.$queryRaw as jest.Mock).mockResolvedValue([])
+    // $executeRaw is used for pg_advisory_xact_lock — no-op in tests.
+    ;(prismaMock.$executeRaw as jest.Mock).mockResolvedValue(0)
   })
 
   describe('updateDeliveryMethodsInNoris', () => {

--- a/nest-city-account/src/tasks/subservices/__tests__/tax-delivery-methods-tasks.subservice.spec.ts
+++ b/nest-city-account/src/tasks/subservices/__tests__/tax-delivery-methods-tasks.subservice.spec.ts
@@ -58,6 +58,14 @@ describe('TaxDeliveryMethodsTasksSubservice', () => {
 
     service = module.get<TaxDeliveryMethodsTasksSubservice>(TaxDeliveryMethodsTasksSubservice)
     throwerErrorGuard = module.get<ThrowerErrorGuard>(ThrowerErrorGuard)
+
+    // Make $transaction execute its callback so the advisory-lock path is exercised in tests.
+    ;(prismaMock.$transaction as jest.Mock).mockImplementation(async (fn: any) => {
+      if (typeof fn === 'function') return fn(prismaMock)
+      return Promise.all(fn)
+    })
+    // $queryRaw is used for pg_advisory_xact_lock — no-op in tests.
+    ;(prismaMock.$queryRaw as jest.Mock).mockResolvedValue([])
   })
 
   describe('updateDeliveryMethodsInNoris', () => {
@@ -75,6 +83,7 @@ describe('TaxDeliveryMethodsTasksSubservice', () => {
       const prismaUserUpdateSpy = jest.spyOn(prismaMock.user, 'updateMany')
 
       prismaMock.user.findMany
+        // Initial batch
         .mockResolvedValueOnce([
           {
             birthNumber: '1234562020',
@@ -117,7 +126,17 @@ describe('TaxDeliveryMethodsTasksSubservice', () => {
             id: '8',
           },
         ] as unknown as UserWithRelations[])
-        .mockResolvedValueOnce([])
+        // Re-check inside advisory-lock transaction: all users still active
+        .mockResolvedValueOnce([
+          { birthNumber: '1234562020' },
+          { birthNumber: '1234564848' },
+          { birthNumber: '1234561234' },
+          { birthNumber: '1234569999' },
+          { birthNumber: '1234567777' },
+          { birthNumber: '1234564646' },
+          { birthNumber: '1234564649' },
+          { birthNumber: '1234564521' },
+        ] as unknown as UserWithRelations[])
 
       await service.updateDeliveryMethodsInNoris()
 
@@ -178,22 +197,19 @@ describe('TaxDeliveryMethodsTasksSubservice', () => {
       expect(prismaUserUpdateSpy).not.toHaveBeenCalled()
     })
 
-    it('should throw error if some user was deactivated during his update in Noris', async () => {
-      const adminApiUpdateSpy = jest
-        .spyOn(service['taxSubservice'], 'updateDeliveryMethodsInNoris')
-        .mockResolvedValue({
-          data: {
-            birthNumbers: ['123456/2020'],
-          },
-        } as AxiosResponse<UpdateDeliveryMethodsInNorisResponseDto>)
-      const internalErrorSpy = jest
-        .spyOn(throwerErrorGuard, 'InternalServerErrorException')
-        .mockImplementation(() => {
-          throw new Error('User deactivated')
-        })
-      const prismaUserUpdateSpy = jest.spyOn(prismaMock.user, 'updateMany')
+    it('should skip deactivated users detected during the lock re-check and not call Noris for them', async () => {
+      const adminApiUpdateSpy = jest.spyOn(service['taxSubservice'], 'updateDeliveryMethodsInNoris')
+      const removeDeliveryMethodSpy = jest.spyOn(
+        service['taxSubservice'],
+        'removeDeliveryMethodFromNoris'
+      )
+      const internalErrorSpy = jest.spyOn(throwerErrorGuard, 'InternalServerErrorException')
+      const prismaUserUpdateSpy = jest
+        .spyOn(prismaMock.user, 'updateMany')
+        .mockResolvedValue({ count: 1 })
 
       prismaMock.user.findMany
+        // Initial batch: one user
         .mockResolvedValueOnce([
           {
             birthNumber: '1234562020',
@@ -201,17 +217,75 @@ describe('TaxDeliveryMethodsTasksSubservice', () => {
             taxDeliveryMethodAtLockDate: DeliveryMethodEnum.EDESK,
           },
         ] as unknown as UserWithRelations[])
+        // Re-check inside the transaction: user was deactivated (birthNumber now null) → empty
+        .mockResolvedValueOnce([])
+
+      await service.updateDeliveryMethodsInNoris()
+
+      expect(internalErrorSpy).not.toHaveBeenCalled()
+      // The user was filtered out by the re-check, so Noris should not be called at all.
+      expect(adminApiUpdateSpy).not.toHaveBeenCalled()
+      // No re-remove needed — locking guarantees correctness without it.
+      expect(removeDeliveryMethodSpy).not.toHaveBeenCalled()
+      // lastTaxDeliveryMethodsUpdateTry is still stamped for the batch.
+      expect(prismaUserUpdateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: { in: ['1'] } },
+          data: { lastTaxDeliveryMethodsUpdateTry: expect.any(Date) },
+        })
+      )
+    })
+
+    it('should call Noris only with users still active after the re-check when some are deactivated mid-flight', async () => {
+      const adminApiUpdateSpy = jest
+        .spyOn(service['taxSubservice'], 'updateDeliveryMethodsInNoris')
+        .mockResolvedValue({
+          data: { birthNumbers: ['123456/2020'] },
+        } as AxiosResponse<UpdateDeliveryMethodsInNorisResponseDto>)
+      const prismaUserUpdateSpy = jest
+        .spyOn(prismaMock.user, 'updateMany')
+        .mockResolvedValue({ count: 1 })
+
+      prismaMock.user.findMany
+        // Initial batch: two users
         .mockResolvedValueOnce([
           {
+            birthNumber: '1234562020',
             id: '1',
+            taxDeliveryMethodAtLockDate: DeliveryMethodEnum.EDESK,
           },
-        ] as User[])
+          {
+            birthNumber: '1234564848',
+            id: '2',
+            taxDeliveryMethodAtLockDate: DeliveryMethodEnum.POSTAL,
+          },
+        ] as unknown as UserWithRelations[])
+        // Re-check: only user1 is still active (user2 was deactivated between the initial query and the lock)
+        .mockResolvedValueOnce([{ birthNumber: '1234562020' }] as unknown as UserWithRelations[])
 
-      await expect(service.updateDeliveryMethodsInNoris()).rejects.toThrow('User deactivated')
+      await service.updateDeliveryMethodsInNoris()
 
-      expect(internalErrorSpy).toHaveBeenCalled()
-      expect(adminApiUpdateSpy).toHaveBeenCalled()
-      expect(prismaUserUpdateSpy).not.toHaveBeenCalled()
+      // Noris is called with only the still-active user's data.
+      expect(adminApiUpdateSpy).toHaveBeenCalledTimes(1)
+      expect(adminApiUpdateSpy).toHaveBeenCalledWith({
+        data: {
+          '1234562020': { deliveryMethod: DeliveryMethodNoris.EDESK },
+        },
+      })
+
+      // lastTaxDeliveryMethodsUpdateTry is stamped for the entire batch, including the deactivated user.
+      expect(prismaUserUpdateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: { in: ['1', '2'] } },
+          data: { lastTaxDeliveryMethodsUpdateTry: expect.any(Date) },
+        })
+      )
+
+      // lastTaxDeliveryMethodsUpdateYear is stamped only for the birth number Noris confirmed.
+      expect(prismaUserUpdateSpy).toHaveBeenCalledWith({
+        where: { birthNumber: { in: ['1234562020'] } },
+        data: { lastTaxDeliveryMethodsUpdateYear: new Date().getFullYear() },
+      })
     })
   })
 

--- a/nest-city-account/src/tasks/subservices/tax-delivery-methods-tasks.subservice.ts
+++ b/nest-city-account/src/tasks/subservices/tax-delivery-methods-tasks.subservice.ts
@@ -10,7 +10,7 @@ import {
   DeliveryMethodErrorsEnum,
   DeliveryMethodErrorsResponseEnum,
 } from '../../utils/guards/dtos/delivery-method.error'
-import { ErrorsEnum, ErrorsResponseEnum } from '../../utils/guards/dtos/error.dto'
+import { ErrorsEnum } from '../../utils/guards/dtos/error.dto'
 import ThrowerErrorGuard from '../../utils/guards/errors.guard'
 import { DeliveryMethodCodec } from '../../utils/norisCodec'
 import { LineLoggerSubservice } from '../../utils/subservices/line-logger.subservice'
@@ -111,60 +111,69 @@ export class TaxDeliveryMethodsTasksSubservice {
       {}
     )
 
-    const updateResponse = await this.taxSubservice.updateDeliveryMethodsInNoris({ data })
-    const updatedBirthNumbers = updateResponse.data.birthNumbers.map((birthNumber) =>
-      birthNumber.replaceAll('/', '')
+    // Sorted acquisition prevents deadlocks: keys along any wait-chain T1->T2->...->Tn are strictly
+    // increasing, so the chain cannot cycle back to T1.
+    const sortedBirthNumbers = Object.keys(data).sort((a, b) => a.localeCompare(b))
+
+    // Advisory lock approach: hold a per-birth-number PostgreSQL advisory xact lock from
+    // the moment we re-check whether each user is still active until the Noris write
+    // completes. A concurrent deactivation either:
+    //   (a) set birthNumber=null before our re-check: we skip, deactivation removes from Noris
+    //   (b) runs after our lock is acquired: it blocks, waits for our write, then removes from Noris
+    // The lock is automatically released when the transaction commits.
+    const norisUpdateResponse = await this.prismaService.$transaction(
+      async (tx) => {
+        for (const bn of sortedBirthNumbers) {
+          // eslint-disable-next-line no-await-in-loop -- locks must be acquired sequentially in sorted order to prevent deadlocks
+          await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('noris_delivery_method'), hashtext(${bn}))`
+        }
+
+        // Re-check which users are still active now that we hold the locks.
+        const stillActiveUsers = await tx.user.findMany({
+          where: {
+            id: { in: users.map((u) => u.id) },
+            birthNumber: { not: null },
+            ...ACTIVE_USER_FILTER,
+          },
+          select: { birthNumber: true },
+        })
+        const activeBirthNumbers = new Set(
+          stillActiveUsers.map((u) => u.birthNumber).filter((bn): bn is string => bn !== null)
+        )
+        const activeData = Object.fromEntries(
+          Object.entries(data).filter(([bn]) => activeBirthNumbers.has(bn))
+        )
+
+        if (Object.keys(activeData).length === 0) return null
+
+        // HTTP call to Noris happens while the locks are still held.
+        return this.taxSubservice.updateDeliveryMethodsInNoris({ data: activeData })
+      },
+      { timeout: 30_000 }
     )
 
-    // Now we should check if some user was not deactivated during his update in Noris.
-    // This would be a problem, since if we update the delivery method in Noris after removing the delivery method, we should manually remove them. However, it is an edge case.
-    const deactivated = await this.prismaService.user.findMany({
-      select: {
-        id: true,
-      },
-      where: {
-        id: {
-          in: users.map((user) => user.id),
-        },
-        birthNumber: null,
-      },
-    })
-    // If someone was deactivated, we should log the error with their birth numbers.
-    if (deactivated.length > 0) {
-      const deactivatedIds = deactivated.map((user) => user.id)
-      const birthNumbersOfDeactivateUsers = users
-        .filter((user) => deactivatedIds.includes(user.id))
-        .map((user) => user.birthNumber)
-      throw this.throwerErrorGuard.InternalServerErrorException(
-        ErrorsEnum.INTERNAL_SERVER_ERROR,
-        ErrorsResponseEnum.INTERNAL_SERVER_ERROR,
-        `Some users were deactivated during the update of the delivery methods in Noris. Their birth numbers are: ${birthNumbersOfDeactivateUsers.join(
-          ', '
-        )}. Remove their delivery methods in Noris manually.`
-      )
-    }
-
-    // If OK, we should set the Users to have updated delivery methods in Noris for the current year. Otherwise the error will be thrown.
+    // Update the try-timestamp for all users in the batch regardless of outcome.
     await this.prismaService.user.updateMany({
       where: {
-        birthNumber: {
-          in: updatedBirthNumbers,
-        },
-      },
-      data: {
-        lastTaxDeliveryMethodsUpdateYear: currentYear,
-      },
-    })
-
-    // For all users, not only those who were updated, we should set the last timestamp of trying to update delivery methods in Noris.
-    await this.prismaService.user.updateMany({
-      where: {
-        id: {
-          in: users.map((user) => user.id),
-        },
+        id: { in: users.map((user) => user.id) },
       },
       data: {
         lastTaxDeliveryMethodsUpdateTry: new Date(),
+      },
+    })
+
+    if (!norisUpdateResponse) return
+
+    const updatedBirthNumbers = norisUpdateResponse.data.birthNumbers.map((birthNumber) =>
+      birthNumber.replaceAll('/', '')
+    )
+
+    await this.prismaService.user.updateMany({
+      where: {
+        birthNumber: { in: updatedBirthNumbers },
+      },
+      data: {
+        lastTaxDeliveryMethodsUpdateYear: currentYear,
       },
     })
   }

--- a/nest-city-account/src/tasks/subservices/tax-delivery-methods-tasks.subservice.ts
+++ b/nest-city-account/src/tasks/subservices/tax-delivery-methods-tasks.subservice.ts
@@ -146,7 +146,7 @@ export class TaxDeliveryMethodsTasksSubservice {
 
         if (Object.keys(activeData).length === 0) return null
 
-        // HTTP call to Noris happens while the locks are still held.
+        // call to Noris happens while the locks are still held.
         return this.taxSubservice.updateDeliveryMethodsInNoris({ data: activeData })
       },
       { timeout: 30_000 }

--- a/nest-city-account/src/tasks/subservices/tax-delivery-methods-tasks.subservice.ts
+++ b/nest-city-account/src/tasks/subservices/tax-delivery-methods-tasks.subservice.ts
@@ -125,7 +125,7 @@ export class TaxDeliveryMethodsTasksSubservice {
       async (tx) => {
         for (const bn of sortedBirthNumbers) {
           // eslint-disable-next-line no-await-in-loop -- locks must be acquired sequentially in sorted order to prevent deadlocks
-          await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('noris_delivery_method'), hashtext(${bn}))`
+          await TaxSubservice.acquireDeliveryMethodLock(tx, bn)
         }
 
         // Re-check which users are still active now that we hold the locks.

--- a/nest-city-account/src/user/user.service.ts
+++ b/nest-city-account/src/user/user.service.ts
@@ -543,7 +543,7 @@ export class UserService {
 
     // Acquire the same per-birth-number advisory lock that the Noris update cron uses.
     // This ensures the removal always lands after any in-flight cron write for this user,
-    // so the final Noris state is always "removed".
+    // so the delivery method is always removed from Noris as the final state.
     let taxDeliveryMethodsRemoved = true
     if (removedUser?.birthNumber) {
       const { birthNumber } = removedUser

--- a/nest-city-account/src/user/user.service.ts
+++ b/nest-city-account/src/user/user.service.ts
@@ -547,12 +547,10 @@ export class UserService {
     let taxDeliveryMethodsRemoved = true
     if (removedUser?.birthNumber) {
       const { birthNumber } = removedUser
-      taxDeliveryMethodsRemoved = await this.prisma.$transaction(
-        async (tx) => {
-          await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('noris_delivery_method'), hashtext(${birthNumber}))`
-          return this.taxSubservice.removeDeliveryMethodFromNoris(birthNumber)
-        }
-      )
+      taxDeliveryMethodsRemoved = await this.prisma.$transaction(async (tx) => {
+        await TaxSubservice.acquireDeliveryMethodLock(tx, birthNumber)
+        return this.taxSubservice.removeDeliveryMethodFromNoris(birthNumber)
+      })
     }
 
     return {

--- a/nest-city-account/src/user/user.service.ts
+++ b/nest-city-account/src/user/user.service.ts
@@ -541,10 +541,19 @@ export class UserService {
 
     await this.bloomreachOutboxService.anonymizeCustomer(externalId)
 
-    const taxDeliveryMethodsRemoved =
-      removedUser && removedUser.birthNumber
-        ? await this.taxSubservice.removeDeliveryMethodFromNoris(removedUser.birthNumber)
-        : true
+    // Acquire the same per-birth-number advisory lock that the Noris update cron uses.
+    // This ensures the removal always lands after any in-flight cron write for this user,
+    // so the final Noris state is always "removed".
+    let taxDeliveryMethodsRemoved = true
+    if (removedUser?.birthNumber) {
+      const { birthNumber } = removedUser
+      taxDeliveryMethodsRemoved = await this.prisma.$transaction(
+        async (tx) => {
+          await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('noris_delivery_method'), hashtext(${birthNumber}))`
+          return this.taxSubservice.removeDeliveryMethodFromNoris(birthNumber)
+        }
+      )
+    }
 
     return {
       success: true,

--- a/nest-city-account/src/utils/subservices/tax.subservice.ts
+++ b/nest-city-account/src/utils/subservices/tax.subservice.ts
@@ -29,7 +29,7 @@ export class TaxSubservice {
   }
 
   static async acquireDeliveryMethodLock(tx: Prisma.TransactionClient, birthNumber: string) {
-    return tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('noris_delivery_method'), hashtext(${birthNumber}))`
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('noris_delivery_method'), hashtext(${birthNumber}))`
   }
 
   async removeDeliveryMethodFromNoris(birthNumber: string): Promise<boolean> {

--- a/nest-city-account/src/utils/subservices/tax.subservice.ts
+++ b/nest-city-account/src/utils/subservices/tax.subservice.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
+import { Prisma } from '@prisma/client'
 import { AxiosPromise } from 'axios'
 import {
   RequestUpdateNorisDeliveryMethodsDto,
@@ -25,6 +26,10 @@ export class TaxSubservice {
     }
 
     this.logger = new LineLoggerSubservice(TaxSubservice.name)
+  }
+
+  static async acquireDeliveryMethodLock(tx: Prisma.TransactionClient, birthNumber: string) {
+    return tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('noris_delivery_method'), hashtext(${birthNumber}))`
   }
 
   async removeDeliveryMethodFromNoris(birthNumber: string): Promise<boolean> {

--- a/nest-tax-backend/src/admin/admin.controller.ts
+++ b/nest-tax-backend/src/admin/admin.controller.ts
@@ -139,9 +139,9 @@ export class AdminController {
 
   @HttpCode(200)
   @ApiOperation({
-    summary: 'Remove delivery methods for given birth number.',
+    summary: '[internal] Remove delivery methods for given birth number.',
     description:
-      'Used when deactivating user from city account, to mark that this user does not have delivery methods anymore.',
+      '⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.',
   })
   @ApiResponse({
     status: 200,

--- a/nest-tax-backend/src/admin/admin.controller.ts
+++ b/nest-tax-backend/src/admin/admin.controller.ts
@@ -141,7 +141,7 @@ export class AdminController {
   @ApiOperation({
     summary: '[internal] Remove delivery methods for given birth number.',
     description:
-      '⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.',
+      '⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.',
   })
   @ApiResponse({
     status: 200,

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -1018,8 +1018,8 @@ export const AdminApiAxiosParamCreator = function (configuration?: Configuration
       }
     },
     /**
-     * Used when deactivating user from city account, to mark that this user does not have delivery methods anymore.
-     * @summary Remove delivery methods for given birth number.
+     * ⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.
+     * @summary [internal] Remove delivery methods for given birth number.
      * @param {string} birthNumber
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -1365,8 +1365,8 @@ export const AdminApiFp = function (configuration?: Configuration) {
         )(axios, localVarOperationServerBasePath || basePath)
     },
     /**
-     * Used when deactivating user from city account, to mark that this user does not have delivery methods anymore.
-     * @summary Remove delivery methods for given birth number.
+     * ⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.
+     * @summary [internal] Remove delivery methods for given birth number.
      * @param {string} birthNumber
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -1578,8 +1578,8 @@ export const AdminApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Used when deactivating user from city account, to mark that this user does not have delivery methods anymore.
-     * @summary Remove delivery methods for given birth number.
+     * ⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.
+     * @summary [internal] Remove delivery methods for given birth number.
      * @param {string} birthNumber
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -1710,8 +1710,8 @@ export class AdminApi extends BaseAPI {
   }
 
   /**
-   * Used when deactivating user from city account, to mark that this user does not have delivery methods anymore.
-   * @summary Remove delivery methods for given birth number.
+   * ⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.
+   * @summary [internal] Remove delivery methods for given birth number.
    * @param {string} birthNumber
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -1018,7 +1018,7 @@ export const AdminApiAxiosParamCreator = function (configuration?: Configuration
       }
     },
     /**
-     * ⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.
+     * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
      * @summary [internal] Remove delivery methods for given birth number.
      * @param {string} birthNumber
      * @param {*} [options] Override http request option.
@@ -1365,7 +1365,7 @@ export const AdminApiFp = function (configuration?: Configuration) {
         )(axios, localVarOperationServerBasePath || basePath)
     },
     /**
-     * ⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.
+     * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
      * @summary [internal] Remove delivery methods for given birth number.
      * @param {string} birthNumber
      * @param {*} [options] Override http request option.
@@ -1578,7 +1578,7 @@ export const AdminApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * ⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.
+     * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
      * @summary [internal] Remove delivery methods for given birth number.
      * @param {string} birthNumber
      * @param {*} [options] Override http request option.
@@ -1710,7 +1710,7 @@ export class AdminApi extends BaseAPI {
   }
 
   /**
-   * ⚠️ Must be called through nest-city-account, which holds a per-birth-number advisory lock to prevent a race with the Noris delivery-method update cron. Calling this endpoint directly bypasses that lock and can leave Noris in an incorrect state.
+   * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
    * @summary [internal] Remove delivery methods for given birth number.
    * @param {string} birthNumber
    * @param {*} [options] Override http request option.


### PR DESCRIPTION
There's a race between two operations that touch Noris delivery methods for the same user:

1. The `updateDeliveryMethodsInNoris` cron (runs every 5 min during tax season) - reads active users from the DB and writes their delivery method to Noris.
2. `deactivateAccount` in `user.service.ts` - removes a user's delivery method from Noris when their account is deactivated.

The dangerous ordering was: cron reads the user as active -> user gets deactivated and removed from Noris -> cron writes the delivery method back to Noris. End result: a deactivated user ends up registered in Noris again.

The old code tried to detect this after the fact: after calling Noris, it queried the DB for any users that had been deactivated in the meantime, and threw an `InternalServerError` with a message asking someone to manually clean up Noris. Not a fix - just an alert that required manual intervention and still left Noris in a bad state until someone acted on it. (It has to be said though that this was a huge edge-case and it would need the two calls to happen almost simultaneously).

## Changes

Both the cron and the deactivation flow now acquire a per-user PostgreSQL advisory transaction lock (`pg_advisory_xact_lock`) before touching Noris. The lock key is derived from the birth number using `hashtext`, so the two sides coordinate automatically.

The cron acquires the locks first, then does a re-check inside the transaction to see which users are still active. By the time it calls Noris, it holds the locks, so any concurrent deactivation trying to acquire the same lock has to wait. When the cron's transaction commits and releases the locks, the deactivation proceeds and removes the user from Noris - which is the correct final state regardless of which side ran first.

The two safe orderings:

- Deactivation sets `birthNumber = null` before the cron's re-check: the re-check sees the user as gone and skips them. Deactivation proceeds without racing.
- Cron holds the lock when deactivation tries to acquire it: deactivation blocks, cron finishes writing to Noris, transaction commits, lock releases, deactivation runs and removes the user from Noris.

Both cases leave Noris in the right state with no manual intervention needed.


## Deadlock prevention

The cron batch can cover multiple users, so it acquires multiple locks. To avoid deadlocks, the birth numbers are sorted before acquiring locks. Any two transactions acquiring the same set of locks in the same order can't form a wait-cycle, so deadlocks are ruled out.

## Remaining limitation

The `POST /admin/remove-delivery-methods-from-noris/:birthNumber` endpoint in `nest-tax-backend` bypasses the lock entirely - nest-tax-backend has no Postgres access and can't participate in the advisory lock protocol. Direct calls to this endpoint from outside nest-city-account can still race with the cron. The endpoint is now marked with an `[internal]` summary and a ⚠️ description warning to make this clear. It remains in the generated OpenAPI client.

Resolves https://github.com/bratislava/private-konto.bratislava.sk/issues/823