### PR TITLE
801 validated config nest tax backend

### DIFF
--- a/nest-tax-backend/.env.example
+++ b/nest-tax-backend/.env.example
@@ -4,9 +4,11 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB (Preview).
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-# Databases
+# Node / cluster environment
+NODE_ENV=development
 DATABASE_URL="postgresql://user:pass@localhost:54320/mydb?connect_timeout=30&schema=public"
 PORT=3000
+DB_CONCURRENCY=10
 
 MSSQL_HOST=172.25.6.28
 MSSQL_DB=cvicna_magistrat
@@ -17,8 +19,11 @@ MSSQL_PASSWORD='<change_this>'
 COGNITO_USER_POOL_ID="eu-central-1_FZDV0j2ZK"
 COGNITO_CLIENT_ID="1pdeai19927kshpgikd6l1ptc6"
 COGNITO_REGION="eu-central-1"
+AWS_COGNITO_ACCESS='<change_this>'
+AWS_COGNITO_SECRET='<change_this>'
 AWS_SES_SMTP_USERNAME='<change_this>'
 AWS_SES_SMTP_PASSWORD='<change_this>'
+AWS_SES_SENDER_EMAIL='Mesto Bratislava <konto@bratislava.sk>'
 
 # Payment gate
 PAYGATE_MERCHANT_NUMBER='<change_this>'
@@ -37,6 +42,7 @@ PAYGATE_PASSPHRASE_KO='<change_this>'
 
 # Api urls
 CITY_ACCOUNT_API_URL=https://nest-city-account.staging.bratislava.sk
+CITY_ACCOUNT_ADMIN_API_KEY='<change_this>'
 
 # Mailgun
 MAILGUN_API_KEY='<change_this>'
@@ -54,8 +60,11 @@ BLOOMREACH_API_URL=https://api.eu1.exponea.com
 PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND=https://city-account-next.staging.bratislava.sk/platba/stav
 
 # Payment reporting
-REPORTING_FILE_NAME=pbr24
 REPORTING_ICO=11111111
+REPORTING_SFTP_HOST='<change_this>'
+REPORTING_SFTP_USER='<change_this>'
+REPORTING_SFTP_KEY='<change_this>'
+REPORTING_FILE_NAME=pbr24
 REPORTING_ACCOUNT_ID=2222222222222222
 REPORTING_BANK_ID=3333
 REPORTING_SFTP_PORT=44

--- a/nest-tax-backend/.env.example
+++ b/nest-tax-backend/.env.example
@@ -31,8 +31,7 @@ PAYGATE_CURRENCY=978
 PAYGATE_PAYMENT_REDIRECT_URL=https://test.3dsecure.gpwebpay.com/pgw/order.do
 PAYGATE_PASSPHRASE='<change_this>'
 PAYGATE_SIGN_CERT='<change_this>'
-# this depends on port defined higher
-PAYGATE_REDIRECT_URL=http://localhost:3000/payment/cardpay/response
+PAYGATE_REDIRECT_URL=https://nest-tax-backend.example.com/payment/cardpay/response
 PAYGATE_KEY='<change_this>'
 # paygate envs for communal waste
 PAYGATE_MERCHANT_NUMBER_KO='<change_this>'

--- a/nest-tax-backend/kubernetes/base/.env
+++ b/nest-tax-backend/kubernetes/base/.env
@@ -1,4 +1,5 @@
 NODE_OPTIONS="--max-old-space-size=7000"
 PORT=3000
+DB_CONCURRENCY=10
 
 

--- a/nest-tax-backend/kubernetes/envs/Staging/.env
+++ b/nest-tax-backend/kubernetes/envs/Staging/.env
@@ -1,4 +1,4 @@
-NODE_ENV=staging
+NODE_ENV=production
 CLUSTER_ENV=staging
 MSSQL_HOST=172.25.6.28
 MSSQL_DB=cvicna_magistrat

--- a/nest-tax-backend/src/app.module.ts
+++ b/nest-tax-backend/src/app.module.ts
@@ -1,5 +1,4 @@
 import { MiddlewareConsumer, Module } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
 import { ScheduleModule } from '@nestjs/schedule'
 import { CognitoAuthModule } from '@nestjs-cognito/auth'
 

--- a/nest-tax-backend/src/app.module.ts
+++ b/nest-tax-backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { CognitoAuthModule } from '@nestjs-cognito/auth'
 import { AdminModule } from './admin/admin.module'
 import { AppController } from './app.controller'
 import { CardPaymentReportingModule } from './card-payment-reporting/card-payment-reporting.module'
+import BaConfigModule from './config/ba-config.module'
 import BaConfigService from './config/ba-config.service'
 import { PaymentModule } from './payment/payment.module'
 import { PrismaModule } from './prisma/prisma.module'
