### PR TITLE
Fix jsx resolution in tsconfig.json in forms-shared

### DIFF
--- a/forms-shared/tsconfig.json
+++ b/forms-shared/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node16",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "declaration": true,
     "outDir": "./dist",
     "types": ["node"]


### PR DESCRIPTION
This error started to appear:
> Your app (or one of its dependencies) is using an outdated JSX transform. Update to the modern JSX transform for faster performance: https://react.dev/link/new-jsx-transform
