### PR TITLE
Add tmp page for towing landing page without form

### DIFF
--- a/next/src/components/page-contents/MunicipalServicePageContent/MunicipalServicePageContent.tsx
+++ b/next/src/components/page-contents/MunicipalServicePageContent/MunicipalServicePageContent.tsx
@@ -1,0 +1,55 @@
+import { Typography } from '@bratislava/component-library'
+
+import { MunicipalServiceEntityFragment } from '@/src/clients/graphql-strapi/api'
+import SectionContainer from '@/src/components/layouts/SectionContainer'
+import Sections from '@/src/components/layouts/Sections'
+import { isDefined } from '@/src/frontend/utils/general'
+import cn from '@/src/utils/cn'
+
+/**
+ * Figma: https://www.figma.com/design/0VrrvwWs7n3T8YFzoHe92X/BK--Dizajn--DEV-?node-id=14475-7297
+ */
+
+export type MunicipalServicePageContentProps = {
+  municipalService: MunicipalServiceEntityFragment
+}
+
+const MunicipalServicePageContent = ({ municipalService }: MunicipalServicePageContentProps) => {
+  const filteredSections = municipalService.sections?.filter(isDefined) ?? []
+
+  return (
+    <>
+      {/* Header */}
+      <SectionContainer className="size-full bg-background-passive-primary py-6 lg:min-h-[120px] lg:py-12">
+        <div className="flex flex-col gap-2 lg:gap-4">
+          <Typography variant="h1">{municipalService.title}</Typography>
+          {/* TODO text and moreInfo link? */}
+        </div>
+      </SectionContainer>
+
+      {/* Sections & Sidebar */}
+      <div
+        key={municipalService.slug} // Helps to re-render table of contents on page change
+        className={cn(
+          'mx-auto flex w-full max-w-(--breakpoint-xl) flex-wrap-reverse px-4 py-8 lg:px-8 lg:py-12',
+        )}
+      >
+        <div
+          className={cn(
+            'w-full max-w-200',
+            '**:data-section-container-outer:not-first:pt-8',
+            '**:data-section-container-outer:not-first:lg:pt-12',
+            // In sidebar layout, horizontal padding is handled by parent wrapper (otherwise it is handled by sections)
+            '**:data-section-container-inner:px-0',
+            '**:data-section-container-inner:lg:px-0',
+          )}
+        >
+          <Sections sections={filteredSections} />
+        </div>
+        {/* TODO Sidebar goes here */}
+      </div>
+    </>
+  )
+}
+
+export default MunicipalServicePageContent

--- a/next/src/pages/mestske-sluzby/vyhladavanie-odtiahnutych-vozidiel.tsx
+++ b/next/src/pages/mestske-sluzby/vyhladavanie-odtiahnutych-vozidiel.tsx
@@ -1,0 +1,46 @@
+import { strapiClient } from '@/src/clients/graphql-strapi'
+import { GeneralQuery, MunicipalServiceEntityFragment } from '@/src/clients/graphql-strapi/api'
+import PageLayout from '@/src/components/layouts/PageLayout'
+import { GeneralContextProvider } from '@/src/components/logic/GeneralContextProvider'
+import { SsrAuthProviderHOC } from '@/src/components/logic/SsrAuthContext'
+import MunicipalServicePageContent from '@/src/components/page-contents/MunicipalServicePageContent/MunicipalServicePageContent'
+import { amplifyGetServerSideProps } from '@/src/frontend/utils/amplifyServer'
+import { slovakServerSideTranslations } from '@/src/frontend/utils/slovakServerSideTranslations'
+
+type Props = {
+  general: GeneralQuery
+  municipalService: MunicipalServiceEntityFragment
+}
+
+// This page is temporarily implemented with hardcoded slug, to be able to show Towing landing page, that does not have related form (form definition)
+// TODO Remove this hardcoded page, and use "municipal service" instead of "form landing page" for landing pages
+
+export const getServerSideProps = amplifyGetServerSideProps<Props>(async () => {
+  const [general, { municipalServices }] = await Promise.all([
+    strapiClient.General(),
+    strapiClient.MunicipalServiceBySlug({ slug: 'vyhladavanie-odtiahnutych-vozidiel' }),
+  ])
+
+  const municipalService = municipalServices[0]
+  if (!municipalService) {
+    return { notFound: true }
+  }
+
+  return {
+    props: {
+      general,
+      municipalService,
+      ...(await slovakServerSideTranslations()),
+    },
+  }
+}, {})
+
+const MunicipalServicesFormSplitPage = ({ general, ...props }: Props) => (
+  <GeneralContextProvider general={general}>
+    <PageLayout>
+      <MunicipalServicePageContent {...props} />
+    </PageLayout>
+  </GeneralContextProvider>
+)
+
+export default SsrAuthProviderHOC(MunicipalServicesFormSplitPage)


### PR DESCRIPTION
- add temporary page for hardcoded slug for towing landing page, that takes data from Municipal service strapi entry