### PR TITLE
1595 Use timing-safe comparison for auth secrets across backends

### DIFF
--- a/nest-city-account/src/auth/strategies/admin.strategy.ts
+++ b/nest-city-account/src/auth/strategies/admin.strategy.ts
@@ -1,9 +1,9 @@
-import { timingSafeEqual } from 'node:crypto'
-
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PassportStrategy } from '@nestjs/passport'
 import { HeaderAPIKeyStrategy } from 'passport-headerapikey'
+
+import { timingSafeStringEqual } from '../../utils/crypto'
 
 @Injectable()
 export class AdminStrategy extends PassportStrategy(HeaderAPIKeyStrategy, 'admin-strategy') {
@@ -14,17 +14,6 @@ export class AdminStrategy extends PassportStrategy(HeaderAPIKeyStrategy, 'admin
   validate(apiKey: string): boolean {
     const secretKey = this.configService.getOrThrow<string>('ADMIN_APP_SECRET')
 
-    if (apiKey.length !== secretKey.length) {
-      return false
-    }
-
-    try {
-      const apiKeyBuffer = Buffer.from(apiKey)
-      const secretBuffer = Buffer.from(secretKey)
-
-      return timingSafeEqual(apiKeyBuffer, secretBuffer)
-    } catch {
-      return false
-    }
+    return timingSafeStringEqual(secretKey, apiKey)
   }
 }

--- a/nest-city-account/src/oauth2/oauth2.service.ts
+++ b/nest-city-account/src/oauth2/oauth2.service.ts
@@ -5,7 +5,7 @@ import { ConfigService } from '@nestjs/config'
 import * as jwt from 'jsonwebtoken'
 
 import { PrismaService } from '../prisma/prisma.service'
-import { decryptData, encryptData } from '../utils/crypto'
+import { decryptData, encryptData,timingSafeStringEqual } from '../utils/crypto'
 import { CognitoSubservice } from '../utils/subservices/cognito.subservice'
 import { LineLoggerSubservice } from '../utils/subservices/line-logger.subservice'
 import { deserializeTokenData, serializeTokenData, TokenData } from '../utils/tokenSerialization'
@@ -502,7 +502,7 @@ export class OAuth2Service {
       )
     }
 
