### PR TITLE
Fix field label size

### DIFF
--- a/forms-shared/src/schemas/showcase.ts
+++ b/forms-shared/src/schemas/showcase.ts
@@ -91,6 +91,22 @@ export default schema(
         ],
       ),
       object(
+        'labelSizeVariants',
+        {
+          title: 'Label Size Variants',
+        },
+        [
+          input(
+            'labelSizeDefault',
+            { type: 'text', title: 'Default Label Size' },
+            { labelSize: 'default' },
+          ),
+          input('labelSizeH5', { type: 'text', title: 'Label Size H5' }, { labelSize: 'h5' }),
+          input('labelSizeH4', { type: 'text', title: 'Label Size H4' }, { labelSize: 'h4' }),
+          input('labelSizeH3', { type: 'text', title: 'Label Size H3' }, { labelSize: 'h3' }),
+        ],
+      ),
+      object(
         'formattedInputs',
         {
           title: 'Formatted Inputs',

--- a/next/src/components/fields/_shared/FieldWrapper.tsx
+++ b/next/src/components/fields/_shared/FieldWrapper.tsx
@@ -10,14 +10,14 @@ import cn from '@/src/utils/cn'
 import { LabelSize } from './types'
 
 const labelSizeStyles = {
-  default: 'text-size-p-small-r lg:text-size-p-small',
-  h3: 'text-size-h3-r lg:text-size-h3',
-  h4: 'text-size-h4-r lg:text-size-h4',
-  h5: 'text-size-h5-r lg:text-size-h5',
+  default: '*:text-size-p-small-r lg:*:text-size-p-small',
+  h3: '*:text-size-h3-r lg:*:text-size-h3',
+  h4: '*:text-size-h4-r lg:*:text-size-h4',
+  h5: '*:text-size-h5-r lg:*:text-size-h5',
 }
 
 type FieldWrapperProps = {
-  label: string
+  label?: string
   isRequired?: boolean
   displayOptionalLabel?: boolean
   labelSize?: LabelSize
@@ -26,6 +26,10 @@ type FieldWrapperProps = {
   errorMessage?: string
   children: ReactNode
 }
+
+/**
+ * Figma: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=16670-31120
+ */
 
 const FieldWrapper = ({
   label,
@@ -48,12 +52,22 @@ const FieldWrapper = ({
     <>
       {/* TODO There is gap-2 in Figma design, but we agreed gap-1 looks better. Keeping gap-1 until the discussion is resolved. */}
       <div className="flex flex-col gap-1">
-        <RACLabel className={cn('flex text-content-passive-primary', labelSizeStyles[labelSize])}>
-          <Typography as="span" className="font-semibold">
-            {label}
-          </Typography>
+        <RACLabel className={cn('flex items-baseline text-content-passive-primary')}>
+          {label ? (
+            <Typography
+              as="span"
+              variant={labelSize === 'default' ? 'h6' : labelSize}
+              className="font-semibold"
+            >
+              {label}
+            </Typography>
+          ) : null}
           {showAsterisk ? (
-            <Typography as="span" className="ml-0.5 font-semibold text-content-error-default">
+            <Typography
+              as="span"
+              variant={labelSize === 'default' ? 'h6' : labelSize}
+              className="ml-0.5 font-semibold text-content-error-default"
+            >
               *
             </Typography>
           ) : null}
@@ -88,7 +102,7 @@ const FieldWrapper = ({
         </RACText>
       ) : null}
       <RACFieldError
-        className="text-size-p-small-r text-error lg:text-size-p-small"
+        className="text-size-p-small-r text-content-error-default lg:text-size-p-small"
         data-cy="error-message"
       >
         {errorMessage}


### PR DESCRIPTION
<img width="845" height="491" alt="image" src="https://github.com/user-attachments/assets/e673053c-9492-4e1c-9ec7-6cd328c2b15a" />

Screenshot with asterisks was taken locally with non-committed values for `displayOptionalLabel` just to demontrate how would asterisk render:

<img width="835" height="500" alt="image" src="https://github.com/user-attachments/assets/22225b02-de6a-47ed-8ac2-4584a7ad9967" />
