### PR TITLE
fix: keep BOTH in database when updating tax installments

### DIFF
--- a/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
+++ b/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
@@ -35,7 +35,7 @@ function assertUpdateManyUsesReminderEnums(
     UnpaidReminderSent.BOTH,
   )
   expect(call2[0].where.bloomreachUnpaidReminderSent).toEqual({
-    not: alreadyOtherSent,
+    notIn: [alreadyOtherSent, UnpaidReminderSent.BOTH],
   })
   expect(call2[0].data.bloomreachUnpaidReminderSent).toBe(newReminderSent)
 }

--- a/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
@@ -225,7 +225,9 @@ export default class NotificationsEventsService {
     await this.prismaService.taxInstallment.updateMany({
       where: {
         ...baseWhere,
-        bloomreachUnpaidReminderSent: { not: alreadyOtherSent },
+        bloomreachUnpaidReminderSent: {
+          notIn: [alreadyOtherSent, UnpaidReminderSent.BOTH],
+        },
       },
       data: { bloomreachUnpaidReminderSent: newReminderSent },
     })


### PR DESCRIPTION
## Bug

When updating `bloomreachUnpaidReminderSent` on tax installments, the logic runs two sequential `updateMany` calls:

1. Records where `bloomreachUnpaidReminderSent = alreadyOtherSent`: set to `BOTH`
2. Records where `bloomreachUnpaidReminderSent != alreadyOtherSent`: set to `newReminderSent`

The second update's condition (`!= alreadyOtherSent`) also matched records that were just set to `BOTH` in step 1, immediately overwriting them. As a result, `BOTH` was never persisted.

## Fix

Exclude `BOTH` from the second update's condition: `notIn: [alreadyOtherSent, UnpaidReminderSent.BOTH]`.
