### PR TITLE
fix wrong build of nest-forms-backend

### DIFF
--- a/nest-forms-backend/package.json
+++ b/nest-forms-backend/package.json
@@ -12,7 +12,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/src/main",
+    "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.{ts,js}\"",
     "lint:report": "eslint -f json -o eslint-report.json \"{src,apps,libs,test}/**/*.{ts,js}\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.{ts,js}\" --fix",

--- a/nest-forms-backend/src/prisma/types.ts
+++ b/nest-forms-backend/src/prisma/types.ts
@@ -5,6 +5,7 @@ import type { FormSignature as _FormSignature } from 'forms-shared/signer/signat
 import type { FormSummary as _FormSummary } from 'forms-shared/summary/summary'
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace -- necessary for Prisma JSON types
   namespace PrismaJson {
     type FormDataJson = GenericObjectType
 

--- a/nest-forms-backend/tsconfig.build.json
+++ b/nest-forms-backend/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules",
-    "test", "dist", "**/*spec.ts"]
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
Generated with Claude code


## Fix staging crash: `MODULE_NOT_FOUND` on boot

`nest-forms-backend` was crash-looping on staging with:

```
Error: Cannot find module '../../../../forms-shared/dist/form-files/fileStatus'
```

### Root cause

`tsconfig.build.json` didn't restrict `include`, so the build also picked up root-level files (`jest.*.ts`, `prisma.config.ts`). This forced TypeScript to infer `rootDir` as the project root instead of `src/`, adding an extra `dist/src/...` nesting level to the build output.

`@nestjs/swagger`'s CLI plugin bakes a literal relative `require()` path into compiled DTOs for enums it needs to introspect at runtime (here, `FileStatusType` imported from `forms-shared`). That path is computed assuming `dist/` mirrors `src/` 1:1 — with the extra nesting, it ended up one `../` short and crashed as soon as `ConvertModule`'s DTOs were loaded.

### Changes

- `tsconfig.build.json` — added `rootDir: "./src"` and `include: ["src/**/*.ts"]` so `dist/` mirrors `src/` exactly (no more stray `jest.config.js`/`prisma.config.js`/`eslint.config.mjs` leaking into the build).
- `src/prisma/types.ts` — moved from `prisma/types.ts` (unreferenced ambient `PrismaJson` global-merge file) to satisfy the new `rootDir` constraint. Added the same `eslint-disable-next-line @typescript-eslint/no-namespace` used for this pattern in `nest-tax-backend`.
- `package.json` — `start:prod` updated from `node dist/src/main` to `node dist/main` to match the corrected output layout.
