### PR TITLE
Tie authRequestId transport to HTTP method in AuthRequestIdGuard

### DIFF
--- a/nest-city-account/src/oauth2/guards/auth-request-id.guard.ts
+++ b/nest-city-account/src/oauth2/guards/auth-request-id.guard.ts
@@ -35,8 +35,25 @@ export class AuthRequestIdGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<RequestWithAuthorizationData>()
 
-    // Support both POST (body.authRequestId) and GET (query.authRequestId)
-    const authRequestId = request.body?.authRequestId || request.query.authRequestId
+    // The transport is tied to the HTTP method: POST reads authRequestId from the
+    // body, GET reads it from the query. The guard is bound per-route, so only these
+    // declared methods can reach it; any other method is a routing/configuration bug,
+    // not a client error, so fail with an internal server error.
+    let authRequestId: unknown
+    if (request.method === 'POST') {
+      authRequestId = request.body?.authRequestId
+    } else if (request.method === 'GET') {
+      authRequestId = request.query.authRequestId
+    } else {
+      throw this.oAuth2ErrorThrower.authorizationException(
+        OAuth2AuthorizationErrorCode.SERVER_ERROR,
+        'Authorization server error',
+        undefined,
+        'AuthRequestIdGuard reached with unexpected HTTP method',
+        { method: request.method },
+        1
+      )
+    }
     if (!authRequestId || typeof authRequestId !== 'string') {
       throw this.oAuth2ErrorThrower.authorizationException(
         OAuth2AuthorizationErrorCode.SERVER_ERROR,


### PR DESCRIPTION
`AuthRequestIdGuard` previously accepted `authRequestId` from either transport (`body?.authRequestId || query.authRequestId`) regardless of HTTP method. This meant a POST could be driven by a query param and a GET by a body param.

This binds the transport to the method:

- **POST** -> `body.authRequestId`
- **GET** -> `query.authRequestId`
- **Any other method** -> unreachable past per-route guard binding (Nest 404/405s first), so it's treated as a routing/config bug and thrown as an OAuth `SERVER_ERROR` (with
  alert) rather than a misleading "missing authRequestId".

An `authRequestId` supplied in the wrong transport for the method is now ignored and rejected as missing.