-    if (!this.validationSubservice.isValidSecret(codeChallenge, expectedChallenge)) {
+    if (!timingSafeStringEqual(codeChallenge, expectedChallenge)) {
       throw this.oAuth2ErrorThrower.tokenException(
         OAuth2TokenErrorCode.INVALID_REQUEST,
         'Invalid request: invalid code_verifier',

--- a/nest-city-account/src/oauth2/subservices/oauth2-validation.subservice.ts
+++ b/nest-city-account/src/oauth2/subservices/oauth2-validation.subservice.ts
@@ -1,8 +1,7 @@
-import { timingSafeEqual } from 'node:crypto'
-
 import { Injectable } from '@nestjs/common'
 import { Request } from 'express'
 
+import { timingSafeStringEqual } from '../../utils/crypto'
 import { OAuth2AuthorizationErrorCode, OAuth2TokenErrorCode } from '../oauth2.error.enum'
 import { OAuth2ErrorThrower } from '../oauth2-error.thrower'
 import { OAuth2Client, OAuth2ClientSubservice } from './oauth2-client.subservice'
@@ -253,25 +252,6 @@ export class OAuth2ValidationSubservice {
   }
 
   /**
-   * Timing-safe comparison of client secrets to prevent timing attacks
-   */
-  isValidSecret(expected: string, provided: string): boolean {
-    try {
-      // Convert strings to buffers for timing-safe comparison
-      const expectedBuffer = Buffer.from(expected, 'utf-8')
-      const providedBuffer = Buffer.from(provided, 'utf-8')
-      const dummyBuffer = Buffer.alloc(expectedBuffer.length)
-      const comparebuffer =
-        expectedBuffer.length === providedBuffer.length ? providedBuffer : dummyBuffer
-
-      return timingSafeEqual(expectedBuffer, comparebuffer)
-    } catch {
-      // timingSafeEqual throws if buffers have different lengths
-      return false
-    }
-  }
-
-  /**
    * Validate client authentication for token endpoint
    * Handles different grant types with appropriate authentication requirements
    *
@@ -345,7 +325,7 @@ export class OAuth2ValidationSubservice {
           { clientId, grantType }
         )
       }
-      if (!this.isValidSecret(client.secret, clientSecret)) {
+      if (!timingSafeStringEqual(client.secret, clientSecret)) {
         throw this.oAuth2ErrorThrower.tokenException(
           OAuth2TokenErrorCode.INVALID_CLIENT,
           'Invalid client: invalid client_secret',

--- a/nest-city-account/src/utils/crypto.ts
+++ b/nest-city-account/src/utils/crypto.ts
@@ -90,6 +90,7 @@ export const timingSafeStringEqual = (
 
     return crypto.timingSafeEqual(expectedBuffer, compareBuffer)
   } catch {
+    // timingSafeEqual throws if buffers have different lengths
     return false
   }
 }

--- a/nest-city-account/src/utils/crypto.ts
+++ b/nest-city-account/src/utils/crypto.ts
@@ -66,3 +66,30 @@ export const decryptData = (encryptedText: string): string => {
 
   return decrypt(ciphertextAndNonce, key).toString('utf8')
 }
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Empty/missing inputs always return false so a blank/unset secret can never
+ * be matched (fail closed).
+ */
+export const timingSafeStringEqual = (
+  expected: string | undefined | null,
+  provided: string | undefined | null
+): boolean => {
+  if (!expected || !provided) {
+    return false
+  }
+
+  try {
+    const expectedBuffer = Buffer.from(expected, 'utf-8')
+    const providedBuffer = Buffer.from(provided, 'utf-8')
+    // Compare against a same-length dummy on length mismatch so both paths cost the same.
+    const dummyBuffer = Buffer.alloc(expectedBuffer.length)
+    const compareBuffer =
+      expectedBuffer.length === providedBuffer.length ? providedBuffer : dummyBuffer
+
+    return crypto.timingSafeEqual(expectedBuffer, compareBuffer)
+  } catch {
+    return false
+  }
+}

--- a/nest-clamav-scanner/src/auth/strategies/auth-basic.strategy.ts
+++ b/nest-clamav-scanner/src/auth/strategies/auth-basic.strategy.ts
@@ -3,6 +3,8 @@ import { ConfigService } from '@nestjs/config'
 import { PassportStrategy } from '@nestjs/passport'
 import { BasicStrategy as Strategy } from 'passport-http'
 
+import { timingSafeStringEqual } from '../../utils/crypto'
+
 @Injectable()
 export class BasicStrategy extends PassportStrategy(Strategy, 'auth-basic') {
   constructor(private readonly configService: ConfigService) {
@@ -16,12 +18,18 @@ export class BasicStrategy extends PassportStrategy(Strategy, 'auth-basic') {
     username: string,
     password: string,
   ): boolean => {
-    if (
-      this.configService.get<string>('NEST_CLAMAV_SCANNER_USERNAME') ===
-        username &&
-      this.configService.get<string>('NEST_CLAMAV_SCANNER_PASSWORD') ===
-        password
-    ) {
+    // Evaluate both comparisons before combining so we don't short-circuit and
+    // leak (via timing) which field was wrong.
+    const usernameMatch = timingSafeStringEqual(
+      this.configService.get<string>('NEST_CLAMAV_SCANNER_USERNAME'),
+      username,
+    )
+    const passwordMatch = timingSafeStringEqual(
+      this.configService.get<string>('NEST_CLAMAV_SCANNER_PASSWORD'),
+      password,
+    )
+
+    if (usernameMatch && passwordMatch) {
       return true
     }
     throw new UnauthorizedException()

--- a/nest-clamav-scanner/src/utils/crypto.ts
+++ b/nest-clamav-scanner/src/utils/crypto.ts
@@ -1,0 +1,28 @@
+import { timingSafeEqual } from 'node:crypto'
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Empty/missing inputs always return false so a blank/unset secret can never
+ * be matched (fail closed).
+ */
+export const timingSafeStringEqual = (
+  expected: string | undefined | null,
+  provided: string | undefined | null,
+): boolean => {
+  if (!expected || !provided) {
+    return false
+  }
+
+  try {
+    const expectedBuffer = Buffer.from(expected, 'utf-8')
+    const providedBuffer = Buffer.from(provided, 'utf-8')
+    // Compare against a same-length dummy on length mismatch so both paths cost the same.
+    const dummyBuffer = Buffer.alloc(expectedBuffer.length)
+    const compareBuffer =
+      expectedBuffer.length === providedBuffer.length ? providedBuffer : dummyBuffer
+
+    return timingSafeEqual(expectedBuffer, compareBuffer)
+  } catch {
+    return false
+  }
+}

--- a/nest-clamav-scanner/src/utils/crypto.ts
+++ b/nest-clamav-scanner/src/utils/crypto.ts
@@ -23,6 +23,7 @@ export const timingSafeStringEqual = (
 
     return timingSafeEqual(expectedBuffer, compareBuffer)
   } catch {
+    // timingSafeEqual throws if buffers have different lengths
     return false
   }
 }

--- a/nest-forms-backend/src/auth/strategies/admin.strategy.ts
+++ b/nest-forms-backend/src/auth/strategies/admin.strategy.ts
@@ -1,10 +1,9 @@
-import { timingSafeEqual } from 'node:crypto'
-
 import { Injectable } from '@nestjs/common'
 import { PassportStrategy } from '@nestjs/passport'
 import Strategy from 'passport-headerapikey'
 
 import BaConfigService from '../../config/ba-config.service'
+import { timingSafeStringEqual } from '../../utils/crypto'
 
 @Injectable()
 export default class AdminStrategy extends PassportStrategy(
@@ -18,17 +17,6 @@ export default class AdminStrategy extends PassportStrategy(
   validate(apiKey: string): boolean {
     const secretKey = this.baConfigService.tokens.adminAppSecret
 
-    if (apiKey.length !== secretKey.length) {
-      return false
-    }
-
-    try {
-      const apiKeyBuffer = Buffer.from(apiKey)
-      const secretBuffer = Buffer.from(secretKey)
-
-      return timingSafeEqual(apiKeyBuffer, secretBuffer)
-    } catch {
-      return false
-    }
+    return timingSafeStringEqual(secretKey, apiKey)
   }
 }

--- a/nest-forms-backend/src/auth/strategies/auth-basic.strategy.ts
+++ b/nest-forms-backend/src/auth/strategies/auth-basic.strategy.ts
@@ -3,6 +3,7 @@ import { PassportStrategy } from '@nestjs/passport'
 import { BasicStrategy as Strategy } from 'passport-http'
 
 import BaConfigService from '../../config/ba-config.service'
+import { timingSafeStringEqual } from '../../utils/crypto'
 
 @Injectable()
 export default class BasicStrategy extends PassportStrategy(
@@ -20,10 +21,18 @@ export default class BasicStrategy extends PassportStrategy(
     username: string,
     password: string,
   ): boolean => {
-    if (
-      this.baConfigService.self.username === username &&
-      this.baConfigService.self.password === password
-    ) {
+    // Evaluate both comparisons before combining so we don't short-circuit and
+    // leak (via timing) which field was wrong.
+    const usernameMatch = timingSafeStringEqual(
+      this.baConfigService.self.username,
+      username,
+    )
+    const passwordMatch = timingSafeStringEqual(
+      this.baConfigService.self.password,
+      password,
+    )
+
+    if (usernameMatch && passwordMatch) {
       return true
     }
     throw new UnauthorizedException()

--- a/nest-forms-backend/src/utils/crypto.ts
+++ b/nest-forms-backend/src/utils/crypto.ts
@@ -1,0 +1,28 @@
+import { timingSafeEqual } from 'node:crypto'
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Empty/missing inputs always return false so a blank/unset secret can never
+ * be matched (fail closed).
+ */
+export const timingSafeStringEqual = (
+  expected: string | undefined | null,
+  provided: string | undefined | null,
+): boolean => {
+  if (!expected || !provided) {
+    return false
+  }
+
+  try {
+    const expectedBuffer = Buffer.from(expected, 'utf-8')
+    const providedBuffer = Buffer.from(provided, 'utf-8')
+    // Compare against a same-length dummy on length mismatch so both paths cost the same.
+    const dummyBuffer = Buffer.alloc(expectedBuffer.length)
+    const compareBuffer =
+      expectedBuffer.length === providedBuffer.length ? providedBuffer : dummyBuffer
+
+    return timingSafeEqual(expectedBuffer, compareBuffer)
+  } catch {
+    return false
+  }
+}

--- a/nest-forms-backend/src/utils/crypto.ts
+++ b/nest-forms-backend/src/utils/crypto.ts
@@ -23,6 +23,7 @@ export const timingSafeStringEqual = (
 
     return timingSafeEqual(expectedBuffer, compareBuffer)
   } catch {
+    // timingSafeEqual throws if buffers have different lengths
     return false
   }
 }

--- a/nest-tax-backend/src/auth/strategies/admin.strategy.ts
+++ b/nest-tax-backend/src/auth/strategies/admin.strategy.ts
@@ -1,9 +1,9 @@
-import { timingSafeEqual } from 'node:crypto'
-
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PassportStrategy } from '@nestjs/passport'
 import { HeaderAPIKeyStrategy } from 'passport-headerapikey'
+
+import { timingSafeStringEqual } from '../../utils/crypto'
 
 @Injectable()
 export class AdminStrategy extends PassportStrategy(
@@ -17,17 +17,6 @@ export class AdminStrategy extends PassportStrategy(
   validate(apiKey: string): boolean {
     const secretKey = this.configService.getOrThrow<string>('ADMIN_APP_SECRET')
 
-    if (apiKey.length !== secretKey.length) {
-      return false
-    }
-
-    try {
-      const apiKeyBuffer = Buffer.from(apiKey)
-      const secretBuffer = Buffer.from(secretKey)
-
-      return timingSafeEqual(apiKeyBuffer, secretBuffer)
-    } catch {
-      return false
-    }
+    return timingSafeStringEqual(secretKey, apiKey)
   }
 }

--- a/nest-tax-backend/src/utils/crypto.ts
+++ b/nest-tax-backend/src/utils/crypto.ts
@@ -1,0 +1,28 @@
+import { timingSafeEqual } from 'node:crypto'
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Empty/missing inputs always return false so a blank/unset secret can never
+ * be matched (fail closed).
+ */
+export const timingSafeStringEqual = (
+  expected: string | undefined | null,
+  provided: string | undefined | null,
+): boolean => {
+  if (!expected || !provided) {
+    return false
+  }
+
+  try {
+    const expectedBuffer = Buffer.from(expected, 'utf-8')
+    const providedBuffer = Buffer.from(provided, 'utf-8')
+    // Compare against a same-length dummy on length mismatch so both paths cost the same.
+    const dummyBuffer = Buffer.alloc(expectedBuffer.length)
+    const compareBuffer =
+      expectedBuffer.length === providedBuffer.length ? providedBuffer : dummyBuffer
+
+    return timingSafeEqual(expectedBuffer, compareBuffer)
+  } catch {
+    return false
+  }
+}

--- a/nest-tax-backend/src/utils/crypto.ts
+++ b/nest-tax-backend/src/utils/crypto.ts
@@ -23,6 +23,7 @@ export const timingSafeStringEqual = (
 
     return timingSafeEqual(expectedBuffer, compareBuffer)
   } catch {
+    // timingSafeEqual throws if buffers have different lengths
     return false
   }
 }


### PR DESCRIPTION
Resolves https://github.com/bratislava/private-konto.bratislava.sk/issues/1595