### PR TITLE
1489 CSP: Add dev, staging and kupaliska subdomains to frame-ancestors 

### DIFF
--- a/next/src/proxy.ts
+++ b/next/src/proxy.ts
@@ -107,7 +107,7 @@ export function proxy(request: NextRequest) {
     object-src 'none';
     base-uri 'self';
     form-action 'self';
-    frame-ancestors 'self' https://olo.sk;
+    frame-ancestors 'self' https://*.staging.bratislava.sk https://*.dev.bratislava.sk https://kupaliska.bratislava.sk https://olo.sk;
     frame-src 'self' https://consentcdn.cookiebot.eu https://challenges.cloudflare.com https://www.slovensko.sk;
     upgrade-insecure-requests;
     report-uri /api/csp-report;


### PR DESCRIPTION
- add https://kupaliska.bratislava.sk
- dev and staging are added as wildcards:  `https://*.staging.bratislava.sk`,  `https://*.dev.bratislava.sk`