@@ -18,6 +19,7 @@ import { UtilsModule } from './utils-module/utils.module'
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    BaConfigModule,
     CognitoAuthModule.registerAsync({
       inject: [BaConfigService],
       useFactory: (baConfigService: BaConfigService) => ({

--- a/nest-tax-backend/src/app.module.ts
+++ b/nest-tax-backend/src/app.module.ts
@@ -18,7 +18,6 @@ import { UtilsModule } from './utils-module/utils.module'
 
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
     BaConfigModule,
     CognitoAuthModule.registerAsync({
       inject: [BaConfigService],

--- a/nest-tax-backend/src/app.module.ts
+++ b/nest-tax-backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { CognitoAuthModule } from '@nestjs-cognito/auth'
 import { AdminModule } from './admin/admin.module'
 import { AppController } from './app.controller'
 import { CardPaymentReportingModule } from './card-payment-reporting/card-payment-reporting.module'
+import BaConfigService from './config/ba-config.service'
 import { PaymentModule } from './payment/payment.module'
 import { PrismaModule } from './prisma/prisma.module'
 import { TasksModule } from './tasks/tasks.module'
@@ -17,15 +18,18 @@ import { UtilsModule } from './utils-module/utils.module'
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
-    CognitoAuthModule.register({
-      jwtVerifier: {
-        userPoolId: process.env.COGNITO_USER_POOL_ID ?? '',
-        clientId: process.env.COGNITO_CLIENT_ID,
-        tokenUse: 'access',
-      },
-      identityProvider: {
-        region: process.env.COGNITO_REGION,
-      },
+    CognitoAuthModule.registerAsync({
+      inject: [BaConfigService],
+      useFactory: (baConfigService: BaConfigService) => ({
+        jwtVerifier: {
+          userPoolId: baConfigService.cognito.userPoolId,
+          clientId: baConfigService.cognito.clientId,
+          tokenUse: 'access',
+        },
+        identityProvider: {
+          region: baConfigService.cognito.region,
+        },
+      }),
     }),
     PrismaModule,
     SharedModule,

--- a/nest-tax-backend/src/auth/guards/not-production.guard.ts
+++ b/nest-tax-backend/src/auth/guards/not-production.guard.ts
@@ -1,9 +1,14 @@
 import { CanActivate, ForbiddenException, Injectable } from '@nestjs/common'
 
+import BaConfigService from '../../config/ba-config.service'
+import { ClusterEnv } from '../../config/environment-variables'
+
 @Injectable()
 export class NotProductionGuard implements CanActivate {
+  constructor(private readonly baConfigService: BaConfigService) {}
+
   canActivate(): boolean {
-    if (process.env.CLUSTER_ENV === 'production') {
+    if (this.baConfigService.environment.clusterEnv === ClusterEnv.Production) {
       throw new ForbiddenException(
         'This endpoint is not available in production environment.',
       )

--- a/nest-tax-backend/src/auth/strategies/admin.strategy.ts
+++ b/nest-tax-backend/src/auth/strategies/admin.strategy.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { PassportStrategy } from '@nestjs/passport'
 import { HeaderAPIKeyStrategy } from 'passport-headerapikey'
 
+import BaConfigService from '../../config/ba-config.service'
 import { timingSafeStringEqual } from '../../utils/crypto'
 
 @Injectable()
@@ -10,12 +10,12 @@ export class AdminStrategy extends PassportStrategy(
   HeaderAPIKeyStrategy,
   'admin-strategy',
 ) {
-  constructor(private readonly configService: ConfigService) {
+  constructor(private readonly baConfigService: BaConfigService) {
     super({ header: 'apiKey', prefix: '' }, false)
   }
 
   validate(apiKey: string): boolean {
-    const secretKey = this.configService.getOrThrow<string>('ADMIN_APP_SECRET')
+    const secretKey = this.baConfigService.tokens.adminAppSecret
 
     return timingSafeStringEqual(secretKey, apiKey)
   }

--- a/nest-tax-backend/src/bloomreach/bloomreach.service.ts
+++ b/nest-tax-backend/src/bloomreach/bloomreach.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 
+import BaConfigService from '../config/ba-config.service'
 import { ErrorsEnum } from '../utils/guards/dtos/error.dto'
 import ThrowerErrorGuard from '../utils/guards/errors.guard'
 import { LineLoggerSubservice } from '../utils/subservices/line-logger.subservice'
@@ -15,26 +15,17 @@ import {
 export class BloomreachService {
   private readonly logger: LineLoggerSubservice
 
-  private readonly bloomreachCredentials = Buffer.from(
-    `${process.env.BLOOMREACH_API_KEY}:${process.env.BLOOMREACH_API_SECRET}`,
-    'binary',
-  ).toString('base64')
+  private readonly bloomreachCredentials: string
 
   constructor(
     private readonly throwerErrorGuard: ThrowerErrorGuard,
-    private readonly configService: ConfigService,
+    private readonly baConfigService: BaConfigService,
   ) {
-    if (
-      !process.env.BLOOMREACH_API_URL ||
-      !process.env.BLOOMREACH_API_KEY ||
-      !process.env.BLOOMREACH_API_SECRET ||
-      !process.env.BLOOMREACH_PROJECT_TOKEN
-    ) {
-      throw this.throwerErrorGuard.InternalServerErrorException(
-        ErrorsEnum.INTERNAL_SERVER_ERROR,
-        'Missing on of pricing api envs: BLOOMREACH_API_URL, BLOOMREACH_API_KEY, BLOOMREACH_API_SECRET, BLOOMREACH_PROJECT_TOKEN.',
-      )
-    }
+    const { apiKey, apiSecret } = this.baConfigService.bloomreach
+    this.bloomreachCredentials = Buffer.from(
+      `${apiKey}:${apiSecret}`,
+      'binary',
+    ).toString('base64')
     this.logger = new LineLoggerSubservice(BloomreachService.name)
   }
 
@@ -43,18 +34,15 @@ export class BloomreachService {
     cognitoId: string,
     eventName: BloomreachEventNameEnum,
   ): Promise<boolean> {
-    if (
-      this.configService.getOrThrow<string>(
-        'FEATURE_TOGGLE_SEND_BLOOMREACH_EVENTS',
-      ) !== 'true'
-    ) {
+    if (!this.baConfigService.featureToggles.sendBloomreachEvents) {
       this.logger.debug(
         `Bloomreach events are disabled, skipping event ${eventName} for user ${cognitoId}. Object content: ${JSON.stringify(data)}`,
       )
       return true
     }
+    const { apiUrl, projectToken } = this.baConfigService.bloomreach
     const eventResponse = await fetch(
-      `${process.env.BLOOMREACH_API_URL}/track/v2/projects/${process.env.BLOOMREACH_PROJECT_TOKEN}/customers/events`,
+      `${apiUrl}/track/v2/projects/${projectToken}/customers/events`,
       {
         method: 'POST',
         body: JSON.stringify({

--- a/nest-tax-backend/src/card-payment-reporting/__tests__/card-payment-reporting.service.spec.ts
+++ b/nest-tax-backend/src/card-payment-reporting/__tests__/card-payment-reporting.service.spec.ts
@@ -1,10 +1,10 @@
-import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 
-import { Prisma } from '../../generated/prisma/client'
+import BaConfigService from '../../config/ba-config.service'
+import { Prisma, TaxType } from '../../generated/prisma/client'
 import { PrismaService } from '../../prisma/prisma.service'
 import ThrowerErrorGuard from '../../utils/guards/errors.guard'
 import DatabaseSubservice from '../../utils/subservices/database.subservice'
@@ -50,7 +50,23 @@ const makePosRow = (overrides: Partial<Record<CsvColumns, string>> = {}) => {
 
 describe('CardPaymentReportingService', () => {
   let service: CardPaymentReportingService
-  let mockConfigService: { getOrThrow: jest.Mock }
+  let mockBaConfigService: {
+    cardPaymentReporting: {
+      ico?: string
+      [TaxType.DZN]: {
+        sftpFilesPath?: string
+        fileName?: string
+        accountId?: string
+        bankId?: string
+      }
+      [TaxType.KO]: {
+        sftpFilesPath?: string
+        fileName?: string
+        accountId?: string
+        bankId?: string
+      }
+    }
+  }
   let mockSftpFileSubservice: { getNewFiles: jest.Mock }
   let mockDatabaseSubservice: {
     getVariableSymbolsByOrderIds: jest.Mock
@@ -69,8 +85,11 @@ describe('CardPaymentReportingService', () => {
       config: { findMany: jest.fn() },
       csvFile: { createMany: jest.fn() },
     }
-    mockConfigService = {
-      getOrThrow: jest.fn(),
+    mockBaConfigService = {
+      cardPaymentReporting: {
+        [TaxType.DZN]: {},
+        [TaxType.KO]: {},
+      },
     }
     mockSftpFileSubservice = {
       getNewFiles: jest.fn().mockResolvedValue([]),
@@ -90,7 +109,7 @@ describe('CardPaymentReportingService', () => {
       providers: [
         CardPaymentReportingService,
         { provide: PrismaService, useValue: mockPrismaService },
-        { provide: ConfigService, useValue: mockConfigService },
+        { provide: BaConfigService, useValue: mockBaConfigService },
         {
           provide: ThrowerErrorGuard,
           useValue: { InternalServerErrorException: jest.fn() },
@@ -254,26 +273,22 @@ POS;;0000001;D;05.11.24;-9,99;-0,00;-9,99;0,00;;Popl. za settlement; ;0;`
   })
 
   describe('generateAndSendPaymentReport', () => {
-    const envValues: Record<string, string> = {
-      REPORTING_SFTP_FILES_PATH: '7322226495/oms/cz',
-      REPORTING_FILE_NAME: 'pbr24',
-      REPORTING_ACCOUNT_ID: '1234567890123456',
-      REPORTING_BANK_ID: '1100',
-      REPORTING_PKO_SFTP_FILES_PATH: '7322257895/oms/cz',
-      REPORTING_PKO_FILE_NAME: 'pbr26',
-      REPORTING_PKO_ACCOUNT_ID: '6543210987654321',
-      REPORTING_PKO_BANK_ID: '2200',
-      REPORTING_ICO: '00603481',
-    }
-
     beforeEach(() => {
-      mockConfigService.getOrThrow.mockImplementation((key: string) => {
-        const value = envValues[key]
-        if (!value) {
-          throw new Error(`Missing config key: ${key}`)
-        }
-        return value
-      })
+      mockBaConfigService.cardPaymentReporting = {
+        ico: '00603481',
+        [TaxType.DZN]: {
+          sftpFilesPath: '7322226495/oms/cz',
+          fileName: 'pbr24',
+          accountId: '1234567890123456',
+          bankId: '1100',
+        },
+        [TaxType.KO]: {
+          sftpFilesPath: '7322257895/oms/cz',
+          fileName: 'pbr26',
+          accountId: '6543210987654321',
+          bankId: '2200',
+        },
+      }
     })
 
     it('should process files from both DzN and PKO SFTP paths', async () => {

--- a/nest-tax-backend/src/card-payment-reporting/card-payment-reporting.module.ts
+++ b/nest-tax-backend/src/card-payment-reporting/card-payment-reporting.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 
 import EmailSubservice from '../utils/subservices/email.subservice'
 import SftpFileSubservice from '../utils/subservices/sftp-file.subservice'
@@ -8,12 +7,7 @@ import { CardPaymentReportingService } from './card-payment-reporting.service'
 
 @Module({
   imports: [],
-  providers: [
-    ConfigService,
-    EmailSubservice,
-    SftpFileSubservice,
-    CardPaymentReportingService,
-  ],
+  providers: [EmailSubservice, SftpFileSubservice, CardPaymentReportingService],
   exports: [CardPaymentReportingService],
   controllers: [CardPaymentReportingController],
 })

--- a/nest-tax-backend/src/card-payment-reporting/card-payment-reporting.service.ts
+++ b/nest-tax-backend/src/card-payment-reporting/card-payment-reporting.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { parse } from 'csv-parse/sync'
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 
+import BaConfigService from '../config/ba-config.service'
 import { TaxType } from '../generated/prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
 import DatabaseSubservice from '../utils/subservices/database.subservice'
@@ -16,28 +16,11 @@ dayjs.extend(timezone)
 
 interface ReportTypeConfig {
   taxType: TaxType
-  sftpPathEnvKey: string
-  fileNameEnvKey: string
-  accountIdEnvKey: string
-  bankIdEnvKey: string
+  sftpPath: string
+  fileName: string
+  accountId: string
+  bankId: string
 }
-
-const REPORT_TYPES: ReportTypeConfig[] = [
-  {
-    taxType: TaxType.DZN,
-    sftpPathEnvKey: 'REPORTING_SFTP_FILES_PATH',
-    fileNameEnvKey: 'REPORTING_FILE_NAME',
-    accountIdEnvKey: 'REPORTING_ACCOUNT_ID',
-    bankIdEnvKey: 'REPORTING_BANK_ID',
-  },
-  {
-    taxType: TaxType.KO,
-    sftpPathEnvKey: 'REPORTING_PKO_SFTP_FILES_PATH',
-    fileNameEnvKey: 'REPORTING_PKO_FILE_NAME',
-    accountIdEnvKey: 'REPORTING_PKO_ACCOUNT_ID',
-    bankIdEnvKey: 'REPORTING_PKO_BANK_ID',
-  },
-]
 
 export const csvColumnNames = [
   'transactionType',
@@ -74,11 +57,31 @@ export interface OutputFile {
 export class CardPaymentReportingService {
   constructor(
     private readonly prismaService: PrismaService,
-    private readonly configService: ConfigService,
+    private readonly baConfigService: BaConfigService,
     private readonly mailSubservice: EmailSubservice,
     private readonly sftpFileSubservice: SftpFileSubservice,
     private readonly databaseSubservice: DatabaseSubservice,
   ) {}
+
+  private getReportTypes(): ReportTypeConfig[] {
+    const { [TaxType.DZN]: dzn, [TaxType.KO]: ko } = this.baConfigService.cardPaymentReporting
+    return [
+      {
+        taxType: TaxType.DZN,
+        sftpPath: dzn.sftpFilesPath,
+        fileName: dzn.fileName,
+        accountId: dzn.accountId,
+        bankId: dzn.bankId,
+      },
+      {
+        taxType: TaxType.KO,
+        sftpPath: ko.sftpFilesPath,
+        fileName: ko.fileName,
+        accountId: ko.accountId,
+        bankId: ko.bankId,
+      },
+    ]
+  }
 
   private generatePrice(price: number, fill: number): string {
     const adjustedFill = price >= 0 ? fill + 3 : fill + 2
@@ -156,7 +159,7 @@ export class CardPaymentReportingService {
       reportFileName,
       'Hlavné mesto Slovenskej republiky Bratislava',
       ' '.repeat(6),
-      this.configService.getOrThrow<string>('REPORTING_ICO'),
+      this.baConfigService.cardPaymentReporting.ico,
       ' '.repeat(22),
       '\n',
       '1',
@@ -293,18 +296,7 @@ export class CardPaymentReportingService {
     outputFiles: OutputFile[]
     sftpFileNames: { taxType: TaxType; name: string }[]
   }> {
-    const sftpPath = this.configService.getOrThrow<string>(
-      reportType.sftpPathEnvKey,
-    )
-    const reportFileName = this.configService.getOrThrow<string>(
-      reportType.fileNameEnvKey,
-    )
-    const accountId = this.configService.getOrThrow<string>(
-      reportType.accountIdEnvKey,
-    )
-    const bankId = this.configService.getOrThrow<string>(
-      reportType.bankIdEnvKey,
-    )
+    const { sftpPath, fileName: reportFileName, accountId, bankId } = reportType
     const sftpFiles = await this.sftpFileSubservice.getNewFiles(
       sftpPath,
       reportType.taxType,
@@ -434,7 +426,7 @@ export class CardPaymentReportingService {
 
   async generateAndSendPaymentReport(emailRecipients: string[], from?: Date) {
     const results = await Promise.all(
-      REPORT_TYPES.map(async (reportType) =>
+      this.getReportTypes().map(async (reportType) =>
         this.processAndSendReport(reportType, emailRecipients, from),
       ),
     )

--- a/nest-tax-backend/src/clients/clients.service.ts
+++ b/nest-tax-backend/src/clients/clients.service.ts
@@ -1,17 +1,18 @@
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import {
   type CityAccountClient,
   createCityAccountClient,
 } from 'openapi-clients/city-account'
 
+import BaConfigService from '../config/ba-config.service'
+
 @Injectable()
 export default class ClientsService {
   public readonly cityAccountApi: CityAccountClient
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(private readonly baConfigService: BaConfigService) {
     this.cityAccountApi = createCityAccountClient({
-      basePath: this.configService.getOrThrow('CITY_ACCOUNT_API_URL'),
+      basePath: this.baConfigService.cityAccountBackend.url,
     })
   }
 }

--- a/nest-tax-backend/src/config/ba-config.instance.ts
+++ b/nest-tax-backend/src/config/ba-config.instance.ts
@@ -1,0 +1,13 @@
+import BaConfig from './ba-config'
+import validateEnvironmentVariables from './environment-variables.validate'
+
+let instance: BaConfig | null = null
+
+export default function getBaConfigInstance(): BaConfig {
+  if (!instance) {
+    const validatedEnvVariables = validateEnvironmentVariables(process.env)
+    instance = new BaConfig(validatedEnvVariables)
+  }
+
+  return instance
+}

--- a/nest-tax-backend/src/config/ba-config.module.ts
+++ b/nest-tax-backend/src/config/ba-config.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+
+import getBaConfigInstance from './ba-config.instance'
+import BaConfigService from './ba-config.service'
+
+@Global()
+@Module({
+  // ConfigModule.forRoot() call is required, because it loads the environmental variables from .env file
+  imports: [ConfigModule.forRoot()],
+  providers: [
+    {
+      provide: BaConfigService,
+      useValue: getBaConfigInstance(),
+    },
+  ],
+  exports: [BaConfigService],
+})
+export default class BaConfigModule {}

--- a/nest-tax-backend/src/config/ba-config.service.ts
+++ b/nest-tax-backend/src/config/ba-config.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@nestjs/common'
+
+import BaConfig from './ba-config'
+
+@Injectable()
+export default class BaConfigService extends BaConfig {}

--- a/nest-tax-backend/src/config/ba-config.service.ts
+++ b/nest-tax-backend/src/config/ba-config.service.ts
@@ -3,4 +3,5 @@ import { Injectable } from '@nestjs/common'
 import BaConfig from './ba-config'
 
 @Injectable()
+// eslint-disable-next-line @darraghor/nestjs-typed/injectable-should-be-provided -- the rule only recognizes a bare class reference in a `providers` array; BaConfigService is actually provided via `{ provide: BaConfigService, useValue/useFactory: ... }` in ba-config.module.ts
 export default class BaConfigService extends BaConfig {}

--- a/nest-tax-backend/src/config/ba-config.ts
+++ b/nest-tax-backend/src/config/ba-config.ts
@@ -1,0 +1,12 @@
+import EnvironmentVariables from './environment-variables'
+
+export default class BaConfig {
+  constructor(protected validatedConfig: EnvironmentVariables) {}
+
+  get environment() {
+    return {
+      nodeEnv: this.validatedConfig.NODE_ENV,
+      clusterEnv: this.validatedConfig.CLUSTER_ENV,
+    }
+  }
+}

--- a/nest-tax-backend/src/config/ba-config.ts
+++ b/nest-tax-backend/src/config/ba-config.ts
@@ -1,3 +1,4 @@
+import { TaxType } from '../generated/prisma/enums'
 import EnvironmentVariables from './environment-variables'
 
 export default class BaConfig {
@@ -48,9 +49,9 @@ export default class BaConfig {
 
   get smtp() {
     return {
-      smtpUsername: this.validatedConfig.AWS_SES_SMTP_USERNAME,
-      smtpPassword: this.validatedConfig.AWS_SES_SMTP_PASSWORD,
-      senderEmail: this.validatedConfig.AWS_SES_SENDER_EMAIL,
+      username: this.validatedConfig.AWS_SES_SMTP_USERNAME,
+      password: this.validatedConfig.AWS_SES_SMTP_PASSWORD,
+      email: this.validatedConfig.AWS_SES_SENDER_EMAIL,
     }
   }
 
@@ -85,13 +86,13 @@ export default class BaConfig {
       redirectUrl: this.validatedConfig.PAYGATE_REDIRECT_URL,
       afterPaymentRedirectFrontend:
         this.validatedConfig.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND,
-      dzn: {
+      [TaxType.DZN]: {
         key: this.validatedConfig.PAYGATE_KEY,
         signCert: this.validatedConfig.PAYGATE_SIGN_CERT,
         merchantNumber: this.validatedConfig.PAYGATE_MERCHANT_NUMBER,
         passphrase: this.validatedConfig.PAYGATE_PASSPHRASE,
       },
-      ko: {
+      [TaxType.KO]: {
         key: this.validatedConfig.PAYGATE_KEY_KO,
         signCert: this.validatedConfig.PAYGATE_SIGN_CERT_KO,
         merchantNumber: this.validatedConfig.PAYGATE_MERCHANT_NUMBER_KO,
@@ -109,13 +110,13 @@ export default class BaConfig {
         username: this.validatedConfig.REPORTING_SFTP_USER,
         privateKey: this.validatedConfig.REPORTING_SFTP_KEY,
       },
-      dzn: {
+      [TaxType.DZN]: {
         fileName: this.validatedConfig.REPORTING_FILE_NAME,
         accountId: this.validatedConfig.REPORTING_ACCOUNT_ID,
         bankId: this.validatedConfig.REPORTING_BANK_ID,
         sftpFilesPath: this.validatedConfig.REPORTING_SFTP_FILES_PATH,
       },
-      ko: {
+      [TaxType.KO]: {
         fileName: this.validatedConfig.REPORTING_PKO_FILE_NAME,
         accountId: this.validatedConfig.REPORTING_PKO_ACCOUNT_ID,
         bankId: this.validatedConfig.REPORTING_PKO_BANK_ID,

--- a/nest-tax-backend/src/config/ba-config.ts
+++ b/nest-tax-backend/src/config/ba-config.ts
@@ -73,7 +73,7 @@ export default class BaConfig {
     }
   }
 
-  get qrCode() {
+  get payment() {
     return {
       beneficiaryName: this.validatedConfig.PAYMENT_QR_BENEFICIARY_NAME,
     }

--- a/nest-tax-backend/src/config/ba-config.ts
+++ b/nest-tax-backend/src/config/ba-config.ts
@@ -9,4 +9,127 @@ export default class BaConfig {
       clusterEnv: this.validatedConfig.CLUSTER_ENV,
     }
   }
+
+  get self() {
+    return {
+      port: this.validatedConfig.PORT,
+    }
+  }
+
+  get database() {
+    return {
+      url: this.validatedConfig.DATABASE_URL,
+      concurrency: this.validatedConfig.DB_CONCURRENCY,
+    }
+  }
+
+  get tokens() {
+    return {
+      adminAppSecret: this.validatedConfig.ADMIN_APP_SECRET,
+    }
+  }
+
+  get cognito() {
+    return {
+      userPoolId: this.validatedConfig.COGNITO_USER_POOL_ID,
+      clientId: this.validatedConfig.COGNITO_CLIENT_ID,
+      region: this.validatedConfig.COGNITO_REGION,
+      accessKeyId: this.validatedConfig.AWS_COGNITO_ACCESS,
+      secretAccessKey: this.validatedConfig.AWS_COGNITO_SECRET,
+    }
+  }
+
+  get cityAccountBackend() {
+    return {
+      url: this.validatedConfig.CITY_ACCOUNT_API_URL,
+      adminApiKey: this.validatedConfig.CITY_ACCOUNT_ADMIN_API_KEY,
+    }
+  }
+
+  get smtp() {
+    return {
+      smtpUsername: this.validatedConfig.AWS_SES_SMTP_USERNAME,
+      smtpPassword: this.validatedConfig.AWS_SES_SMTP_PASSWORD,
+      senderEmail: this.validatedConfig.AWS_SES_SENDER_EMAIL,
+    }
+  }
+
+  get noris() {
+    return {
+      host: this.validatedConfig.MSSQL_HOST,
+      database: this.validatedConfig.MSSQL_DB,
+      username: this.validatedConfig.MSSQL_USERNAME,
+      password: this.validatedConfig.MSSQL_PASSWORD,
+    }
+  }
+
+  get bloomreach() {
+    return {
+      apiUrl: this.validatedConfig.BLOOMREACH_API_URL,
+      apiKey: this.validatedConfig.BLOOMREACH_API_KEY,
+      apiSecret: this.validatedConfig.BLOOMREACH_API_SECRET,
+      projectToken: this.validatedConfig.BLOOMREACH_PROJECT_TOKEN,
+    }
+  }
+
+  get qrCode() {
+    return {
+      beneficiaryName: this.validatedConfig.PAYMENT_QR_BENEFICIARY_NAME,
+    }
+  }
+
+  get paygate() {
+    return {
+      currency: this.validatedConfig.PAYGATE_CURRENCY,
+      paymentRedirectUrl: this.validatedConfig.PAYGATE_PAYMENT_REDIRECT_URL,
+      redirectUrl: this.validatedConfig.PAYGATE_REDIRECT_URL,
+      afterPaymentRedirectFrontend:
+        this.validatedConfig.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND,
+      dzn: {
+        key: this.validatedConfig.PAYGATE_KEY,
+        signCert: this.validatedConfig.PAYGATE_SIGN_CERT,
+        merchantNumber: this.validatedConfig.PAYGATE_MERCHANT_NUMBER,
+        passphrase: this.validatedConfig.PAYGATE_PASSPHRASE,
+      },
+      ko: {
+        key: this.validatedConfig.PAYGATE_KEY_KO,
+        signCert: this.validatedConfig.PAYGATE_SIGN_CERT_KO,
+        merchantNumber: this.validatedConfig.PAYGATE_MERCHANT_NUMBER_KO,
+        passphrase: this.validatedConfig.PAYGATE_PASSPHRASE_KO,
+      },
+    }
+  }
+
+  get cardPaymentReporting() {
+    return {
+      ico: this.validatedConfig.REPORTING_ICO,
+      sftp: {
+        host: this.validatedConfig.REPORTING_SFTP_HOST,
+        port: this.validatedConfig.REPORTING_SFTP_PORT,
+        username: this.validatedConfig.REPORTING_SFTP_USER,
+        privateKey: this.validatedConfig.REPORTING_SFTP_KEY,
+      },
+      dzn: {
+        fileName: this.validatedConfig.REPORTING_FILE_NAME,
+        accountId: this.validatedConfig.REPORTING_ACCOUNT_ID,
+        bankId: this.validatedConfig.REPORTING_BANK_ID,
+        sftpFilesPath: this.validatedConfig.REPORTING_SFTP_FILES_PATH,
+      },
+      ko: {
+        fileName: this.validatedConfig.REPORTING_PKO_FILE_NAME,
+        accountId: this.validatedConfig.REPORTING_PKO_ACCOUNT_ID,
+        bankId: this.validatedConfig.REPORTING_PKO_BANK_ID,
+        sftpFilesPath: this.validatedConfig.REPORTING_PKO_SFTP_FILES_PATH,
+      },
+    }
+  }
+
+  get featureToggles() {
+    return {
+      updateTaxesFromNoris:
+        this.validatedConfig.FEATURE_TOGGLE_UPDATE_TAXES_FROM_NORIS,
+      sendBloomreachEvents:
+        this.validatedConfig.FEATURE_TOGGLE_SEND_BLOOMREACH_EVENTS,
+    }
+  }
 }

--- a/nest-tax-backend/src/config/environment-decorators.ts
+++ b/nest-tax-backend/src/config/environment-decorators.ts
@@ -1,0 +1,81 @@
+import { applyDecorators } from '@nestjs/common'
+import { Expose, Transform } from 'class-transformer'
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  IsUrl,
+  Max,
+  Min,
+} from 'class-validator'
+
+function BooleanTransform() {
+  return Transform(({ value }: { value: unknown }) => {
+    if (typeof value === 'string') {
+      const lower = value.toLowerCase()
+      if (lower === 'true') {
+        return true
+      }
+      if (lower === 'false') {
+        return false
+      }
+    }
+    return value
+  })
+}
+
+function NumberTransform() {
+  return Transform(({ value }: { value: unknown }) => {
+    if (typeof value === 'string' && value.trim() !== '') {
+      const num = Number(value)
+      return Number.isNaN(num) ? value : num
+    }
+    return value
+  })
+}
+
+export function EnvBoolean(required = true) {
+  return applyDecorators(
+    Expose(),
+    BooleanTransform(),
+    IsBoolean(),
+    ...(required ? [IsNotEmpty()] : []),
+  )
+}
+
+export function EnvInt(min?: number, max?: number, required = true) {
+  return applyDecorators(
+    Expose(),
+    NumberTransform(),
+    IsInt(),
+    ...(required ? [IsNotEmpty()] : []),
+    ...(min === undefined ? [] : [Min(min)]),
+    ...(max === undefined ? [] : [Max(max)]),
+  )
+}
+
+export function EnvPort(required = true) {
+  return EnvInt(0, 65_535, required)
+}
+
+export function EnvString(required = true) {
+  return applyDecorators(
+    Expose(),
+    IsString(),
+    ...(required ? [IsNotEmpty()] : []),
+  )
+}
+
+export function EnvUrl(required = true) {
+  return applyDecorators(Expose(), IsUrl(), ...(required ? [IsNotEmpty()] : []))
+}
+
+export function EnvEnum(enumType: object, required = true) {
+  return applyDecorators(
+    Expose(),
+    IsEnum(enumType),
+    ...(required ? [IsNotEmpty()] : []),
+  )
+}

--- a/nest-tax-backend/src/config/environment-decorators.ts
+++ b/nest-tax-backend/src/config/environment-decorators.ts
@@ -69,12 +69,7 @@ export function EnvString(required = true) {
 }
 
 export function EnvUrl(required = true) {
-  return applyDecorators(
-    Expose(),
-    // require_tld: false so localhost URLs (used for local dev callback URLs) pass validation
-    IsUrl({ require_tld: false }),
-    ...(required ? [IsNotEmpty()] : []),
-  )
+  return applyDecorators(Expose(), IsUrl(), ...(required ? [IsNotEmpty()] : []))
 }
 
 export function EnvEnum(enumType: object, required = true) {

--- a/nest-tax-backend/src/config/environment-decorators.ts
+++ b/nest-tax-backend/src/config/environment-decorators.ts
@@ -69,7 +69,12 @@ export function EnvString(required = true) {
 }
 
 export function EnvUrl(required = true) {
-  return applyDecorators(Expose(), IsUrl(), ...(required ? [IsNotEmpty()] : []))
+  return applyDecorators(
+    Expose(),
+    // require_tld: false so localhost URLs (used for local dev callback URLs) pass validation
+    IsUrl({ require_tld: false }),
+    ...(required ? [IsNotEmpty()] : []),
+  )
 }
 
 export function EnvEnum(enumType: object, required = true) {

--- a/nest-tax-backend/src/config/environment-variables.ts
+++ b/nest-tax-backend/src/config/environment-variables.ts
@@ -1,0 +1,28 @@
+import {
+  EnvBoolean,
+  EnvEnum,
+  EnvInt,
+  EnvPort,
+  EnvString,
+  EnvUrl,
+} from './environment-decorators'
+
+export enum NodeEnv {
+  Development = 'development',
+  Production = 'production',
+  Test = 'test',
+}
+
+export enum ClusterEnv {
+  Dev = 'dev',
+  Staging = 'staging',
+  Production = 'production',
+}
+
+export default class EnvironmentVariables {
+  @EnvEnum(NodeEnv)
+  NODE_ENV: NodeEnv
+
+  @EnvEnum(ClusterEnv)
+  CLUSTER_ENV: ClusterEnv
+}

--- a/nest-tax-backend/src/config/environment-variables.ts
+++ b/nest-tax-backend/src/config/environment-variables.ts
@@ -25,4 +25,154 @@ export default class EnvironmentVariables {
 
   @EnvEnum(ClusterEnv)
   CLUSTER_ENV: ClusterEnv
+
+  @EnvPort()
+  PORT: number
+
+  @EnvString()
+  DATABASE_URL: string
+
+  @EnvInt(1)
+  DB_CONCURRENCY: number
+
+  @EnvUrl()
+  CITY_ACCOUNT_API_URL: string
+
+  @EnvString()
+  CITY_ACCOUNT_ADMIN_API_KEY: string
+
+  @EnvString()
+  COGNITO_USER_POOL_ID: string
+
+  @EnvString()
+  COGNITO_CLIENT_ID: string
+
+  @EnvString()
+  COGNITO_REGION: string
+
+  @EnvString()
+  AWS_COGNITO_ACCESS: string
+
+  @EnvString()
+  AWS_COGNITO_SECRET: string
+
+  @EnvString()
+  ADMIN_APP_SECRET: string
+
+  @EnvString()
+  AWS_SES_SMTP_USERNAME: string
+
+  @EnvString()
+  AWS_SES_SMTP_PASSWORD: string
+
+  @EnvString()
+  AWS_SES_SENDER_EMAIL: string
+
+  @EnvString()
+  PAYGATE_CURRENCY: string
+
+  @EnvUrl()
+  PAYGATE_PAYMENT_REDIRECT_URL: string
+
+  @EnvUrl()
+  PAYGATE_REDIRECT_URL: string
+
+  @EnvUrl()
+  PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND: string
+
+  @EnvString()
+  PAYGATE_KEY: string
+
+  @EnvString()
+  PAYGATE_SIGN_CERT: string
+
+  @EnvString()
+  PAYGATE_MERCHANT_NUMBER: string
+
+  @EnvString()
+  PAYGATE_PASSPHRASE: string
+
+  @EnvString()
+  PAYGATE_KEY_KO: string
+
+  @EnvString()
+  PAYGATE_SIGN_CERT_KO: string
+
+  @EnvString()
+  PAYGATE_MERCHANT_NUMBER_KO: string
+
+  @EnvString()
+  PAYGATE_PASSPHRASE_KO: string
+
+  @EnvString()
+  PAYMENT_QR_BENEFICIARY_NAME: string
+
+  @EnvString()
+  MSSQL_HOST: string
+
+  @EnvString()
+  MSSQL_DB: string
+
+  @EnvString()
+  MSSQL_USERNAME: string
+
+  @EnvString()
+  MSSQL_PASSWORD: string
+
+  @EnvUrl()
+  BLOOMREACH_API_URL: string
+
+  @EnvString()
+  BLOOMREACH_API_KEY: string
+
+  @EnvString()
+  BLOOMREACH_API_SECRET: string
+
+  @EnvString()
+  BLOOMREACH_PROJECT_TOKEN: string
+
+  @EnvBoolean()
+  FEATURE_TOGGLE_UPDATE_TAXES_FROM_NORIS: boolean
+
+  @EnvBoolean()
+  FEATURE_TOGGLE_SEND_BLOOMREACH_EVENTS: boolean
+
+  @EnvString()
+  REPORTING_ICO: string
+
+  @EnvString()
+  REPORTING_SFTP_HOST: string
+
+  @EnvPort()
+  REPORTING_SFTP_PORT: number
+
+  @EnvString()
+  REPORTING_SFTP_USER: string
+
+  @EnvString()
+  REPORTING_SFTP_KEY: string
+
+  @EnvString()
+  REPORTING_FILE_NAME: string
+
+  @EnvString()
+  REPORTING_ACCOUNT_ID: string
+
+  @EnvString()
+  REPORTING_BANK_ID: string
+
+  @EnvString()
+  REPORTING_SFTP_FILES_PATH: string
+
+  @EnvString()
+  REPORTING_PKO_FILE_NAME: string
+
+  @EnvString()
+  REPORTING_PKO_ACCOUNT_ID: string
+
+  @EnvString()
+  REPORTING_PKO_BANK_ID: string
+
+  @EnvString()
+  REPORTING_PKO_SFTP_FILES_PATH: string
 }

--- a/nest-tax-backend/src/config/environment-variables.validate.ts
+++ b/nest-tax-backend/src/config/environment-variables.validate.ts
@@ -1,0 +1,23 @@
+import { plainToInstance } from 'class-transformer'
+import { validateSync } from 'class-validator'
+
+import EnvironmentVariables from './environment-variables'
+
+export default function validateEnvironmentVariables(
+  config: Record<string, unknown>,
+): EnvironmentVariables {
+  const validatedConfig = plainToInstance(EnvironmentVariables, config, {
+    enableImplicitConversion: false, // if left true, boolean always parse as true
+    excludeExtraneousValues: true,
+  })
+
+  const errors = validateSync(validatedConfig, {
+    skipMissingProperties: false,
+  })
+
+  if (errors.length > 0) {
+    throw new Error(`Environment validation failed: ${errors.toString()}`)
+  }
+
+  return validatedConfig
+}

--- a/nest-tax-backend/src/main.ts
+++ b/nest-tax-backend/src/main.ts
@@ -17,7 +17,10 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger,
   })
-  const port = app.get(BaConfigService).self.port
+
+  const baConfigService = app.get(BaConfigService)
+  const port = baConfigService.self.port
+
   app.enableVersioning({
     type: VersioningType.URI,
   })

--- a/nest-tax-backend/src/main.ts
+++ b/nest-tax-backend/src/main.ts
@@ -17,10 +17,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger,
   })
-
   const baConfigService = app.get(BaConfigService)
-  const port = baConfigService.self.port
-
   app.enableVersioning({
     type: VersioningType.URI,
   })
@@ -45,7 +42,7 @@ async function bootstrap() {
       'https://inovacie.bratislava.sk',
       'inovacie@bratislava.sk',
     )
-    .addServer(`http://localhost:${port}/`)
+    .addServer(`http://localhost:${baConfigService.self.port}/`)
     .addServer('https://nest-tax-backend.dev.bratislava.sk/')
     .addServer('https://nest-tax-backend.staging.bratislava.sk/')
     .addServer('https://nest-tax-backend.bratislava.sk/')
@@ -63,7 +60,7 @@ async function bootstrap() {
     .getHttpAdapter()
     .get('/spec-json', (_req: Request, res: Response) => res.json(document))
 
-  await app.listen(port)
-  logger.log(`Nest is running on port: ${port}`)
+  await app.listen(baConfigService.self.port)
+  logger.log(`Nest is running on port: ${baConfigService.self.port}`)
 }
 void bootstrap()

--- a/nest-tax-backend/src/main.ts
+++ b/nest-tax-backend/src/main.ts
@@ -4,6 +4,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import type { Request, Response } from 'express'
 
 import { AppModule } from './app.module'
+import BaConfigService from './config/ba-config.service'
 import {
   ErrorFilter,
   HttpExceptionFilter,
@@ -12,11 +13,11 @@ import {
 import { LineLoggerSubservice } from './utils/subservices/line-logger.subservice'
 
 async function bootstrap() {
-  const port = process.env.PORT || 3000
   const logger = new LineLoggerSubservice('Nest')
   const app = await NestFactory.create(AppModule, {
     logger,
   })
+  const port = app.get(BaConfigService).self.port
   app.enableVersioning({
     type: VersioningType.URI,
   })

--- a/nest-tax-backend/src/noris/subservices/__tests__/noris-connection.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/__tests__/noris-connection.subservice.spec.ts
@@ -1,8 +1,8 @@
 import { createMock } from '@golevelup/ts-jest'
-import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 import mssql, { MSSQLError } from 'mssql'
 
+import BaConfigService from '../../../config/ba-config.service'
 import { PrismaService } from '../../../prisma/prisma.service'
 import { ErrorsEnum } from '../../../utils/guards/dtos/error.dto'
 import ThrowerErrorGuard from '../../../utils/guards/errors.guard'
@@ -15,7 +15,7 @@ jest.spyOn(mssql, 'connect').mockImplementation(mockConnect)
 describe('NorisConnectionSubservice', () => {
   let module: TestingModule
   let service: NorisConnectionSubservice
-  let configService: jest.Mocked<ConfigService>
+  let baConfigService: BaConfigService
   let throwerErrorGuard: ThrowerErrorGuard
   let prismaService: jest.Mocked<PrismaService>
 
@@ -26,37 +26,19 @@ describe('NorisConnectionSubservice', () => {
     close: jest.fn().mockResolvedValue(undefined),
   }
 
-  const originalEnv = process.env
-
   beforeEach(async () => {
     jest.clearAllMocks()
 
     // Assign after clearAllMocks so we hold references to the (now-cleared) mock.
     mockMssqlConnect = mssql.connect as jest.Mock
 
-    process.env = {
-      ...originalEnv,
-      MSSQL_HOST: 'localhost',
-      MSSQL_DB: 'testdb',
-      MSSQL_USERNAME: 'user',
-
-      MSSQL_PASSWORD: 'pass',
-    }
-
-    configService = createMock<ConfigService>({
-      getOrThrow: jest.fn((key: string) => {
-        const map: Record<string, string> = {
-          MSSQL_HOST: 'localhost',
-          MSSQL_DB: 'testdb',
-          MSSQL_USERNAME: 'user',
-
-          MSSQL_PASSWORD: 'pass',
-        }
-        if (key in map) {
-          return map[key]
-        }
-        throw new Error(`Unknown key: ${key}`)
-      }),
+    baConfigService = createMock<BaConfigService>({
+      noris: {
+        host: 'localhost',
+        database: 'testdb',
+        username: 'user',
+        password: 'pass',
+      },
     })
 
     prismaService = createMock<PrismaService>()
@@ -64,7 +46,7 @@ describe('NorisConnectionSubservice', () => {
     module = await Test.createTestingModule({
       providers: [
         NorisConnectionSubservice,
-        { provide: ConfigService, useValue: configService },
+        { provide: BaConfigService, useValue: baConfigService },
         ThrowerErrorGuard,
         { provide: PrismaService, useValue: prismaService },
       ],
@@ -75,7 +57,6 @@ describe('NorisConnectionSubservice', () => {
   })
 
   afterEach(async () => {
-    process.env = originalEnv
     await module.close()
   })
 

--- a/nest-tax-backend/src/noris/subservices/__tests__/noris-payment.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/__tests__/noris-payment.subservice.spec.ts
@@ -6,6 +6,7 @@ import * as mssql from 'mssql'
 import prismaMock from '../../../../test/singleton'
 import { createTestTax } from '../../../__tests__/factories/tax.factory'
 import { BloomreachService } from '../../../bloomreach/bloomreach.service'
+import BaConfigService from '../../../config/ba-config.service'
 import {
   PaymentStatus,
   Prisma,
@@ -84,6 +85,10 @@ describe('NorisPaymentSubservice', () => {
         {
           provide: NorisValidatorSubservice,
           useValue: createMock<NorisValidatorSubservice>(),
+        },
+        {
+          provide: BaConfigService,
+          useValue: { database: { concurrency: 10 } },
         },
       ],
     }).compile()

--- a/nest-tax-backend/src/noris/subservices/noris-connection.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-connection.subservice.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnModuleDestroy } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { connect, ConnectionError, ConnectionPool, MSSQLError } from 'mssql'
 
+import BaConfigService from '../../config/ba-config.service'
 import { PrismaService } from '../../prisma/prisma.service'
 import { NORIS_SILENT_CONNECTION_ERRORS_KEY } from '../../utils/constants'
 import { ErrorsEnum } from '../../utils/guards/dtos/error.dto'
@@ -16,22 +16,10 @@ export class NorisConnectionSubservice implements OnModuleDestroy {
   )
 
   constructor(
-    private readonly configService: ConfigService,
+    private readonly baConfigService: BaConfigService,
     private readonly throwerErrorGuard: ThrowerErrorGuard,
     private readonly prismaService: PrismaService,
-  ) {
-    if (
-      !process.env.MSSQL_HOST ||
-      !process.env.MSSQL_DB ||
-      !process.env.MSSQL_USERNAME ||
-      !process.env.MSSQL_PASSWORD
-    ) {
-      throw this.throwerErrorGuard.InternalServerErrorException(
-        ErrorsEnum.INTERNAL_SERVER_ERROR,
-        'Missing one of noris envs: MSSQL_HOST, MSSQL_DB, MSSQL_USERNAME, MSSQL_PASSWORD.',
-      )
-    }
-  }
+  ) {}
 
   async onModuleDestroy(): Promise<void> {
     try {
@@ -52,13 +40,13 @@ export class NorisConnectionSubservice implements OnModuleDestroy {
 
   private async createConnection(): Promise<ConnectionPool> {
     return await connect({
-      server: this.configService.getOrThrow<string>('MSSQL_HOST'),
+      server: this.baConfigService.noris.host,
       port: 1433,
-      database: this.configService.getOrThrow<string>('MSSQL_DB'),
-      user: this.configService.getOrThrow<string>('MSSQL_USERNAME'),
+      database: this.baConfigService.noris.database,
+      user: this.baConfigService.noris.username,
       connectionTimeout: 120_000,
       requestTimeout: 120_000,
-      password: this.configService.getOrThrow<string>('MSSQL_PASSWORD'),
+      password: this.baConfigService.noris.password,
       options: {
         encrypt: true,
         trustServerCertificate: true,

--- a/nest-tax-backend/src/noris/subservices/noris-payment.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-payment.subservice.ts
@@ -11,6 +11,7 @@ import {
   RequestPostNorisPaymentDataLoadDto,
 } from '../../admin/dtos/requests.dto'
 import { BloomreachService } from '../../bloomreach/bloomreach.service'
+import BaConfigService from '../../config/ba-config.service'
 import { PaymentStatus, TaxPayment } from '../../generated/prisma/client'
 import { PrismaService } from '../../prisma/prisma.service'
 import {
@@ -36,9 +37,7 @@ import { NorisValidatorSubservice } from './noris-validator.subservice'
 export class NorisPaymentSubservice {
   private readonly logger: Logger = new Logger('NorisService')
 
-  private readonly concurrency = Number(process.env.DB_CONCURRENCY ?? 10)
-
-  private readonly concurrencyLimit = pLimit(this.concurrency)
+  private readonly concurrencyLimit: ReturnType<typeof pLimit>
 
   constructor(
     private readonly throwerErrorGuard: ThrowerErrorGuard,
@@ -47,7 +46,10 @@ export class NorisPaymentSubservice {
     private readonly cityAccountSubservice: CityAccountSubservice,
     private readonly bloomreachService: BloomreachService,
     private readonly norisValidatorSubservice: NorisValidatorSubservice,
-  ) {}
+    private readonly baConfigService: BaConfigService,
+  ) {
+    this.concurrencyLimit = pLimit(this.baConfigService.database.concurrency)
+  }
 
   async getPaymentDataFromNoris(
     data: RequestPostNorisPaymentDataLoadDto,

--- a/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.communal-waste.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.communal-waste.subservice.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing'
 import * as mssql from 'mssql'
 
 import { BloomreachService } from '../../../../bloomreach/bloomreach.service'
+import BaConfigService from '../../../../config/ba-config.service'
 import { TaxType } from '../../../../generated/prisma/client'
 import { PrismaService } from '../../../../prisma/prisma.service'
 import { QrCodeService } from '../../../../qrcode/qrcode.service'
@@ -76,6 +77,10 @@ describe('NorisTaxCommunalWasteSubservice', () => {
         {
           provide: DatabaseSubservice,
           useValue: createMock<DatabaseSubservice>(),
+        },
+        {
+          provide: BaConfigService,
+          useValue: { database: { concurrency: 10 } },
         },
       ],
     }).compile()

--- a/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.real-estate.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/__tests__/noris-tax.real-estate.subservice.spec.ts
@@ -8,6 +8,7 @@ import { createTestTax } from '../../../../__tests__/factories/tax.factory'
 import { createTestTaxAdministratorEntry } from '../../../../__tests__/factories/taxAdministrator.factory'
 import { createTestTaxPayer } from '../../../../__tests__/factories/taxPayer.factory'
 import { BloomreachService } from '../../../../bloomreach/bloomreach.service'
+import BaConfigService from '../../../../config/ba-config.service'
 import {
   TaxAdministrator,
   TaxPayer,
@@ -196,6 +197,10 @@ describe('NorisTaxRealEstateSubservice', () => {
         {
           provide: DatabaseSubservice,
           useValue: createMock<DatabaseSubservice>(),
+        },
+        {
+          provide: BaConfigService,
+          useValue: { database: { concurrency: 10 } },
         },
       ],
     }).compile()

--- a/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.communal-waste.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.communal-waste.subservice.ts
@@ -3,6 +3,7 @@ import groupBy from 'lodash/groupBy'
 import * as mssql from 'mssql'
 
 import { BloomreachService } from '../../../bloomreach/bloomreach.service'
+import BaConfigService from '../../../config/ba-config.service'
 import { TaxType } from '../../../generated/prisma/client'
 import { PrismaService } from '../../../prisma/prisma.service'
 import { QrCodeService } from '../../../qrcode/qrcode.service'
@@ -42,6 +43,7 @@ export class NorisTaxCommunalWasteSubservice extends AbstractNorisTaxSubservice<
     cityAccountSubservice: CityAccountSubservice,
     paymentSubservice: NorisPaymentSubservice,
     databaseSubservice: DatabaseSubservice,
+    baConfigService: BaConfigService,
   ) {
     const logger = new LineLoggerSubservice(
       NorisTaxCommunalWasteSubservice.name,
@@ -55,6 +57,7 @@ export class NorisTaxCommunalWasteSubservice extends AbstractNorisTaxSubservice<
       logger,
       cityAccountSubservice,
       paymentSubservice,
+      baConfigService,
     )
   }
 

--- a/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.real-estate.subservice.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.real-estate.subservice.ts
@@ -2,6 +2,7 @@ import { HttpException, Injectable } from '@nestjs/common'
 import * as mssql from 'mssql'
 
 import { BloomreachService } from '../../../bloomreach/bloomreach.service'
+import BaConfigService from '../../../config/ba-config.service'
 import { TaxType } from '../../../generated/prisma/client'
 import { PrismaService } from '../../../prisma/prisma.service'
 import { QrCodeService } from '../../../qrcode/qrcode.service'
@@ -34,6 +35,7 @@ export class NorisTaxRealEstateSubservice extends AbstractNorisTaxSubservice<
     cityAccountSubservice: CityAccountSubservice,
     paymentSubservice: NorisPaymentSubservice,
     databaseSubservice: DatabaseSubservice,
+    baConfigService: BaConfigService,
   ) {
     const logger = new LineLoggerSubservice(NorisTaxRealEstateSubservice.name)
     super(
@@ -45,6 +47,7 @@ export class NorisTaxRealEstateSubservice extends AbstractNorisTaxSubservice<
       logger,
       cityAccountSubservice,
       paymentSubservice,
+      baConfigService,
     )
   }
 

--- a/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
+++ b/nest-tax-backend/src/noris/subservices/noris-tax/noris-tax.subservice.abstract.ts
@@ -5,6 +5,7 @@ import pLimit from 'p-limit'
 import { RequestPostNorisLoadDataOptionsDto } from '../../../admin/dtos/requests.dto'
 import { CreateBirthNumbersResponseDto } from '../../../admin/dtos/responses.dto'
 import { BloomreachService } from '../../../bloomreach/bloomreach.service'
+import BaConfigService from '../../../config/ba-config.service'
 import {
   Prisma,
   Tax,
@@ -34,9 +35,7 @@ import {
 import { NorisPaymentSubservice } from '../noris-payment.subservice'
 
 export abstract class AbstractNorisTaxSubservice<TTaxType extends TaxType> {
-  protected readonly concurrency = Number(process.env.DB_CONCURRENCY ?? 10)
-
-  protected readonly concurrencyLimit = pLimit(this.concurrency)
+  protected readonly concurrencyLimit: ReturnType<typeof pLimit>
 
   protected constructor(
     protected readonly qrCodeService: QrCodeService,
@@ -47,7 +46,10 @@ export abstract class AbstractNorisTaxSubservice<TTaxType extends TaxType> {
     protected readonly logger: LineLoggerSubservice,
     protected readonly cityAccountSubservice: CityAccountSubservice,
     protected readonly paymentSubservice: NorisPaymentSubservice,
-  ) {}
+    protected readonly baConfigService: BaConfigService,
+  ) {
+    this.concurrencyLimit = pLimit(this.baConfigService.database.concurrency)
+  }
 
   /**
    * Gets the tax definition for this tax type.

--- a/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
+++ b/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
@@ -759,20 +759,24 @@ describe('PaymentService', () => {
   describe('getRedirectUrl', () => {
     it('should append taxType to base URL without trailing slash', () => {
       baConfigService.paygate.redirectUrl =
-        'http://localhost:3000/payment/cardpay/response'
+        'http://payments.example.com:3000/payment/cardpay/response'
 
       const result = service['getRedirectUrl'](TaxType.DZN)
 
-      expect(result).toBe('http://localhost:3000/payment/cardpay/response/DZN')
+      expect(result).toBe(
+        'http://payments.example.com:3000/payment/cardpay/response/DZN',
+      )
     })
 
     it('should append taxType to base URL with trailing slash', () => {
       baConfigService.paygate.redirectUrl =
-        'http://localhost:3000/payment/cardpay/response/'
+        'http://payments.example.com:3000/payment/cardpay/response/'
 
       const result = service['getRedirectUrl'](TaxType.KO)
 
-      expect(result).toBe('http://localhost:3000/payment/cardpay/response/KO')
+      expect(result).toBe(
+        'http://payments.example.com:3000/payment/cardpay/response/KO',
+      )
     })
 
     it('should handle different TaxType values', () => {
@@ -806,11 +810,13 @@ describe('PaymentService', () => {
 
     it('should handle base URL with port number', () => {
       baConfigService.paygate.redirectUrl =
-        'http://localhost:8080/payment/response'
+        'http://payments.example.com:8080/payment/response'
 
       const result = service['getRedirectUrl'](TaxType.KO)
 
-      expect(result).toBe('http://localhost:8080/payment/response/KO')
+      expect(result).toBe(
+        'http://payments.example.com:8080/payment/response/KO',
+      )
     })
 
     it('should handle base URL ending with multiple slashes', () => {

--- a/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
+++ b/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
@@ -1,12 +1,12 @@
 import { createMock } from '@golevelup/ts-jest'
 import { HttpException, HttpStatus } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 
 import prismaMock from '../../../test/singleton'
 import { createTestTaxPayment } from '../../__tests__/factories/taxPayment.factory'
 import { createTestUserDataFromCityAccount } from '../../__tests__/factories/userDataFromCityAccount.factory'
 import { BloomreachService } from '../../bloomreach/bloomreach.service'
+import BaConfigService from '../../config/ba-config.service'
 import {
   PaymentStatus,
   Prisma,
@@ -23,17 +23,40 @@ import { PaymentRedirectStateEnum } from '../dtos/redirect.payent.dto'
 import { PaymentService } from '../payment.service'
 import { GpWebpaySubservice } from '../subservices/gpwebpay.subservice'
 
+const createMockBaConfigService = () => ({
+  paygate: {
+    currency: 'mock-value',
+    paymentRedirectUrl: 'mock-value',
+    redirectUrl: 'mock-value',
+    afterPaymentRedirectFrontend: 'https://frontend.url',
+    [TaxType.DZN]: {
+      key: 'mock-value',
+      signCert: 'mock-value',
+      merchantNumber: '12345',
+      passphrase: 'mock-value',
+    },
+    [TaxType.KO]: {
+      key: 'mock-value',
+      signCert: 'mock-value',
+      merchantNumber: '12345',
+      passphrase: 'mock-value',
+    },
+  },
+})
+
 describe('PaymentService', () => {
   let service: PaymentService
   let bloomreachService: BloomreachService
   let throwerErrorGuard: ThrowerErrorGuard
   let gpWebpaySubservice: GpWebpaySubservice
   let retryService: RetryService
-  let configService: ConfigService
+  let baConfigService: ReturnType<typeof createMockBaConfigService>
 
   beforeEach(async () => {
     jest.resetModules()
     jest.spyOn(console, 'log').mockImplementation(jest.fn())
+
+    baConfigService = createMockBaConfigService()
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -48,8 +71,8 @@ describe('PaymentService', () => {
           useValue: createMock<ThrowerErrorGuard>(),
         },
         {
-          provide: ConfigService,
-          useValue: createMock<ConfigService>(),
+          provide: BaConfigService,
+          useValue: baConfigService,
         },
         GpWebpaySubservice,
         {
@@ -72,22 +95,6 @@ describe('PaymentService', () => {
     throwerErrorGuard = module.get<ThrowerErrorGuard>(ThrowerErrorGuard)
     gpWebpaySubservice = module.get<GpWebpaySubservice>(GpWebpaySubservice)
     retryService = module.get<RetryService>(RetryService)
-    configService = module.get<ConfigService>(ConfigService)
-
-    jest
-      .spyOn(configService, 'getOrThrow')
-      .mockImplementation((key: string) => {
-        switch (key) {
-          case 'PAYGATE_MERCHANT_NUMBER':
-            return '12345'
-
-          case 'PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND':
-            return 'https://frontend.url'
-
-          default:
-            return 'mock-value'
-        }
-      })
   })
 
   afterEach(() => {
@@ -428,11 +435,6 @@ describe('PaymentService', () => {
       },
     })
 
-    beforeEach(() => {
-      process.env.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND =
-        'https://frontend.url'
-    })
-
     it.each([
       {
         prCode: '14',
@@ -494,7 +496,7 @@ describe('PaymentService', () => {
 
       expect(trackSpy).not.toHaveBeenCalled()
       expect(result).toBe(
-        `${process.env.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND}?status=${PaymentRedirectStateEnum.FAILED_TO_VERIFY}`,
+        `${baConfigService.paygate.afterPaymentRedirectFrontend}?status=${PaymentRedirectStateEnum.FAILED_TO_VERIFY}`,
       )
     })
 
@@ -515,7 +517,7 @@ describe('PaymentService', () => {
 
       expect(trackSpy).not.toHaveBeenCalled()
       expect(result).toBe(
-        `${process.env.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND}?status=${PaymentRedirectStateEnum.FAILED_TO_VERIFY}`,
+        `${baConfigService.paygate.afterPaymentRedirectFrontend}?status=${PaymentRedirectStateEnum.FAILED_TO_VERIFY}`,
       )
     })
 
@@ -534,7 +536,7 @@ describe('PaymentService', () => {
 
       expect(trackSpy).not.toHaveBeenCalled()
       expect(result).toBe(
-        `${process.env.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND}?status=${PaymentRedirectStateEnum.PAYMENT_FAILED}`,
+        `${baConfigService.paygate.afterPaymentRedirectFrontend}?status=${PaymentRedirectStateEnum.PAYMENT_FAILED}`,
       )
     })
 
@@ -756,14 +758,8 @@ describe('PaymentService', () => {
 
   describe('getRedirectUrl', () => {
     it('should append taxType to base URL without trailing slash', () => {
-      jest
-        .spyOn(configService, 'getOrThrow')
-        .mockImplementation((key: string) => {
-          if (key === 'PAYGATE_REDIRECT_URL') {
-            return 'http://localhost:3000/payment/cardpay/response'
-          }
-          return 'mock-value'
-        })
+      baConfigService.paygate.redirectUrl =
+        'http://localhost:3000/payment/cardpay/response'
 
       const result = service['getRedirectUrl'](TaxType.DZN)
 
@@ -771,14 +767,8 @@ describe('PaymentService', () => {
     })
 
     it('should append taxType to base URL with trailing slash', () => {
-      jest
-        .spyOn(configService, 'getOrThrow')
-        .mockImplementation((key: string) => {
-          if (key === 'PAYGATE_REDIRECT_URL') {
-            return 'http://localhost:3000/payment/cardpay/response/'
-          }
-          return 'mock-value'
-        })
+      baConfigService.paygate.redirectUrl =
+        'http://localhost:3000/payment/cardpay/response/'
 
       const result = service['getRedirectUrl'](TaxType.KO)
 
@@ -786,14 +776,8 @@ describe('PaymentService', () => {
     })
 
     it('should handle different TaxType values', () => {
-      jest
-        .spyOn(configService, 'getOrThrow')
-        .mockImplementation((key: string) => {
-          if (key === 'PAYGATE_REDIRECT_URL') {
-            return 'https://example.com/payment/response'
-          }
-          return 'mock-value'
-        })
+      baConfigService.paygate.redirectUrl =
+        'https://example.com/payment/response'
 
       const resultDZN = service['getRedirectUrl'](TaxType.DZN)
       const resultKO = service['getRedirectUrl'](TaxType.KO)
@@ -803,14 +787,8 @@ describe('PaymentService', () => {
     })
 
     it('should handle base URL with query parameters', () => {
-      jest
-        .spyOn(configService, 'getOrThrow')
-        .mockImplementation((key: string) => {
-          if (key === 'PAYGATE_REDIRECT_URL') {
-            return 'https://example.com/payment/response?param=value'
-          }
-          return 'mock-value'
-        })
+      baConfigService.paygate.redirectUrl =
+        'https://example.com/payment/response?param=value'
 
       const result = service['getRedirectUrl'](TaxType.DZN)
 
@@ -818,14 +796,8 @@ describe('PaymentService', () => {
     })
 
     it('should handle base URL with hash', () => {
-      jest
-        .spyOn(configService, 'getOrThrow')
-        .mockImplementation((key: string) => {
-          if (key === 'PAYGATE_REDIRECT_URL') {
-            return 'https://example.com/payment/response#section'
-          }
-          return 'mock-value'
-        })
+      baConfigService.paygate.redirectUrl =
+        'https://example.com/payment/response#section'
 
       const result = service['getRedirectUrl'](TaxType.DZN)
 
@@ -833,14 +805,8 @@ describe('PaymentService', () => {
     })
 
     it('should handle base URL with port number', () => {
-      jest
-        .spyOn(configService, 'getOrThrow')
-        .mockImplementation((key: string) => {
-          if (key === 'PAYGATE_REDIRECT_URL') {
-            return 'http://localhost:8080/payment/response'
-          }
-          return 'mock-value'
-        })
+      baConfigService.paygate.redirectUrl =
+        'http://localhost:8080/payment/response'
 
       const result = service['getRedirectUrl'](TaxType.KO)
 
@@ -848,14 +814,8 @@ describe('PaymentService', () => {
     })
 
     it('should handle base URL ending with multiple slashes', () => {
-      jest
-        .spyOn(configService, 'getOrThrow')
-        .mockImplementation((key: string) => {
-          if (key === 'PAYGATE_REDIRECT_URL') {
-            return 'https://example.com/payment/response//'
-          }
-          return 'mock-value'
-        })
+      baConfigService.paygate.redirectUrl =
+        'https://example.com/payment/response//'
 
       const result = service['getRedirectUrl'](TaxType.DZN)
 

--- a/nest-tax-backend/src/payment/payment.service.ts
+++ b/nest-tax-backend/src/payment/payment.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import formurlencoded from 'form-urlencoded'
 
 import { BloomreachService } from '../bloomreach/bloomreach.service'
+import BaConfigService from '../config/ba-config.service'
 import {
   PaymentStatus,
   Prisma,
@@ -26,10 +26,7 @@ import {
 import { PaymentGateURLGeneratorDto } from './dtos/generator.dto'
 import { PaymentResponseQueryDto } from './dtos/gpwebpay.dto'
 import { PaymentRedirectStateEnum } from './dtos/redirect.payent.dto'
-import {
-  GP_WEBPAY_CONFIG_KEY_MAP,
-  GpWebpaySubservice,
-} from './subservices/gpwebpay.subservice'
+import { GpWebpaySubservice } from './subservices/gpwebpay.subservice'
 
 interface GpWebpayProcessingStrategy {
   dbStatus: 'SUCCESS' | 'NEW_TO_FAILED' | 'KEEP_CURRENT'
@@ -46,16 +43,14 @@ export class PaymentService {
     private readonly gpWebpaySubservice: GpWebpaySubservice,
     private readonly cityAccountSubservice: CityAccountSubservice,
     private readonly bloomreachService: BloomreachService,
-    private readonly configService: ConfigService,
+    private readonly baConfigService: BaConfigService,
     private readonly throwerErrorGuard: ThrowerErrorGuard,
     private readonly taxService: TaxService,
     private readonly retryService: RetryService,
   ) {}
 
   private getRedirectUrl(taxType: TaxType) {
-    const redirectUrl = this.configService.getOrThrow<string>(
-      'PAYGATE_REDIRECT_URL',
-    )
+    const redirectUrl = this.baConfigService.paygate.redirectUrl
 
     const url = new URL(redirectUrl)
 
@@ -98,13 +93,11 @@ export class PaymentService {
       // data that goes to payment gateway should not contain diacritics
       const redirectUrl = this.getRedirectUrl(options.taxType)
       const requestData = {
-        MERCHANTNUMBER: this.configService.getOrThrow<string>(
-          GP_WEBPAY_CONFIG_KEY_MAP[options.taxType].PAYGATE_MERCHANT_NUMBER,
-        ),
+        MERCHANTNUMBER: this.baConfigService.paygate[options.taxType].merchantNumber,
         OPERATION: 'CREATE_ORDER',
         ORDERNUMBER: orderId,
         AMOUNT: payment.amount.toString(),
-        CURRENCY: this.configService.getOrThrow<string>('PAYGATE_CURRENCY'),
+        CURRENCY: this.baConfigService.paygate.currency,
         DEPOSITFLAG: '1',
         URL: redirectUrl,
         DESCRIPTION: options.description,
@@ -114,7 +107,7 @@ export class PaymentService {
         options.taxType,
         requestData,
       )
-      return `${this.configService.getOrThrow<string>('PAYGATE_PAYMENT_REDIRECT_URL')}?${formurlencoded(
+      return `${this.baConfigService.paygate.paymentRedirectUrl}?${formurlencoded(
         signedData,
         {
           ignorenull: true,
@@ -239,7 +232,7 @@ export class PaymentService {
     }: PaymentResponseQueryDto,
   ): Promise<string> {
     if (!ORDERNUMBER) {
-      return `${process.env.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND}?status=${PaymentRedirectStateEnum.FAILED_TO_VERIFY}`
+      return `${this.baConfigService.paygate.afterPaymentRedirectFrontend}?status=${PaymentRedirectStateEnum.FAILED_TO_VERIFY}`
     }
 
     try {
@@ -255,14 +248,14 @@ export class PaymentService {
           this.gpWebpaySubservice.verifyData(taxType, dataToVerify, DIGEST) &&
           this.gpWebpaySubservice.verifyData(
             taxType,
-            `${dataToVerify}|${this.configService.getOrThrow<string>(GP_WEBPAY_CONFIG_KEY_MAP[taxType].PAYGATE_MERCHANT_NUMBER)}`,
+            `${dataToVerify}|${this.baConfigService.paygate[taxType].merchantNumber}`,
             DIGEST1,
           )
         )
       ) {
         // We failed to verify this payment. If we have any side effects here, they can be triggered
         // by just guessing the ORDERNUMBER we generate as a timestamp.
-        return `${process.env.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND}?status=${PaymentRedirectStateEnum.FAILED_TO_VERIFY}`
+        return `${this.baConfigService.paygate.afterPaymentRedirectFrontend}?status=${PaymentRedirectStateEnum.FAILED_TO_VERIFY}`
       }
 
       const taxPaymentWithTax: Prisma.TaxPaymentGetPayload<{
@@ -281,7 +274,7 @@ export class PaymentService {
             `We received a valid payment response for payment we do not have in our database. ORDERNUMBER: ${ORDERNUMBER}`,
           ),
         )
-        return `${process.env.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND}?status=${PaymentRedirectStateEnum.PAYMENT_FAILED}`
+        return `${this.baConfigService.paygate.afterPaymentRedirectFrontend}?status=${PaymentRedirectStateEnum.PAYMENT_FAILED}`
       }
 
       const strategy = this.getProcessingStrategy(PRCODE)
@@ -355,7 +348,7 @@ export class PaymentService {
         )
       }
 
-      return `${process.env.PAYGATE_AFTER_PAYMENT_REDIRECT_FRONTEND}?status=${strategy.feState}&taxType=${type}&year=${year}&order=${order}`
+      return `${this.baConfigService.paygate.afterPaymentRedirectFrontend}?status=${strategy.feState}&taxType=${type}&year=${year}&order=${order}`
     } catch (error) {
       throw this.throwerErrorGuard.UnprocessableEntityException(
         CustomErrorPaymentResponseTypesEnum.PAYMENT_RESPONSE_ERROR,

--- a/nest-tax-backend/src/payment/subservices/__tests__/gpwebpay.subservice.spec.ts
+++ b/nest-tax-backend/src/payment/subservices/__tests__/gpwebpay.subservice.spec.ts
@@ -1,9 +1,9 @@
 import crypto, { Sign, Verify } from 'node:crypto'
 
 import { createMock } from '@golevelup/ts-jest'
-import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 
+import BaConfigService from '../../../config/ba-config.service'
 import { TaxType } from '../../../generated/prisma/client'
 import {
   CreateOrderData,
@@ -14,25 +14,21 @@ import { GpWebpaySubservice } from '../gpwebpay.subservice'
 describe('GpWebpaySubservice', () => {
   let service: GpWebpaySubservice
 
-  const mockConfigService = {
-    getOrThrow: jest.fn((key: string) => {
-      switch (key) {
-        case 'PAYGATE_SIGN_CERT':
-          return 'mock-cert'
-
-        case 'PAYGATE_KEY':
-          return 'mock-key'
-
-        case 'PAYGATE_MERCHANT_NUMBER':
-          return 'mock-merchant-number'
-
-        case 'PAYGATE_PASSPHRASE':
-          return 'mock-passphrase'
-
-        default:
-          throw new Error('Invalid key')
-      }
-    }),
+  const mockBaConfigService = {
+    paygate: {
+      [TaxType.DZN]: {
+        key: 'mock-key',
+        signCert: 'mock-cert',
+        merchantNumber: 'mock-merchant-number',
+        passphrase: 'mock-passphrase',
+      },
+      [TaxType.KO]: {
+        key: 'mock-key-ko',
+        signCert: 'mock-cert-ko',
+        merchantNumber: 'mock-merchant-number-ko',
+        passphrase: 'mock-passphrase-ko',
+      },
+    },
   }
 
   beforeEach(async () => {
@@ -40,8 +36,8 @@ describe('GpWebpaySubservice', () => {
       providers: [
         GpWebpaySubservice,
         {
-          provide: ConfigService,
-          useValue: mockConfigService,
+          provide: BaConfigService,
+          useValue: mockBaConfigService,
         },
       ],
     }).compile()

--- a/nest-tax-backend/src/payment/subservices/gpwebpay.subservice.ts
+++ b/nest-tax-backend/src/payment/subservices/gpwebpay.subservice.ts
@@ -1,8 +1,8 @@
 import crypto from 'node:crypto'
 
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 
+import BaConfigService from '../../config/ba-config.service'
 import { TaxType } from '../../generated/prisma/client'
 import {
   CreateOrderData,
@@ -10,34 +10,9 @@ import {
   SignedOrderData,
 } from '../dtos/gpwebpay.dto'
 
-export const GP_WEBPAY_CONFIG_KEY_MAP: Record<
-  TaxType,
-  {
-    PAYGATE_KEY: string
-    PAYGATE_SIGN_CERT: string
-    PAYGATE_MERCHANT_NUMBER: string
-    PAYGATE_PASSPHRASE: string
-  }
-> = {
-  [TaxType.DZN]: {
-    PAYGATE_KEY: 'PAYGATE_KEY',
-    PAYGATE_SIGN_CERT: 'PAYGATE_SIGN_CERT',
-    PAYGATE_MERCHANT_NUMBER: 'PAYGATE_MERCHANT_NUMBER',
-    // eslint-disable-next-line sonarjs/no-hardcoded-passwords
-    PAYGATE_PASSPHRASE: 'PAYGATE_PASSPHRASE',
-  },
-  [TaxType.KO]: {
-    PAYGATE_KEY: 'PAYGATE_KEY_KO',
-    PAYGATE_SIGN_CERT: 'PAYGATE_SIGN_CERT_KO',
-    PAYGATE_MERCHANT_NUMBER: 'PAYGATE_MERCHANT_NUMBER_KO',
-    // eslint-disable-next-line sonarjs/no-hardcoded-passwords
-    PAYGATE_PASSPHRASE: 'PAYGATE_PASSPHRASE_KO',
-  },
-}
-
 @Injectable()
 export class GpWebpaySubservice {
-  constructor(private readonly configService: ConfigService) {}
+  constructor(private readonly baConfigService: BaConfigService) {}
 
   private readonly getDataToSign = (data: CreateOrderData): string => {
     const digestData: (keyof CreateOrderData)[] = [
@@ -82,15 +57,11 @@ export class GpWebpaySubservice {
     signer.write(this.getDataToSign(data))
     signer.end()
 
-    const key = this.configService.getOrThrow<string>(
-      GP_WEBPAY_CONFIG_KEY_MAP[taxType].PAYGATE_KEY,
-    )
+    const { key, passphrase } = this.baConfigService.paygate[taxType]
     const signature = signer.sign(
       {
         key,
-        passphrase: this.configService.getOrThrow<string>(
-          GP_WEBPAY_CONFIG_KEY_MAP[taxType].PAYGATE_PASSPHRASE,
-        ),
+        passphrase,
       },
       'base64',
     )
@@ -108,9 +79,7 @@ export class GpWebpaySubservice {
     verifier.end()
 
     return verifier.verify(
-      this.configService.getOrThrow<string>(
-        GP_WEBPAY_CONFIG_KEY_MAP[taxType].PAYGATE_SIGN_CERT,
-      ),
+      this.baConfigService.paygate[taxType].signCert,
       digest,
       'base64',
     )

--- a/nest-tax-backend/src/prisma/prisma.service.ts
+++ b/nest-tax-backend/src/prisma/prisma.service.ts
@@ -1,32 +1,35 @@
 import { Injectable, OnModuleInit } from '@nestjs/common'
 import { PrismaPg } from '@prisma/adapter-pg'
 
+import BaConfigService from '../config/ba-config.service'
 import { PrismaClient } from '../generated/prisma/client'
 import type * as Prisma from '../generated/prisma/internal/prismaNamespace'
 import { escapeForLogfmt } from '../utils/logging'
 import { LineLoggerSubservice } from '../utils/subservices/line-logger.subservice'
 
-const prismaClientOptions = {
-  adapter: new PrismaPg({
-    connectionString: process.env.DATABASE_URL,
-  }),
-  log: [
-    { emit: 'event', level: 'info' },
-    { emit: 'event', level: 'warn' },
-    { emit: 'event', level: 'error' },
-  ],
-  errorFormat: 'colorless',
-} satisfies Prisma.PrismaClientOptions
+const getPrismaClientOptions = (connectionString: string) => {
+  return {
+    adapter: new PrismaPg({
+      connectionString,
+    }),
+    log: [
+      { emit: 'event', level: 'info' },
+      { emit: 'event', level: 'warn' },
+      { emit: 'event', level: 'error' },
+    ],
+    errorFormat: 'colorless',
+  } satisfies Prisma.PrismaClientOptions
+}
 
 @Injectable()
 export class PrismaService
-  extends PrismaClient<typeof prismaClientOptions>
+  extends PrismaClient<ReturnType<typeof getPrismaClientOptions>>
   implements OnModuleInit
 {
   private readonly logger: LineLoggerSubservice
 
-  constructor() {
-    super(prismaClientOptions)
+  constructor(baConfigService: BaConfigService) {
+    super(getPrismaClientOptions(baConfigService.database.url))
 
     this.logger = new LineLoggerSubservice(PrismaService.name)
     this.$on('info', (e) => {

--- a/nest-tax-backend/src/qrcode/qrcode.service.ts
+++ b/nest-tax-backend/src/qrcode/qrcode.service.ts
@@ -1,18 +1,15 @@
 import { randomUUID } from 'node:crypto'
 
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { DataModel, generate, PaymentOptions } from 'bysquare'
 import * as qrCode from 'qrcode'
 
+import BaConfigService from '../config/ba-config.service'
 import { QrCodeGeneratorDto } from './dtos/qrcode.dto'
 
 @Injectable()
 export class QrCodeService {
-  constructor(private readonly configService: ConfigService) {
-    // Check if the required environment variables are set
-    this.configService.getOrThrow<string>('PAYMENT_QR_BENEFICIARY_NAME')
-  }
+  constructor(private readonly baConfigService: BaConfigService) {}
 
   async createQrCode(qrCodeData: QrCodeGeneratorDto) {
     const model: DataModel = {
@@ -23,9 +20,7 @@ export class QrCodeService {
           amount: qrCodeData.amount / 100,
           bankAccounts: [{ iban: qrCodeData.iban }],
           beneficiary: {
-            name: this.configService.getOrThrow<string>(
-              'PAYMENT_QR_BENEFICIARY_NAME',
-            ),
+            name: this.baConfigService.qrCode.beneficiaryName,
           },
           currencyCode: 'EUR',
           variableSymbol: qrCodeData.variableSymbol,

--- a/nest-tax-backend/src/qrcode/qrcode.service.ts
+++ b/nest-tax-backend/src/qrcode/qrcode.service.ts
@@ -20,7 +20,7 @@ export class QrCodeService {
           amount: qrCodeData.amount / 100,
           bankAccounts: [{ iban: qrCodeData.iban }],
           beneficiary: {
-            name: this.baConfigService.qrCode.beneficiaryName,
+            name: this.baConfigService.payment.beneficiaryName,
           },
           currencyCode: 'EUR',
           variableSymbol: qrCodeData.variableSymbol,

--- a/nest-tax-backend/src/tasks/__tests__/tasks.service.spec.ts
+++ b/nest-tax-backend/src/tasks/__tests__/tasks.service.spec.ts
@@ -1,6 +1,5 @@
 import { createMock } from '@golevelup/ts-jest'
 import { HttpException, HttpStatus } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 
 import prismaMock from '../../../test/singleton'
@@ -23,7 +22,6 @@ describe('TasksService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TasksService,
-        { provide: ConfigService, useValue: createMock<ConfigService>() },
         ThrowerErrorGuard,
         {
           provide: ReportingTasksService,

--- a/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
+++ b/nest-tax-backend/src/tasks/subservices/__tests__/notifications-events.service.spec.ts
@@ -11,6 +11,7 @@ import { createTestTaxPayer } from '../../../__tests__/factories/taxPayer.factor
 import { createTestTaxPayment } from '../../../__tests__/factories/taxPayment.factory'
 import { createTestUserDataFromCityAccount } from '../../../__tests__/factories/userDataFromCityAccount.factory'
 import { BloomreachService } from '../../../bloomreach/bloomreach.service'
+import BaConfigService from '../../../config/ba-config.service'
 import {
   DeliveryMethodNamed,
   PaymentStatus,
@@ -127,6 +128,10 @@ describe('NotificationsEventsSubservice', () => {
         {
           provide: PaymentService,
           useValue: createMock<PaymentService>(),
+        },
+        {
+          provide: BaConfigService,
+          useValue: { database: { concurrency: 10 } },
         },
 
         ThrowerErrorGuard,

--- a/nest-tax-backend/src/tasks/subservices/noris-sync.tasks.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/noris-sync.tasks.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 
+import BaConfigService from '../../config/ba-config.service'
 import { Prisma, TaxType } from '../../generated/prisma/client'
 import { CustomErrorNorisTypesEnum } from '../../noris/noris.errors'
 import { NorisService } from '../../noris/noris.service'
@@ -26,7 +26,7 @@ export default class NorisSyncTasksService {
   private readonly logger: LineLoggerSubservice
 
   constructor(
-    private readonly configService: ConfigService,
+    private readonly baConfigService: BaConfigService,
     private readonly prismaService: PrismaService,
     private readonly throwerErrorGuard: ThrowerErrorGuard,
     private readonly norisService: NorisService,
@@ -43,11 +43,7 @@ export default class NorisSyncTasksService {
 
     // non-production environment is used for testing and we create taxes from endpoint `create-testing-tax`,
     // this function will overwrite the testing taxes payments which is not desired
-    if (
-      this.configService.getOrThrow<string>(
-        'FEATURE_TOGGLE_UPDATE_TAXES_FROM_NORIS',
-      ) !== 'true'
-    ) {
+    if (!this.baConfigService.featureToggles.updateTaxesFromNoris) {
       this.logger.log(`TasksService: Updating taxes from Noris disabled.`)
       return
     }
@@ -150,11 +146,7 @@ export default class NorisSyncTasksService {
   async updateTaxesFromNoris() {
     // non-production environment is used for testing and we create taxes from endpoint `create-testing-tax`,
     // this process "updateTaxesFromNoris" will overwrite the testing taxes which is not desired
-    if (
-      this.configService.getOrThrow<string>(
-        'FEATURE_TOGGLE_UPDATE_TAXES_FROM_NORIS',
-      ) !== 'true'
-    ) {
+    if (!this.baConfigService.featureToggles.updateTaxesFromNoris) {
       this.logger.log(`TasksService: Updating taxes from Noris disabled.`)
       return
     }

--- a/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/notifications-events.service.ts
@@ -3,6 +3,7 @@ import dayjs, { Dayjs } from 'dayjs'
 import pLimit from 'p-limit'
 
 import { BloomreachService } from '../../bloomreach/bloomreach.service'
+import BaConfigService from '../../config/ba-config.service'
 import {
   DeliveryMethodNamed,
   PaymentStatus,
@@ -38,6 +39,7 @@ export default class NotificationsEventsService {
     private readonly cityAccountSubservice: CityAccountSubservice,
     private readonly throwerErrorGuard: ThrowerErrorGuard,
     private readonly paymentService: PaymentService,
+    private readonly baConfigService: BaConfigService,
   ) {
     this.logger = new LineLoggerSubservice(NotificationsEventsService.name)
   }
@@ -400,8 +402,7 @@ export default class NotificationsEventsService {
       return
     }
 
-    const concurrency = Number(process.env.DB_CONCURRENCY ?? 10)
-    const concurrencyLimit = pLimit(concurrency)
+    const concurrencyLimit = pLimit(this.baConfigService.database.concurrency)
 
     const userDataFromCityAccount =
       await this.cityAccountSubservice.getUserDataAdminBatch(

--- a/nest-tax-backend/src/tasks/tasks.service.ts
+++ b/nest-tax-backend/src/tasks/tasks.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import dayjs from 'dayjs'
 
@@ -26,7 +25,6 @@ const NORIS_SILENT_CONNECTION_ERRORS_THRESHOLD = 20
 export class TasksService {
   constructor(
     private readonly throwerErrorGuard: ThrowerErrorGuard,
-    private readonly configService: ConfigService,
     private readonly notificationsEventsService: NotificationsEventsService,
     private readonly reportingTasksService: ReportingTasksService,
     private readonly norisSyncTasksService: NorisSyncTasksService,
@@ -34,11 +32,7 @@ export class TasksService {
     private readonly taxImportTasksService: TaxImportTasksService,
     private readonly databaseSubservice: DatabaseSubservice,
     private readonly prismaService: PrismaService,
-  ) {
-    this.configService.getOrThrow<string>(
-      'FEATURE_TOGGLE_UPDATE_TAXES_FROM_NORIS',
-    )
-  }
+  ) {}
 
   @Cron(CronExpression.EVERY_10_MINUTES)
   @HandleErrors('Cron Error')

--- a/nest-tax-backend/src/utils/subservices/__tests__/sftp-file.subservice.spec.ts
+++ b/nest-tax-backend/src/utils/subservices/__tests__/sftp-file.subservice.spec.ts
@@ -1,7 +1,7 @@
-import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 import { FileInfo } from 'ssh2-sftp-client'
 
+import BaConfigService from '../../../config/ba-config.service'
 import { PrismaService } from '../../../prisma/prisma.service'
 import ThrowerErrorGuard from '../../guards/errors.guard'
 import SftpFileSubservice from '../sftp-file.subservice'
@@ -16,8 +16,15 @@ const mockPrismaService = {
   },
 }
 
-const mockConfigService = {
-  getOrThrow: jest.fn(),
+const mockBaConfigService = {
+  cardPaymentReporting: {
+    sftp: {
+      host: 'sftp-host',
+      port: 22,
+      username: 'sftp-user',
+      privateKey: 'sftp-key',
+    },
+  },
 }
 
 const mockThrowerErrorGuard = {
@@ -32,7 +39,7 @@ describe('SftpFileSubservice', () => {
       providers: [
         SftpFileSubservice,
         { provide: PrismaService, useValue: mockPrismaService },
-        { provide: ConfigService, useValue: mockConfigService },
+        { provide: BaConfigService, useValue: mockBaConfigService },
         { provide: ThrowerErrorGuard, useValue: mockThrowerErrorGuard },
       ],
     }).compile()

--- a/nest-tax-backend/src/utils/subservices/cityaccount.subservice.ts
+++ b/nest-tax-backend/src/utils/subservices/cityaccount.subservice.ts
@@ -3,6 +3,7 @@ import { isAxiosError } from 'axios'
 import { ResponseUserByBirthNumberDto } from 'openapi-clients/city-account'
 
 import ClientsService from '../../clients/clients.service'
+import BaConfigService from '../../config/ba-config.service'
 import { addSlashToBirthNumber } from '../functions/birthNumber'
 import { ErrorsEnum } from '../guards/dtos/error.dto'
 import ThrowerErrorGuard from '../guards/errors.guard'
@@ -14,6 +15,7 @@ export class CityAccountSubservice {
   constructor(
     private readonly throwerErrorGuard: ThrowerErrorGuard,
     private readonly clientsService: ClientsService,
+    private readonly baConfigService: BaConfigService,
   ) {
     this.logger = new Logger('CityAccountSubservice')
   }
@@ -28,7 +30,7 @@ export class CityAccountSubservice {
           birthNumberWithoutSlash,
           {
             headers: {
-              apiKey: process.env.CITY_ACCOUNT_ADMIN_API_KEY,
+              apiKey: this.baConfigService.cityAccountBackend.adminApiKey,
             },
           },
         )
@@ -84,7 +86,7 @@ export class CityAccountSubservice {
           { birthNumbers: birthNumbersWithoutSlash },
           {
             headers: {
-              apiKey: process.env.CITY_ACCOUNT_ADMIN_API_KEY,
+              apiKey: this.baConfigService.cityAccountBackend.adminApiKey,
             },
           },
         )
@@ -141,7 +143,7 @@ export class CityAccountSubservice {
           { since: since.toISOString(), take },
           {
             headers: {
-              apiKey: process.env.CITY_ACCOUNT_ADMIN_API_KEY,
+              apiKey: this.baConfigService.cityAccountBackend.adminApiKey,
             },
           },
         )

--- a/nest-tax-backend/src/utils/subservices/cognito.subservice.ts
+++ b/nest-tax-backend/src/utils/subservices/cognito.subservice.ts
@@ -5,9 +5,9 @@ import {
   CognitoIdentityProviderServiceException,
 } from '@aws-sdk/client-cognito-identity-provider'
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { CognitoUserAttributesTierEnum } from 'openapi-clients/city-account'
 
+import BaConfigService from '../../config/ba-config.service'
 import { ErrorsEnum } from '../guards/dtos/error.dto'
 import ThrowerErrorGuard from '../guards/errors.guard'
 
@@ -17,23 +17,20 @@ export class CognitoSubservice {
 
   constructor(
     private readonly throwerErrorGuard: ThrowerErrorGuard,
-    private readonly configService: ConfigService,
+    private readonly baConfigService: BaConfigService,
   ) {
     this.cognitoClient = new CognitoIdentityProviderClient({
-      region: this.configService.getOrThrow<string>('COGNITO_REGION'),
+      region: this.baConfigService.cognito.region,
       credentials: {
-        accessKeyId:
-          this.configService.getOrThrow<string>('AWS_COGNITO_ACCESS'),
-        secretAccessKey:
-          this.configService.getOrThrow<string>('AWS_COGNITO_SECRET'),
+        accessKeyId: this.baConfigService.cognito.accessKeyId,
+        secretAccessKey: this.baConfigService.cognito.secretAccessKey,
       },
     })
-    this.configService.getOrThrow<string>('COGNITO_USER_POOL_ID') // Check if exists
   }
 
   private async getUser(userId: string): Promise<AdminGetUserCommandOutput> {
     const inputParams = {
-      UserPoolId: this.configService.getOrThrow<string>('COGNITO_USER_POOL_ID'),
+      UserPoolId: this.baConfigService.cognito.userPoolId,
       Username: userId,
     }
 

--- a/nest-tax-backend/src/utils/subservices/email.subservice.ts
+++ b/nest-tax-backend/src/utils/subservices/email.subservice.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import nodemailer from 'nodemailer'
 import { SentMessageInfo } from 'nodemailer/lib/smtp-transport'
 
+import BaConfigService from '../../config/ba-config.service'
 import { ErrorsEnum } from '../guards/dtos/error.dto'
 import ThrowerErrorGuard from '../guards/errors.guard'
 import { LineLoggerSubservice } from './line-logger.subservice'
@@ -25,16 +25,16 @@ export default class EmailSubservice {
   private readonly transporter: nodemailer.Transporter<SentMessageInfo>
 
   constructor(
-    private readonly configService: ConfigService,
+    private readonly baConfigService: BaConfigService,
     private readonly throwerErrorGuard: ThrowerErrorGuard,
   ) {
     this.transporter = nodemailer.createTransport({
-      host: `email-smtp.${this.configService.getOrThrow<string>('COGNITO_REGION')}.amazonaws.com`,
+      host: `email-smtp.${this.baConfigService.cognito.region}.amazonaws.com`,
       port: 465,
       secure: true,
       auth: {
-        user: this.configService.getOrThrow<string>('AWS_SES_SMTP_USERNAME'),
-        pass: this.configService.getOrThrow<string>('AWS_SES_SMTP_PASSWORD'),
+        user: this.baConfigService.smtp.username,
+        pass: this.baConfigService.smtp.password,
       },
     })
   }
@@ -55,7 +55,7 @@ export default class EmailSubservice {
   ): Promise<void> {
     try {
       const emailOptions = {
-        from: this.configService.getOrThrow<string>('AWS_SES_SENDER_EMAIL'),
+        from: this.baConfigService.smtp.email,
         to: to.join(', '),
         subject,
         text: message,

--- a/nest-tax-backend/src/utils/subservices/sftp-file.subservice.ts
+++ b/nest-tax-backend/src/utils/subservices/sftp-file.subservice.ts
@@ -1,12 +1,12 @@
 import path from 'node:path'
 
 import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 import SFTPClient, { FileInfo } from 'ssh2-sftp-client'
 
+import BaConfigService from '../../config/ba-config.service'
 import { TaxType } from '../../generated/prisma/client'
 import { PrismaService } from '../../prisma/prisma.service'
 import { ErrorsEnum } from '../guards/dtos/error.dto'
@@ -19,19 +19,20 @@ dayjs.extend(timezone)
 export default class SftpFileSubservice {
   constructor(
     private readonly prismaService: PrismaService,
-    private readonly configService: ConfigService,
+    private readonly baConfigService: BaConfigService,
     private readonly throwerErrorGuard: ThrowerErrorGuard,
   ) {}
 
   async getNewFiles(sftpPath: string, taxType: TaxType, from?: Date) {
     const sftp = new SFTPClient()
+    const { sftp: sftpConfig } = this.baConfigService.cardPaymentReporting
 
     try {
       await sftp.connect({
-        host: this.configService.getOrThrow<string>('REPORTING_SFTP_HOST'),
-        port: this.configService.getOrThrow<number>('REPORTING_SFTP_PORT'),
-        username: this.configService.getOrThrow<string>('REPORTING_SFTP_USER'),
-        privateKey: this.configService.getOrThrow<string>('REPORTING_SFTP_KEY'),
+        host: sftpConfig.host,
+        port: sftpConfig.port,
+        username: sftpConfig.username,
+        privateKey: sftpConfig.privateKey,
       })
 
       const sftpFiles: FileInfo[] = await sftp.list(sftpPath)

--- a/nest-tax-backend/src/utils/subservices/sftp-file.subservice.ts
+++ b/nest-tax-backend/src/utils/subservices/sftp-file.subservice.ts
@@ -28,12 +28,7 @@ export default class SftpFileSubservice {
     const { sftp: sftpConfig } = this.baConfigService.cardPaymentReporting
 
     try {
-      await sftp.connect({
-        host: sftpConfig.host,
-        port: sftpConfig.port,
-        username: sftpConfig.username,
-        privateKey: sftpConfig.privateKey,
-      })
+      await sftp.connect(sftpConfig)
 
       const sftpFiles: FileInfo[] = await sftp.list(sftpPath)
 

--- a/nest-tax-backend/src/utils/subservices/shared.module.ts
+++ b/nest-tax-backend/src/utils/subservices/shared.module.ts
@@ -1,6 +1,7 @@
 import { Global, Module } from '@nestjs/common'
 
 import ClientsModule from '../../clients/clients.module'
+import BaConfigModule from '../../config/ba-config.module'
 import ThrowerErrorGuard from '../guards/errors.guard'
 import { CityAccountSubservice } from './cityaccount.subservice'
 import { CognitoSubservice } from './cognito.subservice'
@@ -32,7 +33,7 @@ import DatabaseSubservice from './database.subservice'
  */
 @Global()
 @Module({
-  imports: [ClientsModule], // Only leaf modules can be imported here.
+  imports: [ClientsModule, BaConfigModule], // Only leaf modules can be imported here.
   providers: [
     ThrowerErrorGuard,
     CityAccountSubservice,
@@ -44,6 +45,7 @@ import DatabaseSubservice from './database.subservice'
     CityAccountSubservice,
     CognitoSubservice,
     DatabaseSubservice,
+    BaConfigModule
   ],
 })
 export class SharedModule {}

--- a/nest-tax-backend/src/utils/subservices/shared.module.ts
+++ b/nest-tax-backend/src/utils/subservices/shared.module.ts
@@ -1,7 +1,6 @@
 import { Global, Module } from '@nestjs/common'
 
 import ClientsModule from '../../clients/clients.module'
-import BaConfigModule from '../../config/ba-config.module'
 import ThrowerErrorGuard from '../guards/errors.guard'
 import { CityAccountSubservice } from './cityaccount.subservice'
 import { CognitoSubservice } from './cognito.subservice'
@@ -33,7 +32,7 @@ import DatabaseSubservice from './database.subservice'
  */
 @Global()
 @Module({
-  imports: [ClientsModule, BaConfigModule], // Only leaf modules can be imported here.
+  imports: [ClientsModule], // Only leaf modules can be imported here.
   providers: [
     ThrowerErrorGuard,
     CityAccountSubservice,
@@ -45,7 +44,6 @@ import DatabaseSubservice from './database.subservice'
     CityAccountSubservice,
     CognitoSubservice,
     DatabaseSubservice,
-    BaConfigModule
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
# Add validated, strongly-typed config (`EnvironmentVariables` / `BaConfig`)

## Summary

Replaces every ad-hoc `ConfigService.getOrThrow(...)` and raw `process.env.X` read
with a single, strongly-typed, `class-validator`-backed configuration surface:

- `EnvironmentVariables` — one class-validator-decorated class listing every env
  var the app uses, with a decorator per field (`@EnvString`, `@EnvUrl`, `@EnvInt`,
  `@EnvPort`, `@EnvBoolean`, `@EnvEnum`) that encodes its type and required-ness.
- `BaConfig` — a class with grouped getters (`cognito`, `paygate`,
  `cardPaymentReporting`, `bloomreach`, `noris`, `smtp`, `featureToggles`, …) that
  turn the flat, validated env vars into a nicer shape for consumers.
- `BaConfigService` / `BaConfigModule` — the NestJS DI wiring, provided globally so
  any service can just inject `BaConfigService` instead of `ConfigService`.

All config is now validated **once, eagerly, at process boot** (via
`class-validator`'s `validateSync`), so a missing or malformed env var fails fast
with a clear error instead of surfacing later as a `getOrThrow` runtime exception
deep inside a request handler.

## This pattern is copied from `nest-forms-backend`

The whole `EnvironmentVariables` / `BaConfig` / decorator approach is not new — it
already exists and is proven in `nest-forms-backend`. This PR ports that same
design to `nest-tax-backend`, adapting only the env var list and the `BaConfig`
getter groupings to this service's domain (paygate, card payment reporting, Noris,
Bloomreach, etc.).

Reference implementation in `nest-forms-backend` (same repo, sibling service):

- [`src/config/environment-variables.ts`](https://github.com/bratislava/konto.bratislava.sk/blob/master/nest-forms-backend/src/config/environment-variables.ts)
- [`src/config/environment-decorators.ts`](https://github.com/bratislava/konto.bratislava.sk/blob/master/nest-forms-backend/src/config/environment-decorators.ts)
- [`src/config/environment-variables.validate.ts`](https://github.com/bratislava/konto.bratislava.sk/blob/master/nest-forms-backend/src/config/environment-variables.validate.ts)
- [`src/config/ba-config.ts`](https://github.com/bratislava/konto.bratislava.sk/blob/master/nest-forms-backend/src/config/ba-config.ts)
- [`src/config/ba-config.service.ts`](https://github.com/bratislava/konto.bratislava.sk/blob/master/nest-forms-backend/src/config/ba-config.service.ts)
- [`src/config/ba-config.module.ts`](https://github.com/bratislava/konto.bratislava.sk/blob/master/nest-forms-backend/src/config/ba-config.module.ts)
- [`src/config/ba-config.instance.ts`](https://github.com/bratislava/konto.bratislava.sk/blob/master/nest-forms-backend/src/config/ba-config.instance.ts)

Resolves https://github.com/bratislava/private-konto.bratislava.sk/issues/801