### PR TITLE
755 number field with unit

### DIFF
--- a/forms-shared/src/generator/uiOptionsTypes.ts
+++ b/forms-shared/src/generator/uiOptionsTypes.ts
@@ -103,6 +103,7 @@ export type InputUiOptions = {
 
 export type NumberUiOptions = Omit<InputUiOptions, 'inputType'> & {
   formatOptions?: Intl.NumberFormatOptions
+  unit?: string
 }
 
 export type RadioGroupUiOptions = {

--- a/next/src/components/fields/NumberField.tsx
+++ b/next/src/components/fields/NumberField.tsx
@@ -1,5 +1,6 @@
-import { forwardRef, ReactNode, Ref } from 'react'
+import { forwardRef, ReactNode, Ref, useId } from 'react'
 import { ButtonContext } from 'react-aria-components/Button'
+import { Group as RACGroup } from 'react-aria-components/Group'
 import { Input as RACInput } from 'react-aria-components/Input'
 import {
   NumberField as RACNumberField,
@@ -14,6 +15,7 @@ import { FieldBaseProps } from './_shared/types'
 export interface NumberFieldProps extends RACNumberFieldProps, FieldBaseProps {
   placeholder?: string
   endIcon?: ReactNode
+  unit?: string
 }
 
 const NumberField = (
@@ -26,10 +28,13 @@ const NumberField = (
     errorMessage,
     placeholder,
     endIcon,
+    unit,
     ...rest
   }: NumberFieldProps,
   ref: Ref<HTMLInputElement>,
 ) => {
+  const unitId = useId()
+
   return (
     <RACNumberField
       {...rest}
@@ -56,30 +61,76 @@ const NumberField = (
           helptextFooter={helptextFooter}
           errorMessage={errorMessage}
         >
-          <div className="relative">
-            <RACInput
-              ref={ref}
-              placeholder={placeholder}
-              data-cy={rest.name ? `number-${rest.name}` : undefined}
-              className={({ isFocused, isDisabled, isInvalid }) =>
-                cn(
-                  'w-full rounded-lg border bg-background-passive-base text-size-p-small-r text-content-passive-secondary outline-hidden lg:text-size-p-small',
-                  'px-3 py-2 lg:px-4 lg:py-3',
-                  'placeholder:text-content-passive-tertiary',
-                  {
-                    'border-border-active-default': !isInvalid && !isFocused,
-                    'border-border-active-focused': !isInvalid && isFocused,
-                    'border-border-error': isInvalid,
-                    'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
-                    'hover:border-border-active-hover': !isDisabled && !isInvalid && !isFocused,
-                  },
-                )
+          {unit ? (
+            <RACGroup
+              className={({ isFocusWithin, isInvalid, isDisabled, isHovered }) =>
+                cn('flex w-full overflow-hidden rounded-lg border bg-background-passive-base', {
+                  'border-border-active-default': !isInvalid && !isFocusWithin,
+                  'border-border-active-focused': !isInvalid && isFocusWithin,
+                  'border-border-error': isInvalid,
+                  'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
+                  'border-border-active-hover':
+                    !isDisabled && !isInvalid && !isFocusWithin && isHovered,
+                })
               }
-            />
-            {endIcon ? (
-              <div className="absolute inset-y-0 right-0 flex items-center">{endIcon}</div>
-            ) : null}
-          </div>
+            >
+              {({ isFocusWithin, isInvalid, isDisabled }) => (
+                <>
+                  <RACInput
+                    ref={ref}
+                    placeholder={placeholder}
+                    // Thanks to aria-describedby, screen readers will read the suffix value after announcing the label, with a short pause.
+                    aria-describedby={unitId}
+                    data-cy={rest.name ? `number-${rest.name}` : undefined}
+                    className={cn(
+                      'min-w-0 flex-1 bg-transparent text-size-p-small-r text-content-passive-secondary outline-hidden lg:text-size-p-small',
+                      'px-3 py-2 lg:px-4 lg:py-3',
+                      'placeholder:text-content-passive-tertiary',
+                    )}
+                  />
+                  <div
+                    id={unitId}
+                    className={cn(
+                      'flex items-center self-stretch border-l px-3 font-semibold text-content-passive-secondary lg:px-4',
+                      {
+                        'border-border-active-default': !isInvalid && !isFocusWithin,
+                        'border-border-active-focused': !isInvalid && isFocusWithin,
+                        'border-border-error': isInvalid,
+                        'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
+                      },
+                    )}
+                  >
+                    {unit}
+                  </div>
+                </>
+              )}
+            </RACGroup>
+          ) : (
+            <div className="relative">
+              <RACInput
+                ref={ref}
+                placeholder={placeholder}
+                data-cy={rest.name ? `number-${rest.name}` : undefined}
+                className={({ isFocused, isDisabled, isInvalid }) =>
+                  cn(
+                    'w-full rounded-lg border bg-background-passive-base text-size-p-small-r text-content-passive-secondary outline-hidden lg:text-size-p-small',
+                    'px-3 py-2 lg:px-4 lg:py-3',
+                    'placeholder:text-content-passive-tertiary',
+                    {
+                      'border-border-active-default': !isInvalid && !isFocused,
+                      'border-border-active-focused': !isInvalid && isFocused,
+                      'border-border-error': isInvalid,
+                      'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
+                      'hover:border-border-active-hover': !isDisabled && !isInvalid && !isFocused,
+                    },
+                  )
+                }
+              />
+              {endIcon ? (
+                <div className="absolute inset-y-0 right-0 flex items-center">{endIcon}</div>
+              ) : null}
+            </div>
+          )}
         </FieldWrapper>
       </ButtonContext.Provider>
     </RACNumberField>

--- a/next/src/components/fields/NumberField.tsx
+++ b/next/src/components/fields/NumberField.tsx
@@ -29,59 +29,61 @@ const NumberField = (
     ...rest
   }: NumberFieldProps,
   ref: Ref<HTMLInputElement>,
-) => (
-  <RACNumberField
-    {...rest}
-    isInvalid={!!errorMessage}
-    validationBehavior="aria"
-    className={cn('flex w-full flex-col gap-2', rest.className)}
-  >
-    {/*
-     * RAC's NumberField provides a ButtonContext with `increment` and `decrement` slots for stepper
-     * buttons. Any RAC-based Button rendered as a React descendant (e.g. in RJSF array templates)
-     * will try to consume this context and throw "A slot prop is required. Valid slot names are
-     * "increment" and "decrement"." if no valid slot is set.
-     * Since we don't render stepper buttons, we reset the context to `null` to opt out.
-     * If we want to render stepper button in future, this hotfix needs to be removed.
-     * TODO A way to fix can be adding default slot={props.slot ?? null} to Button from @bratislava/component-library.
-     */}
-    <ButtonContext.Provider value={null as never}>
-      <FieldWrapper
-        label={label}
-        isRequired={rest.isRequired}
-        displayOptionalLabel={displayOptionalLabel}
-        labelSize={labelSize}
-        helptext={helptext}
-        helptextFooter={helptextFooter}
-        errorMessage={errorMessage}
-      >
-        <div className="relative">
-          <RACInput
-            ref={ref}
-            placeholder={placeholder}
-            data-cy={rest.name ? `number-${rest.name}` : undefined}
-            className={({ isFocused, isDisabled, isInvalid }) =>
-              cn(
-                'w-full rounded-lg border bg-background-passive-base text-size-p-small-r text-content-passive-secondary outline-hidden lg:text-size-p-small',
-                'px-3 py-2 lg:px-4 lg:py-3',
-                'placeholder:text-content-passive-tertiary',
-                {
-                  'border-border-active-default': !isInvalid && !isFocused,
-                  'border-border-active-focused': !isInvalid && isFocused,
-                  'border-border-error': isInvalid,
-                  'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
-                  'hover:border-border-active-hover': !isDisabled && !isInvalid && !isFocused,
-                },
-              )
-            }
-          />
-          {endIcon ? (
-            <div className="absolute inset-y-0 right-0 flex items-center">{endIcon}</div>
-          ) : null}
-        </div>
-      </FieldWrapper>
-    </ButtonContext.Provider>
-  </RACNumberField>
-)
+) => {
+  return (
+    <RACNumberField
+      {...rest}
+      isInvalid={!!errorMessage}
+      validationBehavior="aria"
+      className={cn('flex w-full flex-col gap-2', rest.className)}
+    >
+      {/*
+       * RAC's NumberField provides a ButtonContext with `increment` and `decrement` slots for stepper
+       * buttons. Any RAC-based Button rendered as a React descendant (e.g. in RJSF array templates)
+       * will try to consume this context and throw "A slot prop is required. Valid slot names are
+       * "increment" and "decrement"." if no valid slot is set.
+       * Since we don't render stepper buttons, we reset the context to `null` to opt out.
+       * If we want to render stepper button in future, this hotfix needs to be removed.
+       * TODO A way to fix can be adding default slot={props.slot ?? null} to Button from @bratislava/component-library.
+       */}
+      <ButtonContext.Provider value={null as never}>
+        <FieldWrapper
+          label={label}
+          isRequired={rest.isRequired}
+          displayOptionalLabel={displayOptionalLabel}
+          labelSize={labelSize}
+          helptext={helptext}
+          helptextFooter={helptextFooter}
+          errorMessage={errorMessage}
+        >
+          <div className="relative">
+            <RACInput
+              ref={ref}
+              placeholder={placeholder}
+              data-cy={rest.name ? `number-${rest.name}` : undefined}
+              className={({ isFocused, isDisabled, isInvalid }) =>
+                cn(
+                  'w-full rounded-lg border bg-background-passive-base text-size-p-small-r text-content-passive-secondary outline-hidden lg:text-size-p-small',
+                  'px-3 py-2 lg:px-4 lg:py-3',
+                  'placeholder:text-content-passive-tertiary',
+                  {
+                    'border-border-active-default': !isInvalid && !isFocused,
+                    'border-border-active-focused': !isInvalid && isFocused,
+                    'border-border-error': isInvalid,
+                    'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
+                    'hover:border-border-active-hover': !isDisabled && !isInvalid && !isFocused,
+                  },
+                )
+              }
+            />
+            {endIcon ? (
+              <div className="absolute inset-y-0 right-0 flex items-center">{endIcon}</div>
+            ) : null}
+          </div>
+        </FieldWrapper>
+      </ButtonContext.Provider>
+    </RACNumberField>
+  )
+}
 
 export default forwardRef(NumberField)

--- a/next/src/components/styleguide/showcases/NumberFieldShowCase.tsx
+++ b/next/src/components/styleguide/showcases/NumberFieldShowCase.tsx
@@ -25,6 +25,13 @@ const NumberFieldShowCase = () => {
           isDisabled
         />
       </Stack>
+      <Stack direction="column">
+        <NumberField label="Plocha" unit="m²" />
+        <NumberField label="Plocha" unit="m²" value={42} />
+        <NumberField label="Plocha" unit="m²" errorMessage="Error message" />
+        <NumberField label="Plocha" unit="m²" value={42} isDisabled />
+        <NumberField label="Suma" unit="€" helptext="Help text" isRequired />
+      </Stack>
     </Wrapper>
   )
 }

--- a/next/src/components/widget-wrappers/NumberWidgetRJSF.tsx
+++ b/next/src/components/widget-wrappers/NumberWidgetRJSF.tsx
@@ -43,6 +43,7 @@ const NumberWidgetRJSF = (props: NumberWidgetRJSFProps) => {
       <NumberField
         {...fieldProps}
         placeholder={specificOptions.placeholder}
+        unit={specificOptions.unit}
         minValue={schema.minimum}
         maxValue={schema.maximum}
         formatOptions={getFormatOptions()}


### PR DESCRIPTION
Implement "unit" ui option to display unit suffix in NumberField.
Accessibility: using `aria-describedy` should ensure, that the unit is read by screen reader after label, with short pause. (Tested on Mac VoiceOver)

Implementing only suffix, not preffix. Will be implemented when needed. Discussed with PMs.

Note that clicking on unit div does not focus the input. We can discuss if this is okay, or if we should implement some workaround to focus the input after the click on the unit.

Created with help from Claude.




<img width="413" height="428" alt="image" src="https://github.com/user-attachments/assets/c941f225-02fa-4f16-9a15-f7cf9a5ecc7b" />
<img width="298" height="389" alt="image" src="https://github.com/user-attachments/assets/bca86d5f-0a27-4eec-b3f7-9617a820282e" />
