### PR TITLE
Use official GitHub action in labeler workflow

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,36 +1,49 @@
-name: "PR Labeler"
+name: 'PR Labeler'
 on:
   pull_request_review:
-    types: [submitted]
+    types: [ submitted ]
   pull_request:
-    types: [review_requested]
+    types: [ review_requested ]
+
+permissions:
+  pull-requests: write
 
 jobs:
-  created:
-    if: github.event.review.state != 'changes_requested' && github.event.review.state != 'approved'
+  label:
     runs-on: ubuntu-latest
     steps:
-      - name: Add basic label
-        uses: andymckay/labeler@1.0.4
+      - name: Update PR labels
+        uses: actions/github-script@v9
         with:
-          add-labels: 'pr: needs review :pray:'
+          script: |
+            const state = context.payload.review?.state
+            const managedLabels = [
+              'pr: needs review :pray:',
+              'pr: fix & ship :ship:',
+              'pr: needs work :hammer_and_wrench:'
+            ]
+            const labelByState = {
+              default: managedLabels[0],
+              approved: managedLabels[1],
+              changes_requested: managedLabels[2],
+            }
+            const nextLabel = labelByState[state] ?? labelByState.default
+            const issue_number = context.payload.pull_request.number
 
-  approved:
-    if: github.event.review.state == 'approved'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add approve labels
-        uses: andymckay/labeler@1.0.4
-        with:
-          add-labels: 'pr: fix & ship :ship:'
-          remove-labels: 'pr: needs review :pray:, pr: needs work :hammer_and_wrench:'
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number
+            })
 
-  needs-work:
-    if: github.event.review.state == 'changes_requested'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add needs-work labels
-        uses: andymckay/labeler@1.0.4
-        with:
-          add-labels: 'pr: needs work :hammer_and_wrench:'
-          remove-labels: 'pr: fix & ship :ship:, pr: needs review :pray:'
+            const labels = issue.data.labels
+              .map((label) => label.name)
+            const unmanagedLabels = labels.filter((name) => !managedLabels.includes(name))
+            const nextLabels = [...unmanagedLabels, nextLabel]
+
+            await github.rest.issues.setLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              labels: nextLabels
+            })


### PR DESCRIPTION
andymckay/labeler was last published Oct 8, 2021 and archived on Oct 8, 2022


> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: andymckay/labeler@1.0.4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/