### PR TITLE
Apply shared application secrets before service deploys + pin bratislava/github-actions@v3.0.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -245,11 +245,7 @@ jobs:
 
   # ---- Gate + trigger infrastructure deploys ----
   # deploy-secrets is the gate: nothing deploys until every in-scope build (and
-  # the forms-shared test) has finished and none failed. Out-of-scope jobs
-  # report `skipped` (not `failure`), so they don't block — that's the
-  # "skipped on purpose" carve-out. Ordering after that: shared secrets first;
-  # cvdmirror -> clamav -> nest-clamav-scanner; all backends -> next.
-
+  # the forms-shared test) has finished and none failed.
   deploy-secrets:
     name: Shared application secrets
     needs:
@@ -268,7 +264,7 @@ jobs:
         build-next,
       ]
     if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@v3.0.0
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
@@ -278,7 +274,7 @@ jobs:
     name: cvdmirror
     needs: [resolve, build-cvdmirror, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.cvdmirror == 'true' }}
-    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@v3.0.0
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
@@ -286,9 +282,9 @@ jobs:
 
   deploy-clamav:
     name: clamav
-    needs: [resolve, build-clamav, deploy-cvdmirror]
+    needs: [resolve, build-clamav, deploy-cvdmirror, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.clamav == 'true' }}
-    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@v3.0.0
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
@@ -296,9 +292,9 @@ jobs:
 
   deploy-nest-clamav-scanner:
     name: nest-clamav-scanner
-    needs: [resolve, build-nest-clamav-scanner, deploy-clamav]
+    needs: [resolve, build-nest-clamav-scanner, deploy-clamav, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-clamav-scanner == 'true' }}
-    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@v3.0.0
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
@@ -308,7 +304,7 @@ jobs:
     name: nest-forms-backend
     needs: [resolve, build-nest-forms-backend, test-forms-shared, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-forms-backend == 'true' }}
-    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@v3.0.0
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
@@ -318,7 +314,7 @@ jobs:
     name: nest-tax-backend
     needs: [resolve, build-nest-tax-backend, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-tax-backend == 'true' }}
-    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@v3.0.0
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
@@ -328,7 +324,7 @@ jobs:
     name: nest-city-account
     needs: [resolve, build-nest-city-account, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-city-account == 'true' }}
-    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@v3.0.0
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
@@ -338,7 +334,7 @@ jobs:
     name: Strapi
     needs: [resolve, build-strapi, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.strapi == 'true' }}
-    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@v3.0.0
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
@@ -351,6 +347,7 @@ jobs:
         resolve,
         build-next,
         test-forms-shared,
+        deploy-secrets,
         deploy-strapi,
         deploy-nest-forms-backend,
         deploy-nest-clamav-scanner,
@@ -358,7 +355,7 @@ jobs:
         deploy-nest-city-account,
       ]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.next == 'true' }}
-    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@v3.0.0
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -243,15 +243,18 @@ jobs:
       forms_shared_digest: ${{ needs.build-forms-shared.outputs.image_digest }}
       openapi_clients_digest: ${{ needs.build-openapi-clients.outputs.image_digest }}
 
-  # ---- Gate: every deploy waits here until all builds succeed ----
-  # Nothing deploys until every in-scope build (and the forms-shared test) has
-  # finished and none failed. Out-of-scope jobs report `skipped` (not `failure`),
-  # so they don't block — that's the "skipped on purpose" carve-out.
+  # ---- Gate + trigger infrastructure deploys ----
+  # deploy-secrets is the gate: nothing deploys until every in-scope build (and
+  # the forms-shared test) has finished and none failed. Out-of-scope jobs
+  # report `skipped` (not `failure`), so they don't block — that's the
+  # "skipped on purpose" carve-out. Ordering after that: shared secrets first;
+  # cvdmirror -> clamav -> nest-clamav-scanner; all backends -> next.
 
-  builds-complete:
-    name: All builds complete
+  deploy-secrets:
+    name: Shared application secrets
     needs:
       [
+        resolve,
         build-forms-shared,
         test-forms-shared,
         build-openapi-clients,
@@ -264,108 +267,82 @@ jobs:
         build-nest-city-account,
         build-next,
       ]
