### PR TITLE
1527 Fix Modals accessible title missing

### DIFF
--- a/next/src/components/forms/steps/StepperView.tsx
+++ b/next/src/components/forms/steps/StepperView.tsx
@@ -33,7 +33,7 @@ const StepperModal = ({ isOpen, setIsOpen, handleOnSkipToStep }: StepperModalPro
           {({ close }) => (
             <>
               <div className="flex h-14 w-full flex-row items-center gap-1 bg-white p-4 drop-shadow-lg">
-                <Heading slot="title" className="grow text-size-h6-r lg:text-size-h6">
+                <Heading slot="title" className="grow text-size-h6-r font-semibold lg:text-size-h6">
                   {t('StepperView.all_steps')}
                 </Heading>
                 {/* TODO Unify modal close button with other modals */}

--- a/next/src/components/forms/steps/StepperView.tsx
+++ b/next/src/components/forms/steps/StepperView.tsx
@@ -2,7 +2,7 @@ import { Button } from '@bratislava/component-library'
 import { useTranslation } from 'next-i18next/pages'
 import { useState } from 'react'
 import { Dialog, Heading } from 'react-aria-components/Dialog'
-import { Modal, ModalOverlay } from 'react-aria-components/Modal'
+import { Modal as RACModal, ModalOverlay as RACModalOverlay } from 'react-aria-components/Modal'
 
 import StepperViewList from '@/src/components/forms/steps/StepperViewList'
 import StepperViewRow from '@/src/components/forms/steps/StepperViewRow'
@@ -22,13 +22,13 @@ const StepperModal = ({ isOpen, setIsOpen, handleOnSkipToStep }: StepperModalPro
   const { t } = useTranslation('forms')
 
   return (
-    <ModalOverlay
+    <RACModalOverlay
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       className="fixed top-0 left-0 z-50 h-(--visual-viewport-height) w-screen bg-white outline-0 entering:animate-stepper-slide exiting:animate-stepper-slide-reverse"
       isDismissable
     >
-      <Modal isDismissable isOpen={isOpen} onOpenChange={setIsOpen} className="h-full outline-0">
+      <RACModal className="h-full outline-0">
         <Dialog className="flex h-full flex-col outline-0">
           {({ close }) => (
             <>
@@ -50,8 +50,8 @@ const StepperModal = ({ isOpen, setIsOpen, handleOnSkipToStep }: StepperModalPro
             </>
           )}
         </Dialog>
-      </Modal>
-    </ModalOverlay>
+      </RACModal>
+    </RACModalOverlay>
   )
 }
 

--- a/next/src/components/modals/RegistrationModal.tsx
+++ b/next/src/components/modals/RegistrationModal.tsx
@@ -6,6 +6,7 @@ import Markdown from '@/src/components/formatting/Markdown'
 import { useFormContext } from '@/src/components/forms/useFormContext'
 import Icon from '@/src/components/icon-components/Icon'
 import AccountLink from '@/src/components/segments/AccountLink/AccountLink'
+import Dialog from '@/src/components/simple-components/Dialog'
 import Modal, { ModalProps } from '@/src/components/simple-components/Modal'
 
 export enum RegistrationModalType {
@@ -132,79 +133,82 @@ const RegistrationModal = ({ type, login, register, ...rest }: RegistrationModal
       {...rest}
       data-cy="registration-modal"
     >
-      <div className="mb-6 flex flex-col gap-2">
-        {title && <Typography variant="h3">{title}</Typography>}
-        {subtitle && <Markdown variant="large" content={subtitle} />}
-      </div>
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col">
-          <div className="rounded-t-lg bg-gray-100 p-4 md:px-6 md:py-5">
-            <Typography variant="h4">{t('registration_modal.body_title')}</Typography>
-            <ul className="mt-6 flex flex-col gap-2 sm:gap-4">
-              {}
-              {bodyList.map((item, index) => (
-                <li key={index} className="flex items-center gap-4">
-                  <span className="flex size-5 min-w-[20px] items-center justify-center md:size-6 md:min-w-[24px]">
-                    <Icon name="check" className="size-7" />
-                  </span>
-                  <Typography variant="p-tiny" className="lg:text-size-p-large">
-                    {item}
-                  </Typography>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="rounded-b-lg bg-gray-100 px-4 pb-4 md:px-0 md:pb-0">
-            <Button
-              variant="solid"
-              fullWidth
-              onPress={() => register()}
-              className="md:rounded-t-none lg:py-6"
-              data-cy="registration-modal-button"
-            >
-              {t('registration_modal.body_action')}
-            </Button>
-          </div>
+      {/* Accessible title. */}
+      <Dialog aria-label={t('auth.register_title')}>
+        <div className="mb-6 flex flex-col gap-2">
+          {title && <Typography variant="h3">{title}</Typography>}
+          {subtitle && <Markdown variant="large" content={subtitle} />}
         </div>
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col">
+            <div className="rounded-t-lg bg-gray-100 p-4 md:px-6 md:py-5">
+              <Typography variant="h4">{t('registration_modal.body_title')}</Typography>
+              <ul className="mt-6 flex flex-col gap-2 sm:gap-4">
+                {}
+                {bodyList.map((item, index) => (
+                  <li key={index} className="flex items-center gap-4">
+                    <span className="flex size-5 min-w-[20px] items-center justify-center md:size-6 md:min-w-[24px]">
+                      <Icon name="check" className="size-7" />
+                    </span>
+                    <Typography variant="p-tiny" className="lg:text-size-p-large">
+                      {item}
+                    </Typography>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-b-lg bg-gray-100 px-4 pb-4 md:px-0 md:pb-0">
+              <Button
+                variant="solid"
+                fullWidth
+                onPress={() => register()}
+                className="md:rounded-t-none lg:py-6"
+                data-cy="registration-modal-button"
+              >
+                {t('registration_modal.body_action')}
+              </Button>
+            </div>
+          </div>
 
-        <AccountLink variant="login" />
-      </div>
-      {(type === RegistrationModalType.Initial ||
-        type === RegistrationModalType.NotAuthenticatedSubmitForm) && (
-        <div className="mb-4 flex flex-col gap-3 md:mb-0 md:gap-6">
-          <div className="mt-3 flex items-center md:mt-6">
-            <span className="h-0.5 w-full bg-gray-200" />
-            <span className="px-6 text-size-p-large-r lg:text-size-p-large">
-              {t('registration_modal.footer_choice')}
-            </span>
-            <span className="h-0.5 w-full bg-gray-200" />
-          </div>
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
-            {type === RegistrationModalType.Initial && (
-              <>
-                {eidSendPossible ? (
-                  <Button variant="outline-soft" size="small" onPress={close} fullWidth>
-                    {t('registration_modal.buttons_initial_continue_eid')}
-                  </Button>
-                ) : null}
-                <Button variant="outline-soft" size="small" onPress={close} fullWidth>
-                  {t('registration_modal.buttons_initial_skip')}
-                </Button>
-              </>
-            )}
-            {type === RegistrationModalType.NotAuthenticatedSubmitForm && (
-              <>
-                <Button variant="outline-soft" size="small" onPress={close} fullWidth>
-                  {t('registration_modal.buttons_not_verified_submit_back')}
-                </Button>
-                <Button variant="outline-soft" size="small" onPress={close} fullWidth>
-                  {t('registration_modal.buttons_not_verified_submit_send')}
-                </Button>
-              </>
-            )}
-          </div>
+          <AccountLink variant="login" />
         </div>
-      )}
+        {(type === RegistrationModalType.Initial ||
+          type === RegistrationModalType.NotAuthenticatedSubmitForm) && (
+          <div className="mb-4 flex flex-col gap-3 md:mb-0 md:gap-6">
+            <div className="mt-3 flex items-center md:mt-6">
+              <span className="h-0.5 w-full bg-gray-200" />
+              <span className="px-6 text-size-p-large-r lg:text-size-p-large">
+                {t('registration_modal.footer_choice')}
+              </span>
+              <span className="h-0.5 w-full bg-gray-200" />
+            </div>
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
+              {type === RegistrationModalType.Initial && (
+                <>
+                  {eidSendPossible ? (
+                    <Button variant="outline-soft" size="small" onPress={close} fullWidth>
+                      {t('registration_modal.buttons_initial_continue_eid')}
+                    </Button>
+                  ) : null}
+                  <Button variant="outline-soft" size="small" onPress={close} fullWidth>
+                    {t('registration_modal.buttons_initial_skip')}
+                  </Button>
+                </>
+              )}
+              {type === RegistrationModalType.NotAuthenticatedSubmitForm && (
+                <>
+                  <Button variant="outline-soft" size="small" onPress={close} fullWidth>
+                    {t('registration_modal.buttons_not_verified_submit_back')}
+                  </Button>
+                  <Button variant="outline-soft" size="small" onPress={close} fullWidth>
+                    {t('registration_modal.buttons_not_verified_submit_send')}
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </Dialog>
     </Modal>
   )
 }

--- a/next/src/components/modals/TaxFormPdfExportModal/TaxFormPdfExportModal.tsx
+++ b/next/src/components/modals/TaxFormPdfExportModal/TaxFormPdfExportModal.tsx
@@ -25,7 +25,7 @@ const LoadingContent = () => {
       <Spinner size="lg" />
       <div className="flex flex-col gap-3 text-center">
         {/* Accessible Dialog heading */}
-        <Heading slot="title" className="text-size-h3-r lg:text-size-h3">
+        <Heading slot="title" className="text-size-h3-r font-semibold lg:text-size-h3">
           {t('tax_form_pdf_export_modal.preparing')}
         </Heading>
         <Typography variant="p-default">
@@ -83,7 +83,7 @@ const SuccessContent = () => {
       <div className="flex flex-col items-center gap-6">
         <div className="flex flex-col items-center gap-1">
           {/* Accessible Dialog heading */}
-          <Heading slot="title" className="text-size-h2-r lg:text-size-h2">
+          <Heading slot="title" className="text-size-h2-r font-semibold lg:text-size-h2">
             {t('tax_form_pdf_export_modal.heading')}
           </Heading>
           <Typography variant="p-small">{t('tax_form_pdf_export_modal.subheading')}</Typography>

--- a/next/src/components/modals/TaxFormPdfExportModal/TaxFormPdfExportModal.tsx
+++ b/next/src/components/modals/TaxFormPdfExportModal/TaxFormPdfExportModal.tsx
@@ -1,11 +1,13 @@
 import { Button, Typography } from '@bratislava/component-library'
 import { Trans, useTranslation } from 'next-i18next/pages'
 import { mergeProps } from 'react-aria/mergeProps'
+import { Heading } from 'react-aria-components/Heading'
 
 import { useFormContext } from '@/src/components/forms/useFormContext'
 import { useFormRedirects } from '@/src/components/forms/useFormRedirects'
 import Icon from '@/src/components/icon-components/Icon'
 import { TaxFormPdfExportModalState } from '@/src/components/modals/TaxFormPdfExportModal/TaxFormPdfExportModalState'
+import Dialog from '@/src/components/simple-components/Dialog'
 import Modal, { ModalProps } from '@/src/components/simple-components/Modal'
 import Spinner from '@/src/components/simple-components/Spinner'
 import { useSsrAuth } from '@/src/frontend/hooks/useSsrAuth'
@@ -22,7 +24,10 @@ const LoadingContent = () => {
     <div className="flex flex-col items-center gap-6">
       <Spinner size="lg" />
       <div className="flex flex-col gap-3 text-center">
-        <Typography variant="h3">{t('tax_form_pdf_export_modal.preparing')}</Typography>
+        {/* Accessible Dialog heading */}
+        <Heading slot="title" className="text-size-h3-r lg:text-size-h3">
+          {t('tax_form_pdf_export_modal.preparing')}
+        </Heading>
         <Typography variant="p-default">
           {t('tax_form_pdf_export_modal.preparing_description')}
         </Typography>
@@ -77,7 +82,10 @@ const SuccessContent = () => {
       </div>
       <div className="flex flex-col items-center gap-6">
         <div className="flex flex-col items-center gap-1">
-          <Typography variant="h2">{t('tax_form_pdf_export_modal.heading')}</Typography>
+          {/* Accessible Dialog heading */}
+          <Heading slot="title" className="text-size-h2-r lg:text-size-h2">
+            {t('tax_form_pdf_export_modal.heading')}
+          </Heading>
           <Typography variant="p-small">{t('tax_form_pdf_export_modal.subheading')}</Typography>
         </div>
         <div className="flex flex-col items-center gap-1">
@@ -176,22 +184,26 @@ const SuccessContent = () => {
  * Rough version of the modal, some code is copied from RegistrationModal. It will need complex modal refactor in forms
  * in the future.
  */
-const TaxFormPdfExportModal = ({ state, ...props }: TaxFormPdfExportModalProps) => (
-  <Modal
-    modalOverlayClassname="md:py-4"
-    modalClassname="md:max-w-[800px] md:my-4 md:py-12 md:px-14"
-    mobileFullScreen
-    {...mergeProps(props, {
-      onOpenChange: (isOpen) => {
-        if (!isOpen && state?.type === 'loading') {
-          state.onClose()
-        }
-      },
-    } as ModalProps)}
-  >
-    {state?.type === 'loading' && <LoadingContent />}
-    {state?.type === 'success' && <SuccessContent />}
-  </Modal>
-)
+const TaxFormPdfExportModal = ({ state, ...props }: TaxFormPdfExportModalProps) => {
+  return (
+    <Modal
+      modalOverlayClassname="md:py-4"
+      modalClassname="md:max-w-[800px] md:my-4 md:py-12 md:px-14"
+      mobileFullScreen
+      {...mergeProps(props, {
+        onOpenChange: (isOpen) => {
+          if (!isOpen && state?.type === 'loading') {
+            state.onClose()
+          }
+        },
+      } as ModalProps)}
+    >
+      <Dialog>
+        {state?.type === 'loading' && <LoadingContent />}
+        {state?.type === 'success' && <SuccessContent />}
+      </Dialog>
+    </Modal>
+  )
+}
 
 export default TaxFormPdfExportModal

--- a/next/src/components/page-contents/MyApplicationsPageContent/BottomSheetMenu/BottomSheetMenuModal.tsx
+++ b/next/src/components/page-contents/MyApplicationsPageContent/BottomSheetMenu/BottomSheetMenuModal.tsx
@@ -1,7 +1,7 @@
 import { Button, Typography } from '@bratislava/component-library'
 import { useTranslation } from 'next-i18next/pages'
 import { Dialog } from 'react-aria-components/Dialog'
-import { Modal, ModalOverlay } from 'react-aria-components/Modal'
+import { Modal as RACModal, ModalOverlay as RACModalOverlay } from 'react-aria-components/Modal'
 
 import Icon from '@/src/components/icon-components/Icon'
 import BottomSheetMenuRow from '@/src/components/page-contents/MyApplicationsPageContent/BottomSheetMenu/BottomSheetMenuRow'
@@ -25,18 +25,13 @@ const BottomSheetMenuModal = ({
   }
 
   return (
-    <ModalOverlay
+    <RACModalOverlay
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       className="fixed top-0 left-0 z-50 h-(--visual-viewport-height) w-screen bg-gray-800/40 outline-0"
       isDismissable
     >
-      <Modal
-        isDismissable
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        className="fixed bottom-0 w-full outline-0 entering:animate-stepper-slide exiting:animate-stepper-slide-reverse"
-      >
+      <RACModal className="fixed bottom-0 w-full outline-0 entering:animate-stepper-slide exiting:animate-stepper-slide-reverse">
         <Dialog className="flex h-full flex-col outline-0">
           {({ close }) => (
             <>
@@ -71,8 +66,8 @@ const BottomSheetMenuModal = ({
             </>
           )}
         </Dialog>
-      </Modal>
-    </ModalOverlay>
+      </RACModal>
+    </RACModalOverlay>
   )
 }
 

--- a/next/src/components/page-contents/TaxesFees/shared/OfficialCorrespondenceChannelChangeModal.tsx
+++ b/next/src/components/page-contents/TaxesFees/shared/OfficialCorrespondenceChannelChangeModal.tsx
@@ -258,7 +258,7 @@ const OfficialCorrespondenceChannelChangeModal = ({ isOpen, onOpenChange }: Moda
       <Dialog>
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-2">
-            <Heading slot="title" className="text-size-h3-r lg:text-size-h3">
+            <Heading slot="title" className="text-size-h3-r font-semibold lg:text-size-h3">
               {t('taxes.delivery_method_change_modal.title')}
             </Heading>
             <Markdown

--- a/next/src/components/page-contents/TaxesFees/shared/OfficialCorrespondenceChannelChangeModal.tsx
+++ b/next/src/components/page-contents/TaxesFees/shared/OfficialCorrespondenceChannelChangeModal.tsx
@@ -14,6 +14,7 @@ import Markdown from '@/src/components/formatting/Markdown'
 import OfficialCorrespondenceChannelAlert from '@/src/components/page-contents/TaxesFees/shared/OfficialCorrespondenceChannelAlert'
 import { useStrapiTax } from '@/src/components/page-contents/TaxesFees/useStrapiTax'
 import { useUserDataDeliveryMethod } from '@/src/components/page-contents/TaxesFees/useUserDataDeliveryMethod'
+import Dialog from '@/src/components/simple-components/Dialog'
 import Modal, { ModalProps } from '@/src/components/simple-components/Modal'
 import useToast from '@/src/components/simple-components/Toast/useToast'
 import useHookForm from '@/src/frontend/hooks/useHookForm'
@@ -254,28 +255,33 @@ const OfficialCorrespondenceChannelChangeModal = ({ isOpen, onOpenChange }: Moda
       modalClassname="md:max-w-[800px] md:my-4 md:py-12 md:px-14"
       mobileFullScreen
     >
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
-          <Heading slot="title" className="text-size-h3-r lg:text-size-h3">
-            {t('taxes.delivery_method_change_modal.title')}
-          </Heading>
-          <Markdown variant="small" content={t('taxes.delivery_method_change_modal.description')} />
-        </div>
-        {hasChangedDeliveryMethodAfterDeadline && (
-          <OfficialCorrespondenceChannelAlert
-            variant="change-effective-next-year"
-            strapiTax={strapiTax}
+      <Dialog>
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-2">
+            <Heading slot="title" className="text-size-h3-r lg:text-size-h3">
+              {t('taxes.delivery_method_change_modal.title')}
+            </Heading>
+            <Markdown
+              variant="small"
+              content={t('taxes.delivery_method_change_modal.description')}
+            />
+          </div>
+          {hasChangedDeliveryMethodAfterDeadline && (
+            <OfficialCorrespondenceChannelAlert
+              variant="change-effective-next-year"
+              strapiTax={strapiTax}
+            />
+          )}
+          <Form
+            defaultValues={{
+              isSubscribed: isSubscribedDefaultValue,
+              scrolledToBottom: false,
+            }}
+            onSubmit={handleSubmit}
+            agreementContent={accountCommunicationConsentText}
           />
-        )}
-        <Form
-          defaultValues={{
-            isSubscribed: isSubscribedDefaultValue,
-            scrolledToBottom: false,
-          }}
-          onSubmit={handleSubmit}
-          agreementContent={accountCommunicationConsentText}
-        />
-      </div>
+        </div>
+      </Dialog>
     </Modal>
   )
 }

--- a/next/src/components/simple-components/Dialog.tsx
+++ b/next/src/components/simple-components/Dialog.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@bratislava/component-library'
+import { useTranslation } from 'next-i18next/pages'
+import { Dialog as AriaDialog, DialogProps as AriaDialogProps } from 'react-aria-components/Dialog'
+
+import Icon from '@/src/components/icon-components/Icon'
+import cn from '@/src/utils/cn'
+
+export type DialogProps = AriaDialogProps & {
+  noCloseButton?: boolean
+}
+
+/**
+ * A Dialog is a container for the contents of a modal. It must be combined with `Modal` (the
+ * overlay) to create a fully accessible modal dialog.
+ *
+ * Docs: https://react-spectrum.adobe.com/react-aria/Dialog.html
+ *
+ * For accessibility the dialog must have an accessible name. Provide it either by rendering a
+ * `<Heading slot="title">` inside `children`, or by passing an `aria-label`. Without one of these
+ * React Aria logs a warning.
+ */
+const Dialog = ({ children, className, noCloseButton, ...rest }: DialogProps) => {
+  const { t } = useTranslation('account')
+
+  return (
+    <AriaDialog {...rest} className={cn('outline-0', className)}>
+      {(renderProps) => (
+        <>
+          {noCloseButton ? null : (
+            <Button
+              variant="icon-wrapped-negative-margin"
+              icon={<Icon name="close" className="size-6" />}
+              aria-label={t('Modal.aria.close')}
+              onPress={renderProps.close}
+              data-cy="close-modal"
+              className="absolute top-3 right-3 md:top-4 md:right-4"
+            />
+          )}
+          {typeof children === 'function' ? children(renderProps) : children}
+        </>
+      )}
+    </AriaDialog>
+  )
+}
+
+export default Dialog

--- a/next/src/components/simple-components/Dialog.tsx
+++ b/next/src/components/simple-components/Dialog.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@bratislava/component-library'
 import { useTranslation } from 'next-i18next/pages'
-import { Dialog as AriaDialog, DialogProps as AriaDialogProps } from 'react-aria-components/Dialog'
+import { Dialog as RACDialog, DialogProps as RACDialogProps } from 'react-aria-components/Dialog'
 
 import Icon from '@/src/components/icon-components/Icon'
 import cn from '@/src/utils/cn'
 
-export type DialogProps = AriaDialogProps & {
+export type DialogProps = RACDialogProps & {
   noCloseButton?: boolean
 }
 
@@ -23,7 +23,7 @@ const Dialog = ({ children, className, noCloseButton, ...rest }: DialogProps) =>
   const { t } = useTranslation('account')
 
   return (
-    <AriaDialog {...rest} className={cn('outline-0', className)}>
+    <RACDialog {...rest} className={cn('outline-0', className)}>
       {(renderProps) => (
         <>
           {noCloseButton ? null : (
@@ -39,7 +39,7 @@ const Dialog = ({ children, className, noCloseButton, ...rest }: DialogProps) =>
           {typeof children === 'function' ? children(renderProps) : children}
         </>
       )}
-    </AriaDialog>
+    </RACDialog>
   )
 }
 

--- a/next/src/components/simple-components/Modal.tsx
+++ b/next/src/components/simple-components/Modal.tsx
@@ -1,19 +1,18 @@
-import { Button } from '@bratislava/component-library'
-import { useTranslation } from 'next-i18next/pages'
 import React, { PropsWithChildren } from 'react'
 import { mergeProps } from 'react-aria/mergeProps'
-import { Dialog } from 'react-aria-components/Dialog'
-import { Modal as AriaModal, ModalOverlay, ModalOverlayProps } from 'react-aria-components/Modal'
+import {
+  Modal as RACModal,
+  ModalOverlay as RACModalOverlay,
+  ModalOverlayProps,
+} from 'react-aria-components/Modal'
 
 import { useIframeResizerChildContext } from '@/src/components/forms/IframeResizerChild'
-import Icon from '@/src/components/icon-components/Icon'
 import cn from '@/src/utils/cn'
 
 export type ModalProps = Omit<ModalOverlayProps, 'className'> & {
   modalClassname?: string
   modalOverlayClassname?: string
   mobileFullScreen?: boolean
-  noCloseButton?: boolean
   dataCy?: string
 } & PropsWithChildren
 
@@ -55,32 +54,37 @@ const ModalInIframeResizerWrapper = ({ children }: PropsWithChildren) => {
   )
 }
 
+/**
+ * A modal is an overlay element which blocks interaction with elements outside it.
+ *
+ * Docs: https://react-spectrum.adobe.com/react-aria/Modal.html
+ *
+ * This component only provides the overlay. It must be combined with a `Dialog` to create a fully
+ * accessible modal dialog. Overlay props such as `isDismissable`, `isOpen` and `onOpenChange`
+ * belong on the `ModalOverlay`, never on the inner `Modal`.
+ */
 const Modal = ({
   children,
   modalClassname,
   modalOverlayClassname,
   mobileFullScreen,
-  noCloseButton,
   dataCy,
   ...rest
 }: ModalProps) => {
-  const { t } = useTranslation('account')
-
   // Makes `{ isDismissable: true }` default.
-  const modalProps = mergeProps({ isDismissable: true }, rest)
+  const modalOverlayProps = mergeProps({ isDismissable: true }, rest)
 
   return (
-    <ModalOverlay
+    <RACModalOverlay
       className={cn(
         'fixed top-0 left-0 z-50 flex h-(--visual-viewport-height) w-screen items-center justify-center bg-gray-800/40 pt-(--modal-offset-x)',
         modalOverlayClassname,
       )}
-      {...modalProps}
+      {...modalOverlayProps}
     >
       <ModalInIframeResizerWrapper>
-        <AriaModal
+        <RACModal
           data-cy={dataCy}
-          {...modalProps}
           className={cn(
             'relative overflow-auto bg-gray-0 px-4 outline-0 md:mx-4 md:h-min md:max-h-full md:max-w-[592px] md:rounded-2xl md:p-6',
             mobileFullScreen
@@ -89,26 +93,10 @@ const Modal = ({
             modalClassname,
           )}
         >
-          <Dialog className="outline-0">
-            {({ close }) => (
-              <>
-                {noCloseButton ? null : (
-                  <Button
-                    variant="icon-wrapped-negative-margin"
-                    icon={<Icon name="close" className="size-6" />}
-                    aria-label={t('Modal.aria.close')}
-                    onPress={close}
-                    data-cy="close-modal"
-                    className="absolute top-3 right-3 md:top-4 md:right-4"
-                  />
-                )}
-                {children}
-              </>
-            )}
-          </Dialog>
-        </AriaModal>
+          {children}
+        </RACModal>
       </ModalInIframeResizerWrapper>
-    </ModalOverlay>
+    </RACModalOverlay>
   )
 }
 

--- a/next/src/components/styleguide/showcases/ModalShowCase/BaseModalsShowcase.tsx
+++ b/next/src/components/styleguide/showcases/ModalShowCase/BaseModalsShowcase.tsx
@@ -32,7 +32,7 @@ const BaseModalsShowcase = () => {
       <Modal isOpen={simpleModal} onOpenChange={setSimpleModalOpen} modalClassname="max-w-[700px]">
         <Dialog>
           <div className="flex flex-col gap-4">
-            <Heading slot="title" className="text-size-h3-r lg:text-size-h3">
+            <Heading slot="title" className="text-size-h3-r font-semibold lg:text-size-h3">
               Simple Modal Example
             </Heading>
             <div className="flex flex-col gap-4">

--- a/next/src/components/styleguide/showcases/ModalShowCase/BaseModalsShowcase.tsx
+++ b/next/src/components/styleguide/showcases/ModalShowCase/BaseModalsShowcase.tsx
@@ -2,7 +2,9 @@
 
 import { Button, Typography } from '@bratislava/component-library'
 import { useState } from 'react'
+import { Heading } from 'react-aria-components/Heading'
 
+import Dialog from '@/src/components/simple-components/Dialog'
 import Modal from '@/src/components/simple-components/Modal'
 import { Stack } from '@/src/components/styleguide/Stack'
 import { Wrapper } from '@/src/components/styleguide/Wrapper'
@@ -28,26 +30,28 @@ const BaseModalsShowcase = () => {
       </Stack>
 
       <Modal isOpen={simpleModal} onOpenChange={setSimpleModalOpen} modalClassname="max-w-[700px]">
-        <div className="flex flex-col gap-4">
-          <Typography variant="h3" as="h2">
-            Simple Modal Example
-          </Typography>
+        <Dialog>
           <div className="flex flex-col gap-4">
-            <div className="flex w-full items-center justify-center rounded-lg bg-background-passive-primary p-4">
-              Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
-              has been the industry&apos;s standard dummy text ever since the 1500s, when an unknown
-              printer took a galley of type and scrambled it to make a type specimen book.
-            </div>
-            <div className="mt-2 flex justify-between">
-              <Button variant="outline" onPress={() => setSimpleModalOpen(false)}>
-                Cancel
-              </Button>
-              <Button variant="solid" onPress={() => setSimpleModalOpen(false)}>
-                Submit
-              </Button>
+            <Heading slot="title" className="text-size-h3-r lg:text-size-h3">
+              Simple Modal Example
+            </Heading>
+            <div className="flex flex-col gap-4">
+              <div className="flex w-full items-center justify-center rounded-lg bg-background-passive-primary p-4">
+                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                Ipsum has been the industry&apos;s standard dummy text ever since the 1500s, when an
+                unknown printer took a galley of type and scrambled it to make a type specimen book.
+              </div>
+              <div className="mt-2 flex justify-between">
+                <Button variant="outline" onPress={() => setSimpleModalOpen(false)}>
+                  Cancel
+                </Button>
+                <Button variant="solid" onPress={() => setSimpleModalOpen(false)}>
+                  Submit
+                </Button>
+              </div>
             </div>
           </div>
-        </div>
+        </Dialog>
       </Modal>
 
       <MessageModal

--- a/next/src/components/widget-components/Modals/MessageModal.tsx
+++ b/next/src/components/widget-components/Modals/MessageModal.tsx
@@ -1,7 +1,8 @@
-import { Typography } from '@bratislava/component-library'
 import { PropsWithChildren, ReactNode } from 'react'
+import { Heading } from 'react-aria-components/Heading'
 
 import Icon from '@/src/components/icon-components/Icon'
+import Dialog from '@/src/components/simple-components/Dialog'
 import Modal, { ModalProps } from '@/src/components/simple-components/Modal'
 import cn from '@/src/utils/cn'
 
@@ -10,11 +11,9 @@ export type MessageModalProps = PropsWithChildren<{
   title: string
   primaryButton?: ReactNode
   secondaryButton?: ReactNode
+  noCloseButton?: boolean
 }> &
-  Pick<
-    ModalProps,
-    'isOpen' | 'onOpenChange' | 'isDismissable' | 'noCloseButton' | 'mobileFullScreen' | 'dataCy'
-  >
+  Pick<ModalProps, 'isOpen' | 'onOpenChange' | 'isDismissable' | 'mobileFullScreen' | 'dataCy'>
 
 // TODO: remove these
 const icons = {
@@ -34,36 +33,43 @@ const MessageModal = ({
   title,
   primaryButton,
   secondaryButton,
+  noCloseButton,
   ...rest
 }: MessageModalProps) => {
   return (
     <Modal isDismissable {...rest}>
-      <div className="flex flex-col items-center gap-4 lg:gap-6">
-        <div
-          className={cn('rounded-full p-4 *:size-6', {
-            'bg-background-passive-secondary': type === 'info',
-            'bg-background-warning-soft-default': type === 'warning',
-            'bg-background-error-soft-default': type === 'error',
-            'bg-background-success-soft-default': type === 'success',
-          })}
-        >
-          {icons[type]}
-        </div>
-        <div className="flex w-full flex-col gap-5 lg:gap-6">
-          <div className="flex flex-col gap-2">
-            <Typography variant="h5" as="p" className="w-full text-center font-semibold">
-              {title}
-            </Typography>
-            <div className="flex w-full flex-col gap-4 text-center text-size-p-small-r whitespace-pre-wrap lg:text-size-p-small">
-              {children}
+      <Dialog noCloseButton={noCloseButton}>
+        <div className="flex flex-col items-center gap-4 lg:gap-6">
+          <div
+            className={cn('rounded-full p-4 *:size-6', {
+              'bg-background-passive-secondary': type === 'info',
+              'bg-background-warning-soft-default': type === 'warning',
+              'bg-background-error-soft-default': type === 'error',
+              'bg-background-success-soft-default': type === 'success',
+            })}
+          >
+            {icons[type]}
+          </div>
+          <div className="flex w-full flex-col gap-5 lg:gap-6">
+            <div className="flex flex-col gap-2">
+              {/* Accessible heading */}
+              <Heading
+                slot="title"
+                className="w-full text-center text-size-h5-r font-semibold lg:text-size-h5"
+              >
+                {title}
+              </Heading>
+              <div className="flex w-full flex-col gap-4 text-center text-size-p-small-r whitespace-pre-wrap lg:text-size-p-small">
+                {children}
+              </div>
+            </div>
+            <div className="flex flex-col-reverse gap-3 *:w-full empty:hidden lg:flex-row">
+              {secondaryButton}
+              {primaryButton}
             </div>
           </div>
-          <div className="flex flex-col-reverse gap-3 *:w-full empty:hidden lg:flex-row">
-            {secondaryButton}
-            {primaryButton}
-          </div>
         </div>
-      </div>
+      </Dialog>
     </Modal>
   )
 }


### PR DESCRIPTION
- split Dialog and Modal into separate components, as it is in bratislava.sk
- make sure all dialogs have accessible title

Notes:
- I think it's better to have them split, because they also have separate props. And it's easier to orient in custom modals such as StepperView and so. So I followed the approach from bratislava.sk

- Dialog titles must be rendered as Heading with slot="title" to be properly linked. WE can discuss if slot prop and Heading should be used directly in Typography. Now I used Heading with custom styling.