### PR TITLE
1570 Add option to reply to extracted user email

### DIFF
--- a/forms-shared/src/definitions/formDefinitionTypes.ts
+++ b/forms-shared/src/definitions/formDefinitionTypes.ts
@@ -101,16 +101,24 @@ export type FormDefinitionEmail = FormDefinitionBase & {
     newSubmissionTemplate: MailgunTemplateEnum
     userResponseTemplate: MailgunTemplateEnum
     replyToAddress?: { test: string; prod: string }
-    /**
-     * When true, the technical (organization) email's reply-to is set to the user's email
-     * extracted via `extractEmail`, so admin replies go to the submitter instead of Konto.
-     */
-    technicalEmailReplyToExtractedEmail?: boolean
     sendJsonDataAttachmentInTechnicalMail?: boolean
-    extractEmail?: SchemalessFormDataExtractor<any>
     extractName?: SchemalessFormDataExtractor<any>
     technicalEmailSubjectAppendId?: boolean
-  }
+  } & (
+    | {
+        /**
+         * When true, the technical (organization) email's reply-to is set to the user's email
+         * extracted via `extractEmail`, so admin replies go to the submitter instead of Konto.
+         * Requires `extractEmail` to be set.
+         */
+        technicalEmailReplyToExtractedEmail: true
+        extractEmail: SchemalessFormDataExtractor<any>
+      }
+    | {
+        technicalEmailReplyToExtractedEmail?: false
+        extractEmail?: SchemalessFormDataExtractor<any>
+      }
+  )
 }
 
 export type FormDefinition =

--- a/forms-shared/src/definitions/formDefinitionTypes.ts
+++ b/forms-shared/src/definitions/formDefinitionTypes.ts
@@ -121,6 +121,10 @@ export type FormDefinitionEmail = FormDefinitionBase & {
   )
 }
 
+export type FormDefinitionEmailWithExtractEmail = FormDefinitionEmail & {
+  email: { extractEmail: SchemalessFormDataExtractor<any> }
+}
+
 export type FormDefinition =
   | FormDefinitionSlovenskoSkGeneric
   | FormDefinitionSlovenskoSkTax
@@ -150,3 +154,12 @@ export const isEmailFormDefinition = (
 export const isWebhookFormDefinition = (
   formDefinition: FormDefinition,
 ): formDefinition is FormDefinitionWebhook => formDefinition.type === FormDefinitionType.Webhook
+
+/**
+ * When `technicalEmailReplyToExtractedEmail` is `true`, the type guarantees `extractEmail` is set,
+ * so the narrowed definition can be passed where a defined `extractEmail` is required.
+ */
+export const isFormDefinitionWithReplyToAndExtractEmail = (
+  formDefinition: FormDefinitionEmail,
+): formDefinition is FormDefinitionEmailWithExtractEmail =>
+  formDefinition.email.technicalEmailReplyToExtractedEmail === true

--- a/forms-shared/src/definitions/formDefinitionTypes.ts
+++ b/forms-shared/src/definitions/formDefinitionTypes.ts
@@ -101,6 +101,11 @@ export type FormDefinitionEmail = FormDefinitionBase & {
     newSubmissionTemplate: MailgunTemplateEnum
     userResponseTemplate: MailgunTemplateEnum
     replyToAddress?: { test: string; prod: string }
+    /**
+     * When true, the technical (organization) email's reply-to is set to the user's email
+     * extracted via `extractEmail`, so admin replies go to the submitter instead of Konto.
+     */
+    technicalEmailReplyToExtractedEmail?: boolean
     sendJsonDataAttachmentInTechnicalMail?: boolean
     extractEmail?: SchemalessFormDataExtractor<any>
     extractName?: SchemalessFormDataExtractor<any>

--- a/forms-shared/src/definitions/formDefinitionTypes.ts
+++ b/forms-shared/src/definitions/formDefinitionTypes.ts
@@ -107,16 +107,18 @@ export type FormDefinitionEmail = FormDefinitionBase & {
   } & (
     | {
         /**
-         * When true, the technical (organization) email's reply-to is set to the user's email
-         * extracted via `extractEmail`, so admin replies go to the submitter instead of Konto.
-         * Requires `extractEmail` to be set.
+         * When extractEmail is provided, there is an option to enable reply-to header on technical
+         * email to be set to extracted email, so admin replies go to the submitter instead of Konto.
          */
-        technicalEmailReplyToExtractedEmail: true
         extractEmail: SchemalessFormDataExtractor<any>
+        technicalEmailReplyToExtractedEmail?: boolean
       }
     | {
-        technicalEmailReplyToExtractedEmail?: false
-        extractEmail?: SchemalessFormDataExtractor<any>
+        /**
+         * When extractEmail is not provided, technicalEmailReplyToExtractedEmail CANNOT be provided
+         */
+        extractEmail?: never
+        technicalEmailReplyToExtractedEmail?: never
       }
   )
 }

--- a/forms-shared/src/definitions/formDefinitions.ts
+++ b/forms-shared/src/definitions/formDefinitions.ts
@@ -739,6 +739,7 @@ export const formDefinitions: FormDefinition[] = [
       },
       newSubmissionTemplate: MailgunTemplateEnum.BRATISLAVA_NEW_SUBMISSION,
       technicalEmailSubjectAppendId: true,
+      technicalEmailReplyToExtractedEmail: true,
     },
     termsAndConditions: generalTermsAndConditions,
   },

