### PR TITLE
ci: update deploy ref to mpinter/konto-deploy-dev-databases-v1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -287,7 +287,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/cvdmirror
-      dispatch_ref: mpinter/konto-deploy-dev-databases
+      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
 
   deploy-clamav:
     name: clamav
@@ -298,7 +298,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/clamav
-      dispatch_ref: mpinter/konto-deploy-dev-databases
+      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
 
   deploy-nest-clamav-scanner:
     name: nest-clamav-scanner
@@ -309,7 +309,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_clamav_scanner
-      dispatch_ref: mpinter/konto-deploy-dev-databases
+      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
 
   deploy-nest-forms-backend:
     name: nest-forms-backend
@@ -320,7 +320,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_forms_backend
-      dispatch_ref: mpinter/konto-deploy-dev-databases
+      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
 
   deploy-nest-tax-backend:
     name: nest-tax-backend
@@ -331,7 +331,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_tax_backend
-      dispatch_ref: mpinter/konto-deploy-dev-databases
+      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
 
   deploy-nest-city-account:
     name: nest-city-account
@@ -342,7 +342,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_city_account
-      dispatch_ref: mpinter/konto-deploy-dev-databases
+      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
 
   deploy-strapi:
     name: Strapi
@@ -353,7 +353,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/strapi
-      dispatch_ref: mpinter/konto-deploy-dev-databases
+      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
 
   deploy-next:
     name: after Backends deploy Next
@@ -375,7 +375,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/next
-      dispatch_ref: mpinter/konto-deploy-dev-databases
+      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
 
   check-openapi-clients:
     name: Check OpenAPI clients for changes


### PR DESCRIPTION
Update `dispatch_ref` from `mpinter/konto-deploy-dev-databases` to `mpinter/konto-deploy-dev-databases-v1` in deploy workflow.