### PR TITLE
1403 do not override newest tax administrator

### DIFF
--- a/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.real-estate.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.real-estate.subservice.spec.ts
@@ -835,6 +835,59 @@ describe('NorisTaxRealEstateSubservice', () => {
           taxPayer: { id: 1 },
         })
       })
+
+      it('should check for newer tax with correct parameters', async () => {
+        prismaMock.tax.findFirst.mockResolvedValue(null)
+
+        await service['insertTaxDataToDatabase'](
+          mockTaxDefinitionForInsert,
+          mockNorisData[0],
+          2023,
+          prismaMock,
+          mockUserData,
+        )
+
+        expect(prismaMock.tax.findFirst).toHaveBeenCalledWith({
+          select: { id: true },
+          where: {
+            taxPayer: { birthNumber: mockNorisData[0].ICO_RC },
+            dateCreateTax: { gt: mockNorisData[0].datum_realizacie },
+            type: TaxType.DZN,
+          },
+        })
+      })
+
+      it('should update tax payer administrator when no newer tax exists', async () => {
+        prismaMock.tax.findFirst.mockResolvedValue(null)
+        prismaMock.taxPayerTaxAdministrator.upsert.mockResolvedValue({} as any)
+
+        await service['insertTaxDataToDatabase'](
+          mockTaxDefinitionForInsert,
+          mockNorisData[0],
+          2023,
+          prismaMock,
+          mockUserData,
+        )
+
+        expect(prismaMock.taxPayerTaxAdministrator.upsert).toHaveBeenCalled()
+      })
+
+      it('should not update tax payer administrator when newer tax exists', async () => {
+        prismaMock.tax.findFirst.mockResolvedValue({ id: 99 } as any)
+        prismaMock.taxPayerTaxAdministrator.upsert.mockResolvedValue({} as any)
+
+        await service['insertTaxDataToDatabase'](
+          mockTaxDefinitionForInsert,
+          mockNorisData[0],
+          2023,
+          prismaMock,
+          mockUserData,
+        )
+
+        expect(
+          prismaMock.taxPayerTaxAdministrator.upsert,
+        ).not.toHaveBeenCalled()
+      })
     })
 
     describe('processTaxRecordFromNoris', () => {
@@ -940,6 +993,7 @@ describe('NorisTaxRealEstateSubservice', () => {
               upsert: jest.fn().mockResolvedValue({}),
             },
             tax: {
+              findFirst: jest.fn().mockResolvedValue(null),
               upsert: jest.fn().mockResolvedValue({
                 id: 1,
                 order: 1,
@@ -1023,6 +1077,7 @@ describe('NorisTaxRealEstateSubservice', () => {
               upsert: jest.fn().mockResolvedValue({}),
             },
             tax: {
+              findFirst: jest.fn().mockResolvedValue(null),
               upsert: jest.fn().mockResolvedValue({
                 id: 1,
                 order: 1,

--- a/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
@@ -413,6 +413,21 @@ export abstract class AbstractNorisTaxSubservice<TTaxType extends TaxType> {
     userDataFromCityAccount: ResponseUserByBirthNumberDto | null,
     suppressEmail?: boolean,
   ): Promise<TaxWithTaxPayer> {
+    const existsNewerTax = await transaction.tax.findFirst({
+      select: {
+        id: true,
+      },
+      where: {
+        taxPayer: {
+          birthNumber: dataFromNoris.ICO_RC,
+        },
+        dateCreateTax: {
+          gt: dataFromNoris.datum_realizacie,
+        },
+        type: taxDefinition.type,
+      },
+    })
+
     const taxAdministratorData = mapNorisToTaxAdministratorData(dataFromNoris)
     const taxAdministrator = taxAdministratorData
       ? await transaction.taxAdministrator.upsert({
@@ -433,7 +448,7 @@ export abstract class AbstractNorisTaxSubservice<TTaxType extends TaxType> {
       update: taxPayerData,
     })
 
-    if (taxAdministrator?.id) {
+    if (taxAdministrator?.id && !existsNewerTax) {
       const taxPayerTaxAdministratorData = {
         taxPayerId: taxPayer.id,
         taxAdministratorId: taxAdministrator.id,

--- a/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
@@ -413,21 +413,6 @@ export abstract class AbstractNorisTaxSubservice<TTaxType extends TaxType> {
     userDataFromCityAccount: ResponseUserByBirthNumberDto | null,
     suppressEmail?: boolean,
   ): Promise<TaxWithTaxPayer> {
-    const existsNewerTax = await transaction.tax.findFirst({
-      select: {
-        id: true,
-      },
-      where: {
-        taxPayer: {
-          birthNumber: dataFromNoris.ICO_RC,
-        },
-        dateCreateTax: {
-          gt: dataFromNoris.datum_realizacie,
-        },
-        type: taxDefinition.type,
-      },
-    })
-
     const taxAdministratorData = mapNorisToTaxAdministratorData(dataFromNoris)
     const taxAdministrator = taxAdministratorData
       ? await transaction.taxAdministrator.upsert({
@@ -448,6 +433,20 @@ export abstract class AbstractNorisTaxSubservice<TTaxType extends TaxType> {
       update: taxPayerData,
     })
 
+    const existsNewerTax = await transaction.tax.findFirst({
+      select: {
+        id: true,
+      },
+      where: {
+        taxPayer: {
+          birthNumber: dataFromNoris.ICO_RC,
+        },
+        dateCreateTax: {
+          gt: dataFromNoris.datum_realizacie,
+        },
+        type: taxDefinition.type,
+      },
+    })
     if (taxAdministrator?.id && !existsNewerTax) {
       const taxPayerTaxAdministratorData = {
         taxPayerId: taxPayer.id,

--- a/nest-tax-backend/src/tasks/subservices/tax-import.tasks.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/tax-import.tasks.service.ts
@@ -237,20 +237,22 @@ export default class TaxImportTasksService {
       (item) => `${item.year}-${item.taxType}`,
     )
 
-    // Import taxes for each group
-    await Promise.all(
-      Object.values(grouped).map(async (items) => {
-        const first = items[0]
-        this.logger.log(
-          `Importing ${first.taxType} taxes for ${items.length} users for year ${first.year}`,
-        )
-        return this.taxImportHelperService.importTaxes(
-          first.taxType,
-          items.map((item) => item.birthNumber),
-          first.year,
-        )
-      }),
+    const sortedGroups = Object.values(grouped).sort(
+      (a, b) => a[0].year - b[0].year,
     )
+    for (const items of sortedGroups) {
+      const first = items[0]
+      this.logger.log(
+        `Importing ${first.taxType} taxes for ${items.length} users for year ${first.year}`,
+      )
+      // Intentionally sequential: avoid hammering slow DB
+      // eslint-disable-next-line no-await-in-loop
+      await this.taxImportHelperService.importTaxes(
+        first.taxType,
+        items.map((item) => item.birthNumber),
+        first.year,
+      )
+    }
 
     this.logger.log('Completed loadHistoricalTaxes task')
   }


### PR DESCRIPTION
Resolves https://github.com/bratislava/private-konto.bratislava.sk/issues/1403

During creation of the tax, and included upsert of tax payer, we shall not update his tax administrator, if there exists a newer tax. Usually the tax administrators are only updated in the newest taxes, therefore by importing historical taxes they could temporarily be rewritten by their old tax administrators.

`year` is not enough to be used, as some taxes can be created retroactively, from past years.


Because of possible race condition in finding existing tax with greater date of creation, we now at least import taxes ordered by year ascending. It is the best we can do without much overhead to almost always getting the latest tax administrator, from the latest tax by creation date.