### PR TITLE
1467: send death date info to noris

### DIFF
--- a/nest-city-account/src/noris/__tests__/noris.service.spec.ts
+++ b/nest-city-account/src/noris/__tests__/noris.service.spec.ts
@@ -147,13 +147,11 @@ describe('NorisService', () => {
       jest.spyOn(service as any, 'createConnection').mockResolvedValue(mockConnection)
 
       const operation = jest.fn().mockRejectedValue(opError)
-      const errorHandler = jest.fn().mockImplementation(() => {
+      const errorHandler = jest.fn<never, [unknown], unknown>().mockImplementation(() => {
         throw handlerError
       })
 
-      await expect((service as any).withConnection(operation, errorHandler)).rejects.toThrow(
-        handlerError
-      )
+      await expect(service.withConnection(operation, errorHandler)).rejects.toThrow(handlerError)
       expect(errorHandler).toHaveBeenCalledWith(opError)
       expect(mockConnection.close).not.toHaveBeenCalled()
     })
@@ -169,7 +167,7 @@ describe('NorisService', () => {
       const operation = jest.fn().mockResolvedValue(result)
 
       await expect(
-        (service as any).withConnection(operation, () => {
+        service.withConnection(operation, () => {
           throw new Error('unexpected')
         })
       ).resolves.toEqual(result)
@@ -250,7 +248,7 @@ describe('NorisService', () => {
 
   describe('updateEdeskChecks', () => {
     beforeEach(() => {
-      jest.spyOn(service as any, 'withConnection').mockResolvedValue(undefined)
+      jest.spyOn(service, 'withConnection').mockResolvedValue(undefined)
     })
 
     afterEach(() => {
@@ -268,7 +266,7 @@ describe('NorisService', () => {
           deathDate: null,
         },
       ]
-      const withConnectionSpy = jest.spyOn(service as any, 'withConnection')
+      const withConnectionSpy = jest.spyOn(service, 'withConnection')
 
       await expect(service.updateEdeskChecks(edeskChecks)).resolves.toBeUndefined()
 
@@ -276,14 +274,14 @@ describe('NorisService', () => {
     })
 
     it('should process empty array without throwing', async () => {
-      const withConnectionSpy = jest.spyOn(service as any, 'withConnection')
+      const withConnectionSpy = jest.spyOn(service, 'withConnection')
       await expect(service.updateEdeskChecks([])).resolves.toBeUndefined()
       expect(withConnectionSpy).not.toHaveBeenCalled()
     })
 
     it('should reject when withConnection rejects', async () => {
       const internalError = new HttpException('Internal', 500)
-      jest.spyOn(service as any, 'withConnection').mockRejectedValue(internalError)
+      jest.spyOn(service, 'withConnection').mockRejectedValue(internalError)
 
       await expect(
         service.updateEdeskChecks([
@@ -297,6 +295,57 @@ describe('NorisService', () => {
           },
         ])
       ).rejects.toThrow(internalError)
+    })
+
+    it('should pass deathDate to death_date SQL parameter', async () => {
+      const deathDate = new Date('2023-06-15')
+      const mockRequest = createMock<mssql.Request>()
+      mockRequest.input.mockReturnValue(mockRequest)
+
+      const mockPool = createMock<ConnectionPool>()
+      mockPool.request.mockReturnValue(mockRequest)
+
+      jest
+        .spyOn(service, 'withConnection')
+        .mockImplementation((operation: any) => operation(mockPool))
+
+      await service.updateEdeskChecks([
+        {
+          idNoris: 1,
+          lastCheck: new Date('2024-01-15'),
+          edeskStatus: EdeskStatus.ACTIVE,
+          edeskNumber: '12345',
+          uri: 'https://edesk.example/sk/123',
+          deathDate,
+        },
+      ])
+
+      expect(mockRequest.input).toHaveBeenCalledWith('death_date', mssql.DateTime, deathDate)
+    })
+
+    it('should pass null to death_date SQL parameter when deathDate is null', async () => {
+      const mockRequest = createMock<mssql.Request>()
+      mockRequest.input.mockReturnValue(mockRequest)
+
+      const mockPool = createMock<ConnectionPool>()
+      mockPool.request.mockReturnValue(mockRequest)
+
+      jest
+        .spyOn(service, 'withConnection')
+        .mockImplementation((operation: any) => operation(mockPool))
+
+      await service.updateEdeskChecks([
+        {
+          idNoris: 1,
+          lastCheck: new Date('2024-01-15'),
+          edeskStatus: EdeskStatus.ACTIVE,
+          edeskNumber: '12345',
+          uri: 'https://edesk.example/sk/123',
+          deathDate: null,
+        },
+      ])
+
+      expect(mockRequest.input).toHaveBeenCalledWith('death_date', mssql.DateTime, null)
     })
   })
 })

--- a/nest-city-account/src/noris/__tests__/noris.service.spec.ts
+++ b/nest-city-account/src/noris/__tests__/noris.service.spec.ts
@@ -265,6 +265,7 @@ describe('NorisService', () => {
           edeskStatus: EdeskStatus.ACTIVE,
           edeskNumber: '12345',
           uri: 'https://edesk.example/sk/123',
+          deathDate: null,
         },
       ]
       const withConnectionSpy = jest.spyOn(service as any, 'withConnection')
@@ -292,6 +293,7 @@ describe('NorisService', () => {
             edeskStatus: EdeskStatus.ACTIVE,
             edeskNumber: '12345',
             uri: 'https://edesk.example/sk/123',
+            deathDate: null,
           },
         ])
       ).rejects.toThrow(internalError)

--- a/nest-city-account/src/noris/noris.service.ts
+++ b/nest-city-account/src/noris/noris.service.ts
@@ -157,7 +157,7 @@ export class NorisService implements OnModuleDestroy {
               .input('edesk_uri', mssql.VarChar, edeskCheck.uri)
               .input('edesk_pco', mssql.VarChar, null)
               .input('last_check', mssql.DateTime, edeskCheck.lastCheck)
-              .input('death_date', mssql.DateTime, null) // TODO add correct date in https://github.com/bratislava/private-konto.bratislava.sk/issues/1467
+              .input('death_date', mssql.DateTime, edeskCheck.deathDate)
               .execute('lcs.usp21_ino_edesk_update')
           },
           (error) => {

--- a/nest-city-account/src/noris/noris.service.ts
+++ b/nest-city-account/src/noris/noris.service.ts
@@ -106,7 +106,7 @@ export class NorisService implements OnModuleDestroy {
    * @param errorHandler - Error handler for any errors that occur during the operation
    * @returns Result of the operation
    */
-  private async withConnection<T>(
+  async withConnection<T>(
     operation: (connection: ConnectionPool) => Promise<T>,
     errorHandler: (error: unknown) => never
   ): Promise<T> {

--- a/nest-city-account/src/noris/types/noris.types.ts
+++ b/nest-city-account/src/noris/types/noris.types.ts
@@ -70,4 +70,6 @@ export interface UpdateEdeskChecks {
   edeskNumber: string | null
   /** Must be null when status is NONEXISTENT. */
   uri: string | null
+
+  deathDate: Date | null
 }

--- a/nest-city-account/src/tasks/subservices/__tests__/edesk-tasks.subservice.spec.ts
+++ b/nest-city-account/src/tasks/subservices/__tests__/edesk-tasks.subservice.spec.ts
@@ -25,7 +25,9 @@ const createMockCompletedItem = (
     upvsStatus: null,
     edeskStatus: 'active',
     edeskNumber: '12345',
+    edeskDeathDate: null,
     failCount: 0,
+    newUri: null,
     ...overrides,
   } as ExternalEdeskCheck
 }
@@ -313,6 +315,64 @@ describe('EdeskTasksSubservice', () => {
             edeskStatus: 'NONEXISTENT',
             edeskNumber: null,
             uri: null,
+            deathDate: null,
+          }),
+        ])
+      )
+    })
+
+    it('should pass edeskDeathDate as deathDate for completed items', async () => {
+      const deathDate = new Date('2023-06-15')
+      const completedItem = createMockCompletedItem({
+        id: 'id-1',
+        norisId: 1,
+        edeskDeathDate: deathDate,
+      })
+
+      jest.spyOn(upvsQueueService, 'getNumberOfPendingExternalItemsInQueue').mockResolvedValue(0)
+      jest.spyOn(service, 'retrieveNewRecordsFromNorisToUpdate').mockResolvedValue(undefined)
+      jest
+        .spyOn(upvsQueueService, 'retrieveCompletedAndFailedExternalItems')
+        .mockResolvedValue([completedItem])
+
+      const updateEdeskChecksSpy = jest.spyOn(norisService, 'updateEdeskChecks').mockResolvedValue()
+      prismaMock.externalEdeskCheck.deleteMany.mockResolvedValue({ count: 1 })
+
+      await service.updateEdeskInNoris()
+
+      expect(updateEdeskChecksSpy).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            idNoris: 1,
+            deathDate,
+          }),
+        ])
+      )
+    })
+
+    it('should pass null as deathDate for completed items without a death date', async () => {
+      const completedItem = createMockCompletedItem({
+        id: 'id-1',
+        norisId: 1,
+        edeskDeathDate: null,
+      })
+
+      jest.spyOn(upvsQueueService, 'getNumberOfPendingExternalItemsInQueue').mockResolvedValue(0)
+      jest.spyOn(service, 'retrieveNewRecordsFromNorisToUpdate').mockResolvedValue(undefined)
+      jest
+        .spyOn(upvsQueueService, 'retrieveCompletedAndFailedExternalItems')
+        .mockResolvedValue([completedItem])
+
+      const updateEdeskChecksSpy = jest.spyOn(norisService, 'updateEdeskChecks').mockResolvedValue()
+      prismaMock.externalEdeskCheck.deleteMany.mockResolvedValue({ count: 1 })
+
+      await service.updateEdeskInNoris()
+
+      expect(updateEdeskChecksSpy).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            idNoris: 1,
+            deathDate: null,
           }),
         ])
       )

--- a/nest-city-account/src/tasks/subservices/edesk-tasks.subservice.ts
+++ b/nest-city-account/src/tasks/subservices/edesk-tasks.subservice.ts
@@ -159,6 +159,7 @@ export class EdeskTasksSubservice {
       edeskStatus: EdeskStatus
       edeskNumber: string | null
       uri: string | null
+      deathDate: Date | null
     }[] = []
     for (const item of completedItems) {
       try {
@@ -166,6 +167,7 @@ export class EdeskTasksSubservice {
         completedNorisUpdates.push({
           idNoris: item.norisId,
           lastCheck: item.processedAt,
+          deathDate: item.edeskDeathDate,
           ...edeskData,
         })
       } catch (error) {
@@ -187,6 +189,7 @@ export class EdeskTasksSubservice {
       edeskStatus: EdeskStatus.NONEXISTENT,
       edeskNumber: null,
       uri: null,
+      deathDate: null,
     }))
 
     await this.norisService.updateEdeskChecks([...completedNorisUpdates, ...failedNorisUpdates])


### PR DESCRIPTION
Passes info about death date from queue to the Noris procedure.

Resolves https://github.com/bratislava/private-konto.bratislava.sk/issues/1467