### PR TITLE
1476 Create IntegrationModule in nest-tax-backend

### DIFF
--- a/nest-city-account/src/utils/subservices/tax.subservice.ts
+++ b/nest-city-account/src/utils/subservices/tax.subservice.ts
@@ -34,7 +34,7 @@ export class TaxSubservice {
 
   async removeDeliveryMethodFromNoris(birthNumber: string): Promise<boolean> {
     try {
-      await this.clientsService.taxBackendApi.adminControllerRemoveDeliveryMethodsFromNoris(
+      await this.clientsService.taxBackendApi.integrationControllerRemoveDeliveryMethodsFromNoris(
         birthNumber,
         {
           headers: {
@@ -58,7 +58,7 @@ export class TaxSubservice {
   async updateDeliveryMethodsInNoris(
     data: RequestUpdateNorisDeliveryMethodsDto
   ): AxiosPromise<UpdateDeliveryMethodsInNorisResponseDto> {
-    return this.clientsService.taxBackendApi.adminControllerUpdateDeliveryMethodsInNoris(data, {
+    return this.clientsService.taxBackendApi.integrationControllerUpdateDeliveryMethodsInNoris(data, {
       headers: {
         apiKey: this.configService.getOrThrow<string>('TAX_BACKEND_API_KEY'),
       },

--- a/nest-tax-backend/src/admin/admin.controller.ts
+++ b/nest-tax-backend/src/admin/admin.controller.ts
@@ -2,7 +2,6 @@ import {
   Body,
   Controller,
   HttpCode,
-  Param,
   ParseEnumPipe,
   Post,
   Query,
@@ -28,12 +27,8 @@ import {
   RequestAdminDeleteTaxDto,
   RequestPostNorisLoadDataDto,
   RequestPostNorisPaymentDataLoadDto,
-  RequestUpdateNorisDeliveryMethodsDto,
 } from './dtos/requests.dto'
-import {
-  CreateBirthNumbersResponseDto,
-  UpdateDeliveryMethodsInNorisResponseDto,
-} from './dtos/responses.dto'
+import { CreateBirthNumbersResponseDto } from './dtos/responses.dto'
 
 @ApiTags('Admin')
 @Controller('admin')
@@ -118,41 +113,6 @@ export class AdminController {
     @Body() data: DateRangeDto,
   ): Promise<ResponseCreatedAlreadyCreatedDto> {
     return this.adminService.updateOverpaymentsDataFromNorisByDateRange(data)
-  }
-
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Update delivery methods for given birth numbers and date.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Records successfully updated in Noris',
-    type: UpdateDeliveryMethodsInNorisResponseDto,
-  })
-  @UseGuards(AdminGuard)
-  @Post('update-delivery-methods-in-noris')
-  async updateDeliveryMethodsInNoris(
-    @Body() data: RequestUpdateNorisDeliveryMethodsDto,
-  ): Promise<UpdateDeliveryMethodsInNorisResponseDto> {
-    return this.adminService.updateDeliveryMethodsInNoris(data)
-  }
-
-  @HttpCode(200)
-  @ApiOperation({
-    summary: '[internal] Remove delivery methods for given birth number.',
-    description:
-      '⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Records successfully updated in Noris',
-  })
-  @UseGuards(AdminGuard)
-  @Post('remove-delivery-methods-from-noris/:birthNumber')
-  async removeDeliveryMethodsFromNoris(
-    @Param('birthNumber') birthNumber: string,
-  ): Promise<void> {
-    await this.adminService.removeDeliveryMethodsFromNoris(birthNumber)
   }
 
   @HttpCode(200)

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -17,11 +17,9 @@ import {
   NorisRequestGeneral,
   RequestAdminCreateTestingTaxDto,
   RequestAdminDeleteTaxDto,
-  RequestUpdateNorisDeliveryMethodsDto,
 } from './dtos/requests.dto'
 import {
   CreateBirthNumbersResponseDto,
-  UpdateDeliveryMethodsInNorisResponseDto,
 } from './dtos/responses.dto'
 
 @Injectable()

--- a/nest-tax-backend/src/admin/admin.service.ts
+++ b/nest-tax-backend/src/admin/admin.service.ts
@@ -89,16 +89,6 @@ export class AdminService {
     })
   }
 
-  async updateDeliveryMethodsInNoris({
-    data,
-  }: RequestUpdateNorisDeliveryMethodsDto): Promise<UpdateDeliveryMethodsInNorisResponseDto> {
-    return this.norisService.updateDeliveryMethodsInNoris({ data })
-  }
-
-  async removeDeliveryMethodsFromNoris(birthNumber: string): Promise<void> {
-    await this.norisService.removeDeliveryMethodsFromNoris(birthNumber)
-  }
-
   /**
    * Creates a testing tax record with specified details for development and testing purposes.
    * @WARNING! This tax should be removed after testing, with the endpoint `delete-testing-tax`.

--- a/nest-tax-backend/src/app.module.ts
+++ b/nest-tax-backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { TasksModule } from './tasks/tasks.module'
 import { TaxModule } from './tax/tax.module'
 import AppLoggerMiddleware from './utils/middlewares/logger'
 import { UtilsModule } from './utils-module/utils.module'
+import { IntegrationModule } from './integration/integration.module'
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { UtilsModule } from './utils-module/utils.module'
     ScheduleModule.forRoot(),
     CardPaymentReportingModule,
     UtilsModule,
+    IntegrationModule,
   ],
   controllers: [AppController],
   providers: [],

--- a/nest-tax-backend/src/app.module.ts
+++ b/nest-tax-backend/src/app.module.ts
@@ -6,13 +6,13 @@ import { CognitoAuthModule } from '@nestjs-cognito/auth'
 import { AdminModule } from './admin/admin.module'
 import { AppController } from './app.controller'
 import { CardPaymentReportingModule } from './card-payment-reporting/card-payment-reporting.module'
+import { IntegrationModule } from './integration/integration.module'
 import { PaymentModule } from './payment/payment.module'
 import { PrismaModule } from './prisma/prisma.module'
 import { TasksModule } from './tasks/tasks.module'
 import { TaxModule } from './tax/tax.module'
 import AppLoggerMiddleware from './utils/middlewares/logger'
 import { UtilsModule } from './utils-module/utils.module'
-import { IntegrationModule } from './integration/integration.module'
 
 @Module({
   imports: [

--- a/nest-tax-backend/src/integration/integration.controller.ts
+++ b/nest-tax-backend/src/integration/integration.controller.ts
@@ -1,4 +1,3 @@
-import { IntegrationService } from './integration.service'
 import {
   Body,
   Controller,
@@ -7,10 +6,17 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common'
-import { AdminGuard } from '../auth/guards/admin.guard'
-import { ApiOperation, ApiResponse, ApiSecurity, ApiTags } from '@nestjs/swagger'
-import { UpdateDeliveryMethodsInNorisResponseDto } from '../admin/dtos/responses.dto'
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger'
+
 import { RequestUpdateNorisDeliveryMethodsDto } from '../admin/dtos/requests.dto'
+import { UpdateDeliveryMethodsInNorisResponseDto } from '../admin/dtos/responses.dto'
+import { AdminGuard } from '../auth/guards/admin.guard'
+import { IntegrationService } from './integration.service'
 
 /**
  * IntegrationController - Backend-to-Backend Integration APIs

--- a/nest-tax-backend/src/integration/integration.controller.ts
+++ b/nest-tax-backend/src/integration/integration.controller.ts
@@ -1,0 +1,66 @@
+import { IntegrationService } from './integration.service'
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common'
+import { AdminGuard } from '../auth/guards/admin.guard'
+import { ApiOperation, ApiResponse, ApiSecurity, ApiTags } from '@nestjs/swagger'
+import { UpdateDeliveryMethodsInNorisResponseDto } from '../admin/dtos/responses.dto'
+import { RequestUpdateNorisDeliveryMethodsDto } from '../admin/dtos/requests.dto'
+
+/**
+ * IntegrationController - Backend-to-Backend Integration APIs
+ *
+ * This controller exposes stable API endpoints for programmatic access by other backend services.
+ * These endpoints are versioned and maintained for stability.
+ *
+ * Route prefix: /integration
+ */
+@ApiTags('Backend Integration API')
+@ApiSecurity('apiKey')
+@UseGuards(AdminGuard)
+@Controller('integration')
+export class IntegrationController {
+  constructor(private readonly integrationService: IntegrationService) {}
+
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Update delivery methods for given birth numbers and date.',
+    deprecated: true,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Records successfully updated in Noris',
+    type: UpdateDeliveryMethodsInNorisResponseDto,
+  })
+  @UseGuards(AdminGuard)
+  @Post('update-delivery-methods-in-noris')
+  async updateDeliveryMethodsInNoris(
+    @Body() data: RequestUpdateNorisDeliveryMethodsDto,
+  ): Promise<UpdateDeliveryMethodsInNorisResponseDto> {
+    return await this.integrationService.updateDeliveryMethodsInNoris(data)
+  }
+
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Remove delivery methods for given birth number.',
+    description:
+      "⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account's business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.",
+    deprecated: true,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Records successfully updated in Noris',
+  })
+  @UseGuards(AdminGuard)
+  @Post('remove-delivery-methods-from-noris/:birthNumber')
+  async removeDeliveryMethodsFromNoris(
+    @Param('birthNumber') birthNumber: string,
+  ): Promise<void> {
+    await this.integrationService.removeDeliveryMethodsFromNoris(birthNumber)
+  }
+}

--- a/nest-tax-backend/src/integration/integration.module.ts
+++ b/nest-tax-backend/src/integration/integration.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common'
+
+import { IntegrationService } from './integration.service'
+import { IntegrationController } from './integration.controller'
+
+/**
+ * IntegrationModule - Backend-to-Backend Integration APIs
+ *
+ * This module provides stable API endpoints for programmatic access by other backend services.
+ * It acts as a thin layer that exposes functionality from domain modules (User, Verification, PhysicalEntity).
+ */
+@Module({
+  imports: [],
+  providers: [IntegrationService],
+  controllers: [IntegrationController],
+  exports: [],
+})
+export class IntegrationModule {}

--- a/nest-tax-backend/src/integration/integration.module.ts
+++ b/nest-tax-backend/src/integration/integration.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common'
 
-import { IntegrationService } from './integration.service'
-import { IntegrationController } from './integration.controller'
 import { NorisModule } from '../noris/noris.module'
+import { IntegrationController } from './integration.controller'
+import { IntegrationService } from './integration.service'
 
 /**
  * IntegrationModule - Backend-to-Backend Integration APIs

--- a/nest-tax-backend/src/integration/integration.module.ts
+++ b/nest-tax-backend/src/integration/integration.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 
 import { IntegrationService } from './integration.service'
 import { IntegrationController } from './integration.controller'
+import { NorisModule } from '../noris/noris.module'
 
 /**
  * IntegrationModule - Backend-to-Backend Integration APIs
@@ -10,7 +11,7 @@ import { IntegrationController } from './integration.controller'
  * It acts as a thin layer that exposes functionality from domain modules (User, Verification, PhysicalEntity).
  */
 @Module({
-  imports: [],
+  imports: [NorisModule],
   providers: [IntegrationService],
   controllers: [IntegrationController],
   exports: [],

--- a/nest-tax-backend/src/integration/integration.service.ts
+++ b/nest-tax-backend/src/integration/integration.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common'
+import { NorisService } from '../noris/noris.service'
+import { RequestUpdateNorisDeliveryMethodsDto } from '../admin/dtos/requests.dto'
+
+/**
+ * IntegrationService - Thin delegation layer for backend-to-backend integration APIs
+ *
+ * This service exposes stable integration endpoints by delegating to domain services.
+ * It exists to provide a clean separation between integration APIs and internal domain logic.
+ */
+@Injectable()
+export class IntegrationService {
+  constructor(private readonly norisService: NorisService) {}
+
+  async updateDeliveryMethodsInNoris(
+    data: RequestUpdateNorisDeliveryMethodsDto,
+  ) {
+    return await this.norisService.updateDeliveryMethodsInNoris(data)
+  }
+
+  async removeDeliveryMethodsFromNoris(birthNumber: string) {
+    await this.norisService.removeDeliveryMethodsFromNoris(birthNumber)
+  }
+}

--- a/nest-tax-backend/src/integration/integration.service.ts
+++ b/nest-tax-backend/src/integration/integration.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common'
-import { NorisService } from '../noris/noris.service'
+
 import { RequestUpdateNorisDeliveryMethodsDto } from '../admin/dtos/requests.dto'
+import { NorisService } from '../noris/noris.service'
 
 /**
  * IntegrationService - Thin delegation layer for backend-to-backend integration APIs

--- a/openapi-clients/tax/api.ts
+++ b/openapi-clients/tax/api.ts
@@ -1018,50 +1018,6 @@ export const AdminApiAxiosParamCreator = function (configuration?: Configuration
       }
     },
     /**
-     * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
-     * @summary [internal] Remove delivery methods for given birth number.
-     * @param {string} birthNumber
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    adminControllerRemoveDeliveryMethodsFromNoris: async (
-      birthNumber: string,
-      options: RawAxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'birthNumber' is not null or undefined
-      assertParamExists('adminControllerRemoveDeliveryMethodsFromNoris', 'birthNumber', birthNumber)
-      const localVarPath = `/admin/remove-delivery-methods-from-noris/{birthNumber}`.replace(
-        '{birthNumber}',
-        encodeURIComponent(String(birthNumber)),
-      )
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      // authentication apiKey required
-      await setApiKeyToObject(localVarHeaderParameter, 'apiKey', configuration)
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * Updates existing taxes with new data from Noris by birth numbers and year, and saves it to our database.
      * @summary Updates data from Noris.
      * @param {RequestPostNorisLoadDataDto} requestPostNorisLoadDataDto
@@ -1104,59 +1060,6 @@ export const AdminApiAxiosParamCreator = function (configuration?: Configuration
       }
       localVarRequestOptions.data = serializeDataIfNeeded(
         requestPostNorisLoadDataDto,
-        localVarRequestOptions,
-        configuration,
-      )
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
-     *
-     * @summary Update delivery methods for given birth numbers and date.
-     * @param {RequestUpdateNorisDeliveryMethodsDto} requestUpdateNorisDeliveryMethodsDto
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    adminControllerUpdateDeliveryMethodsInNoris: async (
-      requestUpdateNorisDeliveryMethodsDto: RequestUpdateNorisDeliveryMethodsDto,
-      options: RawAxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'requestUpdateNorisDeliveryMethodsDto' is not null or undefined
-      assertParamExists(
-        'adminControllerUpdateDeliveryMethodsInNoris',
-        'requestUpdateNorisDeliveryMethodsDto',
-        requestUpdateNorisDeliveryMethodsDto,
-      )
-      const localVarPath = `/admin/update-delivery-methods-in-noris`
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      // authentication apiKey required
-      await setApiKeyToObject(localVarHeaderParameter, 'apiKey', configuration)
-
-      localVarHeaderParameter['Content-Type'] = 'application/json'
-      localVarHeaderParameter['Accept'] = 'application/json'
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        requestUpdateNorisDeliveryMethodsDto,
         localVarRequestOptions,
         configuration,
       )
@@ -1365,35 +1268,6 @@ export const AdminApiFp = function (configuration?: Configuration) {
         )(axios, localVarOperationServerBasePath || basePath)
     },
     /**
-     * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
-     * @summary [internal] Remove delivery methods for given birth number.
-     * @param {string} birthNumber
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async adminControllerRemoveDeliveryMethodsFromNoris(
-      birthNumber: string,
-      options?: RawAxiosRequestConfig,
-    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.adminControllerRemoveDeliveryMethodsFromNoris(
-          birthNumber,
-          options,
-        )
-      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
-      const localVarOperationServerBasePath =
-        operationServerMap['AdminApi.adminControllerRemoveDeliveryMethodsFromNoris']?.[
-          localVarOperationServerIndex
-        ]?.url
-      return (axios, basePath) =>
-        createRequestFunction(
-          localVarAxiosArgs,
-          globalAxios,
-          BASE_PATH,
-          configuration,
-        )(axios, localVarOperationServerBasePath || basePath)
-    },
-    /**
      * Updates existing taxes with new data from Noris by birth numbers and year, and saves it to our database.
      * @summary Updates data from Noris.
      * @param {RequestPostNorisLoadDataDto} requestPostNorisLoadDataDto
@@ -1411,40 +1285,6 @@ export const AdminApiFp = function (configuration?: Configuration) {
       const localVarOperationServerIndex = configuration?.serverIndex ?? 0
       const localVarOperationServerBasePath =
         operationServerMap['AdminApi.adminControllerUpdateDataFromNoris']?.[
-          localVarOperationServerIndex
-        ]?.url
-      return (axios, basePath) =>
-        createRequestFunction(
-          localVarAxiosArgs,
-          globalAxios,
-          BASE_PATH,
-          configuration,
-        )(axios, localVarOperationServerBasePath || basePath)
-    },
-    /**
-     *
-     * @summary Update delivery methods for given birth numbers and date.
-     * @param {RequestUpdateNorisDeliveryMethodsDto} requestUpdateNorisDeliveryMethodsDto
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async adminControllerUpdateDeliveryMethodsInNoris(
-      requestUpdateNorisDeliveryMethodsDto: RequestUpdateNorisDeliveryMethodsDto,
-      options?: RawAxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<UpdateDeliveryMethodsInNorisResponseDto>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.adminControllerUpdateDeliveryMethodsInNoris(
-          requestUpdateNorisDeliveryMethodsDto,
-          options,
-        )
-      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
-      const localVarOperationServerBasePath =
-        operationServerMap['AdminApi.adminControllerUpdateDeliveryMethodsInNoris']?.[
           localVarOperationServerIndex
         ]?.url
       return (axios, basePath) =>
@@ -1578,21 +1418,6 @@ export const AdminApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
-     * @summary [internal] Remove delivery methods for given birth number.
-     * @param {string} birthNumber
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    adminControllerRemoveDeliveryMethodsFromNoris(
-      birthNumber: string,
-      options?: RawAxiosRequestConfig,
-    ): AxiosPromise<void> {
-      return localVarFp
-        .adminControllerRemoveDeliveryMethodsFromNoris(birthNumber, options)
-        .then((request) => request(axios, basePath))
-    },
-    /**
      * Updates existing taxes with new data from Noris by birth numbers and year, and saves it to our database.
      * @summary Updates data from Noris.
      * @param {RequestPostNorisLoadDataDto} requestPostNorisLoadDataDto
@@ -1605,21 +1430,6 @@ export const AdminApiFactory = function (
     ): AxiosPromise<void> {
       return localVarFp
         .adminControllerUpdateDataFromNoris(requestPostNorisLoadDataDto, options)
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     *
-     * @summary Update delivery methods for given birth numbers and date.
-     * @param {RequestUpdateNorisDeliveryMethodsDto} requestUpdateNorisDeliveryMethodsDto
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    adminControllerUpdateDeliveryMethodsInNoris(
-      requestUpdateNorisDeliveryMethodsDto: RequestUpdateNorisDeliveryMethodsDto,
-      options?: RawAxiosRequestConfig,
-    ): AxiosPromise<UpdateDeliveryMethodsInNorisResponseDto> {
-      return localVarFp
-        .adminControllerUpdateDeliveryMethodsInNoris(requestUpdateNorisDeliveryMethodsDto, options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -1710,22 +1520,6 @@ export class AdminApi extends BaseAPI {
   }
 
   /**
-   * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
-   * @summary [internal] Remove delivery methods for given birth number.
-   * @param {string} birthNumber
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   */
-  public adminControllerRemoveDeliveryMethodsFromNoris(
-    birthNumber: string,
-    options?: RawAxiosRequestConfig,
-  ) {
-    return AdminApiFp(this.configuration)
-      .adminControllerRemoveDeliveryMethodsFromNoris(birthNumber, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
    * Updates existing taxes with new data from Noris by birth numbers and year, and saves it to our database.
    * @summary Updates data from Noris.
    * @param {RequestPostNorisLoadDataDto} requestPostNorisLoadDataDto
@@ -1738,22 +1532,6 @@ export class AdminApi extends BaseAPI {
   ) {
     return AdminApiFp(this.configuration)
       .adminControllerUpdateDataFromNoris(requestPostNorisLoadDataDto, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   *
-   * @summary Update delivery methods for given birth numbers and date.
-   * @param {RequestUpdateNorisDeliveryMethodsDto} requestUpdateNorisDeliveryMethodsDto
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   */
-  public adminControllerUpdateDeliveryMethodsInNoris(
-    requestUpdateNorisDeliveryMethodsDto: RequestUpdateNorisDeliveryMethodsDto,
-    options?: RawAxiosRequestConfig,
-  ) {
-    return AdminApiFp(this.configuration)
-      .adminControllerUpdateDeliveryMethodsInNoris(requestUpdateNorisDeliveryMethodsDto, options)
       .then((request) => request(this.axios, this.basePath))
   }
 
@@ -1786,6 +1564,281 @@ export class AdminApi extends BaseAPI {
   ) {
     return AdminApiFp(this.configuration)
       .adminControllerUpdatePaymentsFromNoris(requestPostNorisPaymentDataLoadDto, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
+ * BackendIntegrationAPIApi - axios parameter creator
+ */
+export const BackendIntegrationAPIApiAxiosParamCreator = function (configuration?: Configuration) {
+  return {
+    /**
+     * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
+     * @summary Remove delivery methods for given birth number.
+     * @param {string} birthNumber
+     * @param {*} [options] Override http request option.
+     * @deprecated
+     * @throws {RequiredError}
+     */
+    integrationControllerRemoveDeliveryMethodsFromNoris: async (
+      birthNumber: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'birthNumber' is not null or undefined
+      assertParamExists(
+        'integrationControllerRemoveDeliveryMethodsFromNoris',
+        'birthNumber',
+        birthNumber,
+      )
+      const localVarPath = `/integration/remove-delivery-methods-from-noris/{birthNumber}`.replace(
+        '{birthNumber}',
+        encodeURIComponent(String(birthNumber)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication apiKey required
+      await setApiKeyToObject(localVarHeaderParameter, 'apiKey', configuration)
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     *
+     * @summary Update delivery methods for given birth numbers and date.
+     * @param {RequestUpdateNorisDeliveryMethodsDto} requestUpdateNorisDeliveryMethodsDto
+     * @param {*} [options] Override http request option.
+     * @deprecated
+     * @throws {RequiredError}
+     */
+    integrationControllerUpdateDeliveryMethodsInNoris: async (
+      requestUpdateNorisDeliveryMethodsDto: RequestUpdateNorisDeliveryMethodsDto,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'requestUpdateNorisDeliveryMethodsDto' is not null or undefined
+      assertParamExists(
+        'integrationControllerUpdateDeliveryMethodsInNoris',
+        'requestUpdateNorisDeliveryMethodsDto',
+        requestUpdateNorisDeliveryMethodsDto,
+      )
+      const localVarPath = `/integration/update-delivery-methods-in-noris`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication apiKey required
+      await setApiKeyToObject(localVarHeaderParameter, 'apiKey', configuration)
+
+      localVarHeaderParameter['Content-Type'] = 'application/json'
+      localVarHeaderParameter['Accept'] = 'application/json'
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        requestUpdateNorisDeliveryMethodsDto,
+        localVarRequestOptions,
+        configuration,
+      )
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * BackendIntegrationAPIApi - functional programming interface
+ */
+export const BackendIntegrationAPIApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = BackendIntegrationAPIApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
+     * @summary Remove delivery methods for given birth number.
+     * @param {string} birthNumber
+     * @param {*} [options] Override http request option.
+     * @deprecated
+     * @throws {RequiredError}
+     */
+    async integrationControllerRemoveDeliveryMethodsFromNoris(
+      birthNumber: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.integrationControllerRemoveDeliveryMethodsFromNoris(
+          birthNumber,
+          options,
+        )
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath =
+        operationServerMap[
+          'BackendIntegrationAPIApi.integrationControllerRemoveDeliveryMethodsFromNoris'
+        ]?.[localVarOperationServerIndex]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
+    /**
+     *
+     * @summary Update delivery methods for given birth numbers and date.
+     * @param {RequestUpdateNorisDeliveryMethodsDto} requestUpdateNorisDeliveryMethodsDto
+     * @param {*} [options] Override http request option.
+     * @deprecated
+     * @throws {RequiredError}
+     */
+    async integrationControllerUpdateDeliveryMethodsInNoris(
+      requestUpdateNorisDeliveryMethodsDto: RequestUpdateNorisDeliveryMethodsDto,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<UpdateDeliveryMethodsInNorisResponseDto>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.integrationControllerUpdateDeliveryMethodsInNoris(
+          requestUpdateNorisDeliveryMethodsDto,
+          options,
+        )
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath =
+        operationServerMap[
+          'BackendIntegrationAPIApi.integrationControllerUpdateDeliveryMethodsInNoris'
+        ]?.[localVarOperationServerIndex]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
+  }
+}
+
+/**
+ * BackendIntegrationAPIApi - factory interface
+ */
+export const BackendIntegrationAPIApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = BackendIntegrationAPIApiFp(configuration)
+  return {
+    /**
+     * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
+     * @summary Remove delivery methods for given birth number.
+     * @param {string} birthNumber
+     * @param {*} [options] Override http request option.
+     * @deprecated
+     * @throws {RequiredError}
+     */
+    integrationControllerRemoveDeliveryMethodsFromNoris(
+      birthNumber: string,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<void> {
+      return localVarFp
+        .integrationControllerRemoveDeliveryMethodsFromNoris(birthNumber, options)
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     *
+     * @summary Update delivery methods for given birth numbers and date.
+     * @param {RequestUpdateNorisDeliveryMethodsDto} requestUpdateNorisDeliveryMethodsDto
+     * @param {*} [options] Override http request option.
+     * @deprecated
+     * @throws {RequiredError}
+     */
+    integrationControllerUpdateDeliveryMethodsInNoris(
+      requestUpdateNorisDeliveryMethodsDto: RequestUpdateNorisDeliveryMethodsDto,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<UpdateDeliveryMethodsInNorisResponseDto> {
+      return localVarFp
+        .integrationControllerUpdateDeliveryMethodsInNoris(
+          requestUpdateNorisDeliveryMethodsDto,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * BackendIntegrationAPIApi - object-oriented interface
+ */
+export class BackendIntegrationAPIApi extends BaseAPI {
+  /**
+   * ⚠️ Must be called only through nest-city-account, which is the source of truth for delivery methods. Calling this endpoint directly bypasses nest-city-account\'s business logic (including the per-birth-number advisory lock) and can leave Noris in an incorrect state.
+   * @summary Remove delivery methods for given birth number.
+   * @param {string} birthNumber
+   * @param {*} [options] Override http request option.
+   * @deprecated
+   * @throws {RequiredError}
+   */
+  public integrationControllerRemoveDeliveryMethodsFromNoris(
+    birthNumber: string,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return BackendIntegrationAPIApiFp(this.configuration)
+      .integrationControllerRemoveDeliveryMethodsFromNoris(birthNumber, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   *
+   * @summary Update delivery methods for given birth numbers and date.
+   * @param {RequestUpdateNorisDeliveryMethodsDto} requestUpdateNorisDeliveryMethodsDto
+   * @param {*} [options] Override http request option.
+   * @deprecated
+   * @throws {RequiredError}
+   */
+  public integrationControllerUpdateDeliveryMethodsInNoris(
+    requestUpdateNorisDeliveryMethodsDto: RequestUpdateNorisDeliveryMethodsDto,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return BackendIntegrationAPIApiFp(this.configuration)
+      .integrationControllerUpdateDeliveryMethodsInNoris(
+        requestUpdateNorisDeliveryMethodsDto,
+        options,
+      )
       .then((request) => request(this.axios, this.basePath))
   }
 }

--- a/openapi-clients/tax/client.ts
+++ b/openapi-clients/tax/client.ts
@@ -1,5 +1,6 @@
 import {
   AdminApiFactory,
+  BackendIntegrationAPIApiFactory,
   CardPaymentReportingApiFactory,
   DefaultApiFactory,
   PaymentApiFactory,
@@ -26,6 +27,7 @@ export const createTaxClient = ({
 
   return {
     ...AdminApiFactory(...args),
+    ...BackendIntegrationAPIApiFactory(...args),
     ...CardPaymentReportingApiFactory(...args),
     ...DefaultApiFactory(...args),
     ...PaymentApiFactory(...args),


### PR DESCRIPTION
Adds a new IntegrationModule that consolidates backend-to-backend integration endpoints (currently delivery methods) behind a dedicated controller/service. Migrates these endpoints from the admin module to IntegrationController, wires NorisModule into it, and updates TaxSubservice to call the new routes via
BackendIntegrationAPIApi. The admin module delivery method endpoints are removed.