--- a/forms-shared/src/form-utils/formDataExtractors.ts
+++ b/forms-shared/src/form-utils/formDataExtractors.ts
@@ -1,4 +1,8 @@
-import { FormDefinition, FormDefinitionEmail } from '../definitions/formDefinitionTypes'
+import {
+  FormDefinition,
+  FormDefinitionEmail,
+  FormDefinitionEmailWithExtractEmail,
+} from '../definitions/formDefinitionTypes'
 import type { GenericObjectType } from '@rjsf/utils' with {
   'resolution-mode': 'import',
 }
@@ -29,10 +33,18 @@ export const extractFormSubjectTechnical = (
   return evaluateFormDataExtractor(extractTechnicalSubjectFn, formData)
 }
 
-export const extractEmailFormEmail = (
+export function extractEmailFormEmail(
+  formDefinition: FormDefinitionEmailWithExtractEmail,
+  formData: GenericObjectType,
+): string
+export function extractEmailFormEmail(
   formDefinition: FormDefinitionEmail,
   formData: GenericObjectType,
-) => {
+): string | undefined
+export function extractEmailFormEmail(
+  formDefinition: FormDefinitionEmail,
+  formData: GenericObjectType,
+) {
   const extractEmail = formDefinition.email.extractEmail
   if (!extractEmail) {
     return undefined

--- a/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
+++ b/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
@@ -339,7 +339,7 @@ export default class EmailFormsService {
       },
       emailFrom: this.resolveAddress(formDefinition.email.fromAddress),
       replyTo: formDefinition.email.technicalEmailReplyToExtractedEmail
-        ? (extractEmailFormEmail(formDefinition, form.formDataJson) ?? undefined)
+        ? extractEmailFormEmail(formDefinition, form.formDataJson)
         : undefined,
       attachments: formDefinition.email.sendJsonDataAttachmentInTechnicalMail
         ? this.createJsonAttachment(

--- a/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
+++ b/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
@@ -7,6 +7,7 @@ import type { GenericObjectType } from '@rjsf/utils' with {
 import {
   FormDefinitionEmail,
   FormDefinitionType,
+  isReplyToExtractedEmailFormDefinition,
 } from 'forms-shared/definitions/formDefinitionTypes'
 import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinitionBySlug'
 import {
@@ -338,7 +339,7 @@ export default class EmailFormsService {
         },
       },
       emailFrom: this.resolveAddress(formDefinition.email.fromAddress),
-      replyTo: formDefinition.email.technicalEmailReplyToExtractedEmail
+      replyTo: isReplyToExtractedEmailFormDefinition(formDefinition)
         ? extractEmailFormEmail(formDefinition, form.formDataJson)
         : undefined,
       attachments: formDefinition.email.sendJsonDataAttachmentInTechnicalMail

--- a/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
+++ b/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
@@ -338,6 +338,9 @@ export default class EmailFormsService {
         },
       },
       emailFrom: this.resolveAddress(formDefinition.email.fromAddress),
+      replyTo: formDefinition.email.technicalEmailReplyToExtractedEmail
+        ? (extractEmailFormEmail(formDefinition, form.formDataJson) ?? undefined)
+        : undefined,
       attachments: formDefinition.email.sendJsonDataAttachmentInTechnicalMail
         ? this.createJsonAttachment(
             formId,

--- a/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
+++ b/nest-forms-backend/src/form-delivery-consumer/services/email-forms.service.ts
@@ -7,7 +7,7 @@ import type { GenericObjectType } from '@rjsf/utils' with {
 import {
   FormDefinitionEmail,
   FormDefinitionType,
-  isReplyToExtractedEmailFormDefinition,
+  isFormDefinitionWithReplyToAndExtractEmail,
 } from 'forms-shared/definitions/formDefinitionTypes'
 import { getFormDefinitionBySlug } from 'forms-shared/definitions/getFormDefinitionBySlug'
 import {
@@ -339,7 +339,7 @@ export default class EmailFormsService {
         },
       },
       emailFrom: this.resolveAddress(formDefinition.email.fromAddress),
-      replyTo: isReplyToExtractedEmailFormDefinition(formDefinition)
+      replyTo: isFormDefinitionWithReplyToAndExtractEmail(formDefinition)
         ? extractEmailFormEmail(formDefinition, form.formDataJson)
         : undefined,
       attachments: formDefinition.email.sendJsonDataAttachmentInTechnicalMail


### PR DESCRIPTION
Add option, to enable replying to user's extracted email, in technical emails.

Reason: When we send the technical email to a ticketing portal, the customer service team want to reply to the user, who sent the form, not Konto.