### PR TITLE
Point deploy dispatch_ref to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -287,7 +287,6 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/cvdmirror
-      dispatch_ref: master
 
   deploy-clamav:
     name: clamav
@@ -298,7 +297,6 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/clamav
-      dispatch_ref: master
 
   deploy-nest-clamav-scanner:
     name: nest-clamav-scanner
@@ -309,7 +307,6 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_clamav_scanner
-      dispatch_ref: master
 
   deploy-nest-forms-backend:
     name: nest-forms-backend
@@ -320,7 +317,6 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_forms_backend
-      dispatch_ref: master
 
   deploy-nest-tax-backend:
     name: nest-tax-backend
@@ -331,7 +327,6 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_tax_backend
-      dispatch_ref: master
 
   deploy-nest-city-account:
     name: nest-city-account
@@ -342,7 +337,6 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_city_account
-      dispatch_ref: master
 
   deploy-strapi:
     name: Strapi
@@ -353,7 +347,6 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/strapi
-      dispatch_ref: master
 
   deploy-next:
     name: after Backends deploy Next
@@ -375,7 +368,6 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/next
-      dispatch_ref: master
 
   check-openapi-clients:
     name: Check OpenAPI clients for changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -287,7 +287,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/cvdmirror
-      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
+      dispatch_ref: master
 
   deploy-clamav:
     name: clamav
@@ -298,7 +298,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/clamav
-      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
+      dispatch_ref: master
 
   deploy-nest-clamav-scanner:
     name: nest-clamav-scanner
@@ -309,7 +309,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_clamav_scanner
-      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
+      dispatch_ref: master
 
   deploy-nest-forms-backend:
     name: nest-forms-backend
@@ -320,7 +320,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_forms_backend
-      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
+      dispatch_ref: master
 
   deploy-nest-tax-backend:
     name: nest-tax-backend
@@ -331,7 +331,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_tax_backend
-      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
+      dispatch_ref: master
 
   deploy-nest-city-account:
     name: nest-city-account
@@ -342,7 +342,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_city_account
-      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
+      dispatch_ref: master
 
   deploy-strapi:
     name: Strapi
@@ -353,7 +353,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/strapi
-      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
+      dispatch_ref: master
 
   deploy-next:
     name: after Backends deploy Next
@@ -375,7 +375,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/next
-      dispatch_ref: mpinter/konto-deploy-dev-databases-v1
+      dispatch_ref: master
 
   check-openapi-clients:
     name: Check OpenAPI clients for changes


### PR DESCRIPTION
Points the `dispatch_ref` in the deploy GitHub Action to `master` (the default) across all 8 deploy jobs, replacing the temporary `mpinter/konto-deploy-dev-databases-v1` feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)