### PR TITLE
Lint GitHub Actions workflows (github-actions-scanner + shellcheck)

### DIFF
--- a/.github/workflows/build-next.yml
+++ b/.github/workflows/build-next.yml
@@ -81,20 +81,22 @@ jobs:
 
       - name: Prepare Next.js build env
         shell: bash
+        env:
+          BUILD_ENV: ${{ inputs.build_env }}
         run: |
           # Mimic bratiska-cli build_image behavior by promoting the
           # bratiska-cli build env file to .env.production.local
           # before docker build starts.
-          case "${{ inputs.build_env }}" in
+          case "$BUILD_ENV" in
             dev|staging|prod)
               ;;
             *)
-              echo "::error::Unsupported build_env '${{ inputs.build_env }}'. Allowed values: dev, staging, prod."
+              echo "::error::Unsupported build_env '$BUILD_ENV'. Allowed values: dev, staging, prod."
               exit 1
               ;;
           esac
 
-          source_env_file=".env.bratiska-cli-build.${{ inputs.build_env }}"
+          source_env_file=".env.bratiska-cli-build.$BUILD_ENV"
           if [[ ! -f "$source_env_file" ]]; then
             echo "::error file=$source_env_file::Missing $source_env_file in $PWD"
             exit 1

--- a/.github/workflows/build-shared-package.yml
+++ b/.github/workflows/build-shared-package.yml
@@ -79,7 +79,12 @@ jobs:
 
       - name: Print summary
         shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          PUSH: ${{ inputs.push }}
         run: |
-          echo "### Build Complete" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Digest: \`${{ steps.build.outputs.digest }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Pushed: \`${{ inputs.push }}\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Build Complete"
+            echo "- Digest: \`$DIGEST\`"
+            echo "- Pushed: \`$PUSH\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,11 +49,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,7 +66,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -79,4 +79,4 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,20 +76,24 @@ jobs:
             production)  NEXT_BUILD_ENV="prod" ;;
           esac
 
-          echo "cluster=$CLUSTER" >> $GITHUB_OUTPUT
-          echo "next-build-env=$NEXT_BUILD_ENV" >> $GITHUB_OUTPUT
+          {
+            echo "cluster=$CLUSTER"
+            echo "next-build-env=$NEXT_BUILD_ENV"
+          } >> "$GITHUB_OUTPUT"
 
-          echo "## Pipeline info :rocket:" >> $GITHUB_STEP_SUMMARY
-          echo ":arrow_right: Ref: **$REF**" >> $GITHUB_STEP_SUMMARY
-          echo ":arrow_right: Cluster: **$CLUSTER**" >> $GITHUB_STEP_SUMMARY
-          echo "### We are going to deploy :ship:" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Pipeline info :rocket:"
+            echo ":arrow_right: Ref: **$REF**"
+            echo ":arrow_right: Cluster: **$CLUSTER**"
+            echo "### We are going to deploy :ship:"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           for SVC in next strapi nest-forms-backend nest-clamav-scanner nest-tax-backend nest-city-account clamav cvdmirror; do
             if [[ "$ONLY" == "all" || "$ONLY" == "$SVC" ]]; then
-              echo "$SVC=true" >> $GITHUB_OUTPUT
-              echo ":soon: **$SVC**" >> $GITHUB_STEP_SUMMARY
+              echo "$SVC=true" >> "$GITHUB_OUTPUT"
+              echo ":soon: **$SVC**" >> "$GITHUB_STEP_SUMMARY"
             else
-              echo "$SVC=false" >> $GITHUB_OUTPUT
+              echo "$SVC=false" >> "$GITHUB_OUTPUT"
             fi
           done
 
@@ -386,5 +390,7 @@ jobs:
 
       - name: Build and run OpenAPI client check
         working-directory: openapi-clients
-        run: docker run --rm $(docker build -q -f Dockerfile.check .)
+        run: |
+          IMAGE_ID=$(docker build -q -f Dockerfile.check .)
+          docker run --rm "$IMAGE_ID"
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Map ref to environment and services
         id: resolve
         run: |
-          REF="${{ github.ref }}"
+          REF="$GITHUB_REF"
 
           if [[ "$REF" == "refs/heads/master" ]]; then
             CLUSTER="staging"

--- a/.github/workflows/test-forms-shared.yml
+++ b/.github/workflows/test-forms-shared.yml
@@ -44,8 +44,10 @@ jobs:
       - name: Prepare Docker build args
         id: docker-build-args
         shell: bash
+        env:
+          DIRECTORY: ${{ inputs.directory }}
         run: |
-          node "${{ inputs.directory }}/scripts/printDockerBuildArgs.ts" "${{ inputs.directory }}" >> "$GITHUB_OUTPUT"
+          node "$DIRECTORY/scripts/printDockerBuildArgs.ts" "$DIRECTORY" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker build
         uses: bratislava/github-actions/.github/actions/setup-docker-build@beta


### PR DESCRIPTION
Based on a suggestion from @vidriduch , ran [shellcheck](https://www.shellcheck.net) and [github actions scanner](https://github.com/snyk-labs/github-actions-scanner) on actions and cleared up most of the findings - moving `${{ inputs.* }}` and step-output interpolations into `env:` blocks to prevent shell injection, quoting `$GITHUB_OUTPUT`/`$GITHUB_STEP_SUMMARY` and grouping their redirects, and splitting the `docker run $(docker build -q ...)` call into a quoted variable. Also bumps `codeql-analysis.yml` to `actions/checkout@v6` and `github/codeql-action@v3` (v2 is EOL).

Did not go into "every input should not appear inline but be first assigned as env" as it (imho) produced a lot of noise and sacrificed a lot of readability.
