### PR TITLE
fix: remove unique constraint violation when importing historical taxes

### DIFF
--- a/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.real-estate.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.real-estate.subservice.spec.ts
@@ -908,6 +908,7 @@ describe('NorisTaxRealEstateSubservice', () => {
               }),
             },
             taxInstallment: {
+              deleteMany: jest.fn().mockResolvedValue({}),
               createMany: jest.fn().mockResolvedValue({}),
             },
             taxDetail: {
@@ -947,6 +948,7 @@ describe('NorisTaxRealEstateSubservice', () => {
               }),
             },
             taxInstallment: {
+              deleteMany: jest.fn().mockResolvedValue({}),
               createMany: jest.fn().mockResolvedValue({}),
             },
             taxDetail: {
@@ -1029,6 +1031,7 @@ describe('NorisTaxRealEstateSubservice', () => {
               }),
             },
             taxInstallment: {
+              deleteMany: jest.fn().mockResolvedValue({}),
               createMany: jest.fn().mockResolvedValue({}),
             },
             taxDetail: {

--- a/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
@@ -492,6 +492,7 @@ export abstract class AbstractNorisTaxSubservice<TTaxType extends TaxType> {
     })
 
     const taxInstallments = mapNorisToTaxInstallmentsData(dataFromNoris, tax.id)
+    await transaction.taxInstallment.deleteMany({ where: { taxId: tax.id } })
     await transaction.taxInstallment.createMany({
       data: taxInstallments,
     })

--- a/nest-tax-backend/src/tasks/subservices/tax-import.tasks.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/tax-import.tasks.service.ts
@@ -219,6 +219,10 @@ export default class TaxImportTasksService {
                             -- We want to exclude only resolved attempts
                             AND (tia.status = 'SUCCESS'::"TaxImportStatus" OR
                                  tia.status = 'NOT_FOUND'::"TaxImportStatus"))
+          -- Newly created users (createdAt = updatedAt, no attempts yet) are handled
+          -- by loadTaxesForUsers which imports all years at once; exclude them here
+          -- to avoid racing with that cron when both fire at the same time
+          AND tp."createdAt" != tp."updatedAt"
         ORDER BY tp."updatedAt", tp.id
         LIMIT ${LOAD_HISTORICAL_TAXES_BATCH};
     `


### PR DESCRIPTION
Fix: unique constraint crash on taxInstallment during concurrent import

## Error

```
PrismaClientKnownRequestError: Unique constraint failed on the fields: (`taxId`,`order`)
  at NorisTaxRealEstateSubservice.insertTaxDataToDatabase
```

Example: https://grafana.bratislava.sk/goto/afm0s7w86esxsa?orgId=1

## Root cause

Two cron jobs fire simultaneously:

- `loadTaxesForUsers` (every 3 min) - imports all years at once for new users
- `loadHistoricalTaxes` (every 10 min) - fills in missing (year, taxType) gaps for existing users

A user created at 6:59 had no `TaxImportAttempt` records yet, so both crons picked them up at 7:00. Both passed the "tax doesn't exist" check, then raced into `insertTaxDataToDatabase`. The first transaction committed the tax + installments; the second's `tax.upsert` took the UPDATE path but then called `taxInstallment.createMany` without clearing the already-committed installments - unique constraint violation.

## Fix

**1. Make `insertTaxDataToDatabase` idempotent** (`noris-tax.subservice.abstract.ts`)

Delete existing installments before re-creating them, the same way `updateExistingTaxRecord` already does. The second concurrent transaction now cleans up and re-inserts instead of crashing.

**2. Exclude newly created users from `loadHistoricalTaxes`** (`tax-import.tasks.service.ts`)

Added `AND tp."createdAt" != tp."updatedAt"` to the query. Users where these timestamps are equal have never been processed and are `loadTaxesForUsers`'s responsibility.
