### PR TITLE
1558 Implement replyTo email header option

### DIFF
--- a/forms-shared/src/definitions/formDefinitionTypes.ts
+++ b/forms-shared/src/definitions/formDefinitionTypes.ts
@@ -100,6 +100,7 @@ export type FormDefinitionEmail = FormDefinitionBase & {
     fromAddress: { test: string; prod: string }
     newSubmissionTemplate: MailgunTemplateEnum
     userResponseTemplate: MailgunTemplateEnum
+    replyToAddress?: { test: string; prod: string }
     sendJsonDataAttachmentInTechnicalMail?: boolean
     extractEmail?: SchemalessFormDataExtractor<any>
     extractName?: SchemalessFormDataExtractor<any>

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -733,6 +733,10 @@ export const formDefinitions: FormDefinition[] = [
       extractName: kontaktnyFormularPaasExtractName,
       mailer: 'mailgun',
       userResponseTemplate: MailgunTemplateEnum.PAAS_CONTACT_FORM_SENT_SUCCESS,
+      replyToAddress: {
+        prod: 'paas@bratislava.sk',
+        test: 'inovacie.bratislava@gmail.com',
+      },
       newSubmissionTemplate: MailgunTemplateEnum.BRATISLAVA_NEW_SUBMISSION,
       technicalEmailSubjectAppendId: true,
     },

--- a/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
+++ b/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
@@ -240,6 +240,9 @@ export default class EmailFormsService {
           },
         },
         emailFrom: this.resolveAddress(formDefinition.email.fromAddress),
+        replyTo: formDefinition.email.replyToAddress
+          ? this.resolveAddress(formDefinition.email.replyToAddress)
+          : undefined,
         attachments,
       })
     } catch (error) {

--- a/nest-forms-backend/src/utils/global-services/mailer/mailer.interface.ts
+++ b/nest-forms-backend/src/utils/global-services/mailer/mailer.interface.ts
@@ -5,6 +5,7 @@ import { SendEmailInputDto } from '../../global-dtos/mailgun.dto'
 export interface MailerSendEmailParams {
   data: SendEmailInputDto
   emailFrom?: string
+  replyTo?: string
   subject?: string
   attachments?: { filename: string; content: Buffer | Readable }[]
 }

--- a/nest-forms-backend/src/utils/global-services/mailer/mailgun.service.ts
+++ b/nest-forms-backend/src/utils/global-services/mailer/mailgun.service.ts
@@ -54,7 +54,7 @@ export default class MailgunService implements Mailer {
   }
 
   async sendEmail(params: MailerSendEmailParams): Promise<void> {
-    const { data, emailFrom, attachments, subject } = params
+    const { data, emailFrom, replyTo, attachments, subject } = params
     const mailgunAttachments = attachments?.map((attachment) => ({
       data: attachment.content,
       filename: attachment.filename,
@@ -86,6 +86,7 @@ export default class MailgunService implements Mailer {
           to: data.to,
           subject: subject ?? MAILGUN_CONFIG[data.template].subject,
           attachment: mailgunAttachments,
+          ...(replyTo ? { 'h:Reply-To': replyTo } : {}),
           ...emailContent,
         },
       )

--- a/nest-forms-backend/src/utils/global-services/mailer/olo-mailer.service.ts
+++ b/nest-forms-backend/src/utils/global-services/mailer/olo-mailer.service.ts
@@ -47,6 +47,7 @@ export default class OloMailerService implements Mailer {
    * @param attachments Optional array of attachments to be sent with the email.
    */
   async sendEmail(params: MailerSendEmailParams): Promise<void> {
+    // TODO implement replyTo when needed
     const { data, emailFrom, attachments, subject } = params
     try {
       const mailBody = await this.mailgunHelper.getFilledTemplate(
@@ -56,6 +57,7 @@ export default class OloMailerService implements Mailer {
       await this.oloTransporter.sendMail({
         from: `OLO <${emailFrom}>`,
         to: data.to,
+        // replyTo,
         subject: subject ?? MAILGUN_CONFIG[data.template].subject,
         html: mailBody,
         attachments,

--- a/nest-forms-backend/src/utils/global-services/mailer/olo-mailer.service.ts
+++ b/nest-forms-backend/src/utils/global-services/mailer/olo-mailer.service.ts
@@ -47,8 +47,7 @@ export default class OloMailerService implements Mailer {
    * @param attachments Optional array of attachments to be sent with the email.
    */
   async sendEmail(params: MailerSendEmailParams): Promise<void> {
-    // TODO implement replyTo when needed
-    const { data, emailFrom, attachments, subject } = params
+    const { data, emailFrom, replyTo, attachments, subject } = params
     try {
       const mailBody = await this.mailgunHelper.getFilledTemplate(
         MAILGUN_CONFIG[data.template].template,
@@ -57,7 +56,7 @@ export default class OloMailerService implements Mailer {
       await this.oloTransporter.sendMail({
         from: `OLO <${emailFrom}>`,
         to: data.to,
-        // replyTo,
+        replyTo,
         subject: subject ?? MAILGUN_CONFIG[data.template].subject,
         html: mailBody,
         attachments,


### PR DESCRIPTION
## Changes

Add optional `replyToAddress` to email form definitions. When set, the user confirmation email includes a `Reply-To` header, resolved per environment via `resolveAddress` (same `{ test, prod }` shape as `fromAddress`).

- `replyToAddress?: { test, prod }` on `FormDefinitionEmail`
- Wired into Mailgun mailer (`h:Reply-To`) ad OLO (`replyTo`) mailer via `MailerSendEmailParams.replyTo` 
- Set `replyToAddress` for PAAS contact form (`paas@bratislava.sk`)

Closes https://github.com/bratislava/private-konto.bratislava.sk/issues/1558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
