### PR TITLE
bugfix: remove audience setting from cognito strategy

### DIFF
--- a/nest-city-account/src/auth/strategies/cognito.strategy.ts
+++ b/nest-city-account/src/auth/strategies/cognito.strategy.ts
@@ -16,7 +16,6 @@ export class CognitoStrategy extends PassportStrategy(Strategy, 'cognito-strateg
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      audience: baConfigService.cognito.clientId,
       issuer: `https://cognito-idp.${baConfigService.cognito.region}.amazonaws.com/${baConfigService.cognito.userPoolId}`,
       algorithms: ['RS256'],
       secretOrKeyProvider: passportJwtSecret({


### PR DESCRIPTION
This emerged after merging https://github.com/bratislava/konto.bratislava.sk/pull/4431

Before, `audience` was set to env value `AWS_COGNITO_COGNITO_CLIENT_ID`. I have changed it therefore, by using new `BaConfig` to `baConfigService.cognito.clientId`. However, value of `clientId` is `AWS_COGNITO_CLIENT_ID`.

Notice the extra "COGNITO" in `AWS_COGNITO_COGNITO_CLIENT_ID`. This was for the whole time silently undefined, and now after the PR, it was set to a value, which is incorrect.