### PR TITLE
fix: do not override tax installments bloomreach info

### DIFF
--- a/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.real-estate.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.real-estate.subservice.spec.ts
@@ -908,8 +908,8 @@ describe('NorisTaxRealEstateSubservice', () => {
               }),
             },
             taxInstallment: {
+              upsert: jest.fn().mockResolvedValue({}),
               deleteMany: jest.fn().mockResolvedValue({}),
-              createMany: jest.fn().mockResolvedValue({}),
             },
             taxDetail: {
               createMany: jest.fn().mockResolvedValue({}),
@@ -948,8 +948,8 @@ describe('NorisTaxRealEstateSubservice', () => {
               }),
             },
             taxInstallment: {
+              upsert: jest.fn().mockResolvedValue({}),
               deleteMany: jest.fn().mockResolvedValue({}),
-              createMany: jest.fn().mockResolvedValue({}),
             },
             taxDetail: {
               createMany: jest.fn().mockResolvedValue({}),
@@ -1031,8 +1031,8 @@ describe('NorisTaxRealEstateSubservice', () => {
               }),
             },
             taxInstallment: {
+              upsert: jest.fn().mockResolvedValue({}),
               deleteMany: jest.fn().mockResolvedValue({}),
-              createMany: jest.fn().mockResolvedValue({}),
             },
             taxDetail: {
               createMany: jest.fn().mockResolvedValue({}),

--- a/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
@@ -92,12 +92,6 @@ export abstract class AbstractNorisTaxSubservice<TTaxType extends TaxType> {
     >,
   ): Promise<void> {
     await this.prismaService.$transaction(async (tx) => {
-      await tx.taxInstallment.deleteMany({
-        where: {
-          taxId: existingTax.id,
-        },
-      })
-
       const userFromCityAccount: ResponseUserByBirthNumberDto | null =
         userDataFromCityAccount[norisItem.ICO_RC] || null
 
@@ -492,9 +486,20 @@ export abstract class AbstractNorisTaxSubservice<TTaxType extends TaxType> {
     })
 
     const taxInstallments = mapNorisToTaxInstallmentsData(dataFromNoris, tax.id)
-    await transaction.taxInstallment.deleteMany({ where: { taxId: tax.id } })
-    await transaction.taxInstallment.createMany({
-      data: taxInstallments,
+    await Promise.all(
+      taxInstallments.map(async (installment) =>
+        transaction.taxInstallment.upsert({
+          where: { taxId_order: { taxId: tax.id, order: installment.order } },
+          create: installment,
+          update: { amount: installment.amount, dueDate: installment.dueDate },
+        }),
+      ),
+    )
+    await transaction.taxInstallment.deleteMany({
+      where: {
+        taxId: tax.id,
+        order: { notIn: taxInstallments.map((i) => i.order) },
+      },
     })
 
     await transaction.taxImportAttempt.upsert({


### PR DESCRIPTION
Tax data imports (both initial inserts and re-imports on updates) used a deleteMany + createMany pattern for TaxInstallment records. This destroyed the bloomreachUnpaidReminderSent field on each re-import, causing Bloomreach unpaid reminders to be sent again for installments that had already been notified.