### PR TITLE
1579: active installment not calculating correctly when after due date

### DIFF
--- a/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
+++ b/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
@@ -2089,6 +2089,46 @@ describe('getTaxDetailPureForInstallmentGenerator', () => {
       ),
     )
   })
+
+  it('should generate payment for first installment when its due date has passed and it is not yet paid', () => {
+    // dateOfValidity 2025-01-01 + 15 days = 2025-01-16; today 2025-01-20 is after that
+    // - installment 1 becomes AFTER_DUE_DATE; the generator must still charge installment 1
+    const options = {
+      ...baseOptionsRealEstate,
+      today: new Date('2025-01-20'),
+      taxPayments: [],
+    }
+
+    const output = getTaxDetailPureForInstallmentGenerator(options)
+
+    expect(output).toEqual({
+      amount: 2201,
+      taxId: 123,
+      description: 'Platba 1. splatky za dane pre BA s id dane 123',
+      taxType: TaxType.DZN,
+    })
+  })
+
+  it('should generate payment for remaining 1 cent of first installment when its due date has passed and it was partially paid', () => {
+    // Reproduces the exact user-reported scenario:
+    // installment 1 = 2201, paid = 2200 (1 cent short), due date already passed
+    // - installment 1 is AFTER_DUE_DATE with remainingAmount = 1
+    // - generator must charge 1 cent with "zostatku" description, not skip to installment 2
+    const options = {
+      ...baseOptionsRealEstate,
+      today: new Date('2025-01-20'),
+      taxPayments: [{ amount: 2200, status: PaymentStatus.SUCCESS }],
+    }
+
+    const output = getTaxDetailPureForInstallmentGenerator(options)
+
+    expect(output).toEqual({
+      amount: 1,
+      taxId: 123,
+      description: 'Platba zostatku 1. splatky za dane pre BA s id dane 123',
+      taxType: TaxType.DZN,
+    })
+  })
 })
 
 describe('getTaxDetailPureForOneTimeGenerator', () => {

--- a/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
+++ b/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
@@ -2113,7 +2113,7 @@ describe('getTaxDetailPureForInstallmentGenerator', () => {
     // Reproduces the exact user-reported scenario:
     // installment 1 = 2201, paid = 2200 (1 cent short), due date already passed
     // - installment 1 is AFTER_DUE_DATE with remainingAmount = 1
-    // - generator must charge 1 cent with "zostatku" description, not skip to installment 2
+    // - generator must charge 1 cent with "platba zostatku" description, not skip to installment 2
     const options = {
       ...baseOptionsRealEstate,
       today: new Date('2025-01-20'),

--- a/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
+++ b/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
@@ -2129,6 +2129,45 @@ describe('getTaxDetailPureForInstallmentGenerator', () => {
       taxType: TaxType.DZN,
     })
   })
+
+  it('should charge the oldest installment when multiple installments are past due date and none are paid', () => {
+    // today 2025-09-20 is after both installment 1 due date (2025-01-16) and
+    // installment 2 NORIS due date (2025-08-31), but before installment 3 (2025-10-31)
+    // - installments 1 and 2 are both AFTER_DUE_DATE; generator must charge installment 1
+    const options = {
+      ...baseOptionsRealEstate,
+      today: new Date('2025-09-20'),
+      taxPayments: [],
+    }
+
+    const output = getTaxDetailPureForInstallmentGenerator(options)
+
+    expect(output).toEqual({
+      amount: 2201,
+      taxId: 123,
+      description: 'Platba 1. splatky za dane pre BA s id dane 123',
+      taxType: TaxType.DZN,
+    })
+  })
+
+  it('should charge the remainder of the oldest installment when multiple installments are past due date and the oldest is partially paid', () => {
+    // today 2025-09-20: installments 1 and 2 are both AFTER_DUE_DATE
+    // installment 1 has 1 cent remaining; generator must charge that 1 cent, not installment 2
+    const options = {
+      ...baseOptionsRealEstate,
+      today: new Date('2025-09-20'),
+      taxPayments: [{ amount: 2200, status: PaymentStatus.SUCCESS }],
+    }
+
+    const output = getTaxDetailPureForInstallmentGenerator(options)
+
+    expect(output).toEqual({
+      amount: 1,
+      taxId: 123,
+      description: 'Platba zostatku 1. splatky za dane pre BA s id dane 123',
+      taxType: TaxType.DZN,
+    })
+  })
 })
 
 describe('getTaxDetailPureForOneTimeGenerator', () => {

--- a/nest-tax-backend/src/tax/utils/unified-tax.util.ts
+++ b/nest-tax-backend/src/tax/utils/unified-tax.util.ts
@@ -389,6 +389,16 @@ const calculateInstallmentStatus = (
 export const parseInstallmentDueDate = (dueDate: Date): Dayjs =>
   dayjs.tz(dueDate, bratislavaTimeZone)
 
+const findActiveInstallment = (
+  installments: ResponseInstallmentItemDto[],
+): ResponseInstallmentItemDto | undefined =>
+  installments.find(
+    (installment) =>
+      installment.status === InstallmentPaidStatusEnum.NOT_PAID ||
+      installment.status === InstallmentPaidStatusEnum.PARTIALLY_PAID ||
+      installment.status === InstallmentPaidStatusEnum.AFTER_DUE_DATE,
+  )
+
 const calculateInstallmentPaymentDetails = (options: {
   overallAmount: number
   overallPaid: number
@@ -499,12 +509,7 @@ const calculateInstallmentPaymentDetails = (options: {
       totalInstallmentAmount: installmentAmounts[index].total,
     }))
 
-  const active = installmentDetails.find(
-    (installment) =>
-      installment.status === InstallmentPaidStatusEnum.NOT_PAID ||
-      installment.status === InstallmentPaidStatusEnum.PARTIALLY_PAID ||
-      installment.status === InstallmentPaidStatusEnum.AFTER_DUE_DATE,
-  )
+  const active = findActiveInstallment(installmentDetails)
 
   // All valid reasons for no active payment should have been caught before
   //  the ` calculateInstallmentAmounts ` call
@@ -807,11 +812,8 @@ export const getTaxDetailPureForInstallmentGenerator = (options: {
   }
 
   // Find the active installment details
-  const activeInstallmentInfo = installmentPayment.installments.find(
-    (installment) =>
-      installment.status === InstallmentPaidStatusEnum.NOT_PAID ||
-      installment.status === InstallmentPaidStatusEnum.PARTIALLY_PAID ||
-      installment.status === InstallmentPaidStatusEnum.AFTER_DUE_DATE,
+  const activeInstallmentInfo = findActiveInstallment(
+    installmentPayment.installments,
   )
 
   if (!activeInstallmentInfo) {

--- a/nest-tax-backend/src/tax/utils/unified-tax.util.ts
+++ b/nest-tax-backend/src/tax/utils/unified-tax.util.ts
@@ -810,7 +810,8 @@ export const getTaxDetailPureForInstallmentGenerator = (options: {
   const activeInstallmentInfo = installmentPayment.installments.find(
     (installment) =>
       installment.status === InstallmentPaidStatusEnum.NOT_PAID ||
-      installment.status === InstallmentPaidStatusEnum.PARTIALLY_PAID,
+      installment.status === InstallmentPaidStatusEnum.PARTIALLY_PAID ||
+      installment.status === InstallmentPaidStatusEnum.AFTER_DUE_DATE,
   )
 
   if (!activeInstallmentInfo) {
@@ -821,10 +822,15 @@ export const getTaxDetailPureForInstallmentGenerator = (options: {
   }
   // Create description based on the installment status
   // data that goes to payment gateway should not contain diacritics
-  const description =
-    activeInstallmentInfo.status === InstallmentPaidStatusEnum.PARTIALLY_PAID
-      ? `Platba zostatku ${activeInstallmentInfo.installmentNumber}. splatky za dane pre BA s id dane ${taxId}`
-      : `Platba ${activeInstallmentInfo.installmentNumber}. splatky za dane pre BA s id dane ${taxId}`
+  const isPartialPayment =
+    activeInstallmentInfo.status === InstallmentPaidStatusEnum.PARTIALLY_PAID ||
+    (activeInstallmentInfo.status ===
+      InstallmentPaidStatusEnum.AFTER_DUE_DATE &&
+      activeInstallmentInfo.remainingAmount <
+        activeInstallmentInfo.totalInstallmentAmount)
+  const description = isPartialPayment
+    ? `Platba zostatku ${activeInstallmentInfo.installmentNumber}. splatky za dane pre BA s id dane ${taxId}`
+    : `Platba ${activeInstallmentInfo.installmentNumber}. splatky za dane pre BA s id dane ${taxId}`
 
   return {
     amount: activeInstallmentInfo.remainingAmount,


### PR DESCRIPTION
# fix: charge correct installment amount when first installment is past due date

Resolves https://github.com/bratislava/private-konto.bratislava.sk/issues/1579

## Problem

A taxpayer pays their first installment by card a few days after its validity-based due date. Instead of being charged the first installment's amount, they are charged the second installment's amount. After paying, a 1-cent residual appears on the first installment. Clicking "pay installment" again shows the second installment (78 EUR) instead of the 1 cent.

### Root cause

`getTaxDetailPureForInstallmentGenerator` in `src/tax/utils/unified-tax.util.ts` searched for the active installment using only `NOT_PAID` and `PARTIALLY_PAID` statuses:

```typescript
// BEFORE (buggy)
const activeInstallmentInfo = installmentPayment.installments.find(
  (installment) =>
    installment.status === InstallmentPaidStatusEnum.NOT_PAID ||
    installment.status === InstallmentPaidStatusEnum.PARTIALLY_PAID,
    // ← AFTER_DUE_DATE was missing
)
```

`calculateInstallmentStatus` assigns `AFTER_DUE_DATE` to any unpaid installment whose due date has passed. Because the generator's `.find()` did not include `AFTER_DUE_DATE`, it silently skipped the first installment (overdue but unpaid/partially-paid) and charged the **second** installment's amount instead.

Notably, `calculateInstallmentPaymentDetails` - called earlier in the same function - **already had the correct search** (lines 502–507), including `AFTER_DUE_DATE`. The inconsistency between the two `.find()` calls was the entire bug.

### Concrete trace (from the reported case)

| Field | Value |
|---|---|
| Total | 23,575 cents (235.75 EUR) |
| Installment 1 | 7,859 cents, due 2026-05-05 |
| Installment 2 | 7,858 cents, due 2026-08-31 |
| Installment 3 | 7,858 cents, due 2026-10-31 |

The user clicked "pay installment by card" on **2026-05-07** - two days after installment 1's validity-based due date (2026-05-05 = createdAt 2026-04-20 + 15 working days).

`calculateInstallmentStatus` marked installment 1 as `AFTER_DUE_DATE`. The buggy `.find()` skipped it and returned installment 2 (7,858 cents). The user was charged **7,858** instead of **7,859** - 1 cent short.

Every subsequent "pay installment" click repeated the same mistake: installment 1 (now `AFTER_DUE_DATE` with 1 cent remaining) was skipped again, and the system showed 78 EUR (installment 2) instead of 1 cent. The user - correctly - refused to pay, generating three abandoned `NEW` payments of 7,858 cents (IDs 674793, 674795, 674822).

## Fix

**`src/tax/utils/unified-tax.util.ts`**

1. Add `AFTER_DUE_DATE` to the `.find()` so overdue installments are no longer skipped.
2. Fix the payment-gateway description: when the status is `AFTER_DUE_DATE` but the installment was partially paid (remaining < total), the description correctly says `"Platba zostatku X. splatky"` instead of the full-installment wording.

```typescript
// AFTER
const activeInstallmentInfo = installmentPayment.installments.find(
  (installment) =>
    installment.status === InstallmentPaidStatusEnum.NOT_PAID ||
    installment.status === InstallmentPaidStatusEnum.PARTIALLY_PAID ||
    installment.status === InstallmentPaidStatusEnum.AFTER_DUE_DATE,
)

const isPartialPayment =
  activeInstallmentInfo.status === InstallmentPaidStatusEnum.PARTIALLY_PAID ||
  (activeInstallmentInfo.status === InstallmentPaidStatusEnum.AFTER_DUE_DATE &&
    activeInstallmentInfo.remainingAmount <
      activeInstallmentInfo.totalInstallmentAmount)
const description = isPartialPayment
  ? `Platba zostatku ${activeInstallmentInfo.installmentNumber}. splatky...`
  : `Platba ${activeInstallmentInfo.installmentNumber}. splatky...`
```

## Tests added

Two new cases in `describe('getTaxDetailPureForInstallmentGenerator')` in `unified-tax.util.spec.ts`:

- **"should generate payment for first installment when its due date has passed and it is not yet paid"** - verifies that an overdue unpaid first installment is still charged correctly, not skipped in favour of installment 2.
- **"should generate payment for remaining 1 cent of first installment when its due date has passed and it was partially paid"** - directly reproduces the reported scenario: installment 1 partially paid (1 cent short), due date passed, expected charge = 1 cent with `"zostatku"` description.

Both tests use `dateOfValidity: 2025-01-01` and `today: 2025-01-20`, placing the validity-based due date (2025-01-16) in the past.

To check the former error I ran the tests on master, and they failed as expected:

```ts
  ● getTaxDetailPureForInstallmentGenerator › should generate payment for first installment when its due date has passed and it is not yet paid

    expect(received).toEqual(expected) // deep equality

    - Expected  - 2
    + Received  + 2

      Object {
    -   "amount": 2201,
    -   "description": "Platba 1. splatky za dane pre BA s id dane 123",
    +   "amount": 2200,
    +   "description": "Platba 2. splatky za dane pre BA s id dane 123",
        "taxId": 123,
        "taxType": "DZN",
      }

      2102 |     const output = getTaxDetailPureForInstallmentGenerator(options)
      2103 |
    > 2104 |     expect(output).toEqual({
           |                    ^
      2105 |       amount: 2201,
      2106 |       taxId: 123,
      2107 |       description: 'Platba 1. splatky za dane pre BA s id dane 123',

      at Object.<anonymous> (tax/utils/__tests__/unified-tax.util.spec.ts:2104:20)

  ● getTaxDetailPureForInstallmentGenerator › should generate payment for remaining 1 cent of first installment when its due date has passed and it was partially paid

    expect(received).toEqual(expected) // deep equality

    - Expected  - 2
    + Received  + 2

      Object {
    -   "amount": 1,
    -   "description": "Platba zostatku 1. splatky za dane pre BA s id dane 123",
    +   "amount": 2200,
    +   "description": "Platba 2. splatky za dane pre BA s id dane 123",
        "taxId": 123,
        "taxType": "DZN",
      }

      2123 |     const output = getTaxDetailPureForInstallmentGenerator(options)
      2124 |
    > 2125 |     expect(output).toEqual({
           |                    ^
      2126 |       amount: 1,
      2127 |       taxId: 123,
      2128 |       description: 'Platba zostatku 1. splatky za dane pre BA s id dane 123',

      at Object.<anonymous> (tax/utils/__tests__/unified-tax.util.spec.ts:2125:20)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 679 passed, 681 total
Snapshots:   0 total
Time:        16.964 s
Ran all test suites matching unified-tax.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)