### PR TITLE
Add next-env.d.ts to .gitignore

### DIFF
--- a/next/.gitignore
+++ b/next/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+/next-env.d.ts
 
 # production
 /build


### PR DESCRIPTION
Next.js regenerates next-env.d.ts based on which command you're running, and the path to the generated route types differs between dev and build modes rn recent Next.js versions (15.5+).

According to docs, this file should be gitignored:

https://nextjs.org/docs/pages/api-reference/config/typescript#next-envdts

