### PR TITLE
hotfix: set death_date to null

### DIFF
--- a/nest-city-account/src/noris/noris.service.ts
+++ b/nest-city-account/src/noris/noris.service.ts
@@ -157,6 +157,7 @@ export class NorisService implements OnModuleDestroy {
               .input('edesk_uri', mssql.VarChar, edeskCheck.uri)
               .input('edesk_pco', mssql.VarChar, null)
               .input('last_check', mssql.DateTime, edeskCheck.lastCheck)
+              .input('death_date', mssql.DateTime, null) // TODO add correct date in https://github.com/bratislava/private-konto.bratislava.sk/issues/1467
               .execute('lcs.usp21_ino_edesk_update')
           },
           (error) => {


### PR DESCRIPTION
`death_date` became required in `usp21_ino_edesk_update` procedure. Temporarily replacing with const `null`, will be fixed in https://github.com/bratislava/private-konto.bratislava.sk/issues/1467