-    if: ${{ !cancelled() }}
-    runs-on: bratislava
-    steps:
-      - name: Verify every in-scope build succeeded
-        run: |
-          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
-            echo "::error::A build job failed or was cancelled — aborting all deploys."
-            exit 1
-          fi
-          echo "All in-scope builds succeeded (skipped builds are intentional); proceeding to deploy."
-
-  # ---- Trigger infrastructure deploys ----
-  # Ordering: shared secrets first; cvdmirror -> clamav -> nest-clamav-scanner;
-  # all backends -> next.
-
-  deploy-secrets:
-    name: Shared application secrets
-    needs: [resolve, builds-complete]
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/secrets
-      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-cvdmirror:
     name: cvdmirror
-    needs: [resolve, build-cvdmirror, builds-complete, deploy-secrets]
+    needs: [resolve, build-cvdmirror, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.cvdmirror == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/cvdmirror
-      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-clamav:
     name: clamav
-    needs: [resolve, build-clamav, deploy-cvdmirror, builds-complete]
+    needs: [resolve, build-clamav, deploy-cvdmirror]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.clamav == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/clamav
-      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-nest-clamav-scanner:
     name: nest-clamav-scanner
-    needs: [resolve, build-nest-clamav-scanner, deploy-clamav, builds-complete]
+    needs: [resolve, build-nest-clamav-scanner, deploy-clamav]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-clamav-scanner == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_clamav_scanner
-      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-nest-forms-backend:
     name: nest-forms-backend
-    needs: [resolve, build-nest-forms-backend, test-forms-shared, builds-complete, deploy-secrets]
+    needs: [resolve, build-nest-forms-backend, test-forms-shared, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-forms-backend == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_forms_backend
-      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-nest-tax-backend:
     name: nest-tax-backend
-    needs: [resolve, build-nest-tax-backend, builds-complete, deploy-secrets]
+    needs: [resolve, build-nest-tax-backend, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-tax-backend == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_tax_backend
-      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-nest-city-account:
     name: nest-city-account
-    needs: [resolve, build-nest-city-account, builds-complete, deploy-secrets]
+    needs: [resolve, build-nest-city-account, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-city-account == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_city_account
-      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-strapi:
     name: Strapi
-    needs: [resolve, build-strapi, builds-complete, deploy-secrets]
+    needs: [resolve, build-strapi, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.strapi == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/strapi
-      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-next:
     name: after Backends deploy Next
@@ -374,7 +351,6 @@ jobs:
         resolve,
         build-next,
         test-forms-shared,
-        builds-complete,
         deploy-strapi,
         deploy-nest-forms-backend,
         deploy-nest-clamav-scanner,
@@ -387,7 +363,6 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/next
-      dispatch_ref: mpinter/konto-secret-handling
 
   check-openapi-clients:
     name: Check OpenAPI clients for changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -276,11 +276,23 @@ jobs:
           echo "All in-scope builds succeeded (skipped builds are intentional); proceeding to deploy."
 
   # ---- Trigger infrastructure deploys ----
-  # Ordering: cvdmirror -> clamav -> nest-clamav-scanner; all backends -> next.
+  # Ordering: shared secrets first; cvdmirror -> clamav -> nest-clamav-scanner;
+  # all backends -> next.
+
+  deploy-secrets:
+    name: Shared application secrets
+    needs: [resolve, builds-complete]
+    if: ${{ !failure() && !cancelled() }}
+    uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
+    secrets: inherit
+    with:
+      cluster: ${{ needs.resolve.outputs.cluster }}
+      app: konto.bratislava.sk/secrets
+      dispatch_ref: mpinter/rollout-status
 
   deploy-cvdmirror:
     name: cvdmirror
-    needs: [resolve, build-cvdmirror, builds-complete]
+    needs: [resolve, build-cvdmirror, builds-complete, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.cvdmirror == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
@@ -313,7 +325,7 @@ jobs:
 
   deploy-nest-forms-backend:
     name: nest-forms-backend
-    needs: [resolve, build-nest-forms-backend, test-forms-shared, builds-complete]
+    needs: [resolve, build-nest-forms-backend, test-forms-shared, builds-complete, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-forms-backend == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
@@ -324,7 +336,7 @@ jobs:
 
   deploy-nest-tax-backend:
     name: nest-tax-backend
-    needs: [resolve, build-nest-tax-backend, builds-complete]
+    needs: [resolve, build-nest-tax-backend, builds-complete, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-tax-backend == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
@@ -335,7 +347,7 @@ jobs:
 
   deploy-nest-city-account:
     name: nest-city-account
-    needs: [resolve, build-nest-city-account, builds-complete]
+    needs: [resolve, build-nest-city-account, builds-complete, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.nest-city-account == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit
@@ -346,7 +358,7 @@ jobs:
 
   deploy-strapi:
     name: Strapi
-    needs: [resolve, build-strapi, builds-complete]
+    needs: [resolve, build-strapi, builds-complete, deploy-secrets]
     if: ${{ !failure() && !cancelled() && needs.resolve.outputs.strapi == 'true' }}
     uses: bratislava/github-actions/.github/workflows/trigger-infra-deploy.yml@beta
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -288,7 +288,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/secrets
-      dispatch_ref: mpinter/rollout-status
+      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-cvdmirror:
     name: cvdmirror
@@ -299,7 +299,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/cvdmirror
-      dispatch_ref: mpinter/rollout-status
+      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-clamav:
     name: clamav
@@ -310,7 +310,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/clamav
-      dispatch_ref: mpinter/rollout-status
+      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-nest-clamav-scanner:
     name: nest-clamav-scanner
@@ -321,7 +321,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_clamav_scanner
-      dispatch_ref: mpinter/rollout-status
+      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-nest-forms-backend:
     name: nest-forms-backend
@@ -332,7 +332,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_forms_backend
-      dispatch_ref: mpinter/rollout-status
+      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-nest-tax-backend:
     name: nest-tax-backend
@@ -343,7 +343,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_tax_backend
-      dispatch_ref: mpinter/rollout-status
+      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-nest-city-account:
     name: nest-city-account
@@ -354,7 +354,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_city_account
-      dispatch_ref: mpinter/rollout-status
+      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-strapi:
     name: Strapi
@@ -365,7 +365,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/strapi
-      dispatch_ref: mpinter/rollout-status
+      dispatch_ref: mpinter/konto-secret-handling
 
   deploy-next:
     name: after Backends deploy Next
@@ -387,7 +387,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/next
-      dispatch_ref: mpinter/rollout-status
+      dispatch_ref: mpinter/konto-secret-handling
 
   check-openapi-clients:
     name: Check OpenAPI clients for changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -287,6 +287,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/cvdmirror
+      dispatch_ref: mpinter/rollout-status
 
   deploy-clamav:
     name: clamav
@@ -297,6 +298,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/clamav
+      dispatch_ref: mpinter/rollout-status
 
   deploy-nest-clamav-scanner:
     name: nest-clamav-scanner
@@ -307,6 +309,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_clamav_scanner
+      dispatch_ref: mpinter/rollout-status
 
   deploy-nest-forms-backend:
     name: nest-forms-backend
@@ -317,6 +320,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_forms_backend
+      dispatch_ref: mpinter/rollout-status
 
   deploy-nest-tax-backend:
     name: nest-tax-backend
@@ -327,6 +331,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_tax_backend
+      dispatch_ref: mpinter/rollout-status
 
   deploy-nest-city-account:
     name: nest-city-account
@@ -337,6 +342,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/nest_city_account
+      dispatch_ref: mpinter/rollout-status
 
   deploy-strapi:
     name: Strapi
@@ -347,6 +353,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/strapi
+      dispatch_ref: mpinter/rollout-status
 
   deploy-next:
     name: after Backends deploy Next
@@ -368,6 +375,7 @@ jobs:
     with:
       cluster: ${{ needs.resolve.outputs.cluster }}
       app: konto.bratislava.sk/next
+      dispatch_ref: mpinter/rollout-status
 
   check-openapi-clients:
     name: Check OpenAPI clients for changes


### PR DESCRIPTION
Adds a `deploy-secrets` job to the monorepo deploy pipeline: after all builds complete and before any service deploys, it triggers an infra deploy of `konto.bratislava.sk/secrets` (shared application secrets). All root deploy jobs (`cvdmirror`, `nest-forms-backend`, `nest-tax-backend`, `nest-city-account`, `strapi`) now depend on it; the rest inherit the ordering transitively.