### PR TITLE
1580 Update JWT token expiration to 4 minutes

### DIFF
--- a/nest-city-account/src/api-jwt-tokens/api-jwt-tokens.service.ts
+++ b/nest-city-account/src/api-jwt-tokens/api-jwt-tokens.service.ts
@@ -4,7 +4,7 @@ import { v1 as uuidv1 } from 'uuid'
 
 const defaultOptions: jwt.SignOptions = {
   algorithm: 'RS256',
-  expiresIn: '5m', // 5 minutes
+  expiresIn: '4m', // 4 minutes
 }
 
 /**
@@ -14,7 +14,7 @@ const defaultOptions: jwt.SignOptions = {
 @Injectable()
 export default class ApiJwtTokensService {
   /**
-   * Default options: RS256, 5-minute expiry.
+   * Default options: RS256, 4-minute expiry.
    * Header override (alg: RS256, cty: JWT) is always applied on top.
    * Pass `options` to override any of the defaults further.
    */
@@ -36,7 +36,7 @@ export default class ApiJwtTokensService {
   }
 
   /**
-   * Default options: RS256, 5-minute expiry.
+   * Default options: RS256, 4-minute expiry.
    * Pass `options` to override any of the defaults.
    */
   createTechnicalAccountJwtToken(

--- a/nest-forms-backend/src/api-jwt-tokens/api-jwt-tokens.service.ts
+++ b/nest-forms-backend/src/api-jwt-tokens/api-jwt-tokens.service.ts
@@ -4,7 +4,7 @@ import { v1 as uuidv1 } from 'uuid'
 
 const defaultOptions: jwt.SignOptions = {
   algorithm: 'RS256',
-  expiresIn: '5m', // 5 minutes
+  expiresIn: '4m', // 5 minutes
 }
 
 /**
@@ -14,7 +14,7 @@ const defaultOptions: jwt.SignOptions = {
 @Injectable()
 export default class ApiJwtTokensService {
   /**
-   * Default options: RS256, 5-minute expiry.
+   * Default options: RS256, 4-minute expiry.
    * Header override (alg: RS256, cty: JWT) is always applied on top.
    * Pass `options` to override any of the defaults further.
    */
@@ -40,7 +40,7 @@ export default class ApiJwtTokensService {
   }
 
   /**
-   * Default options: RS256, 5-minute expiry.
+   * Default options: RS256, 4-minute expiry.
    * Pass `options` to override any of the defaults.
    */
   createTechnicalAccountJwtToken(


### PR DESCRIPTION
JWT tokens were signed with exp set to exactly 5 minutes, matching the server's MAX_EXP_IN cap and leaving zero tolerance for clock skew.