### PR TITLE
Fix TableOfContents position when sticky

### DIFF
--- a/next/next-i18next.config.js
+++ b/next/next-i18next.config.js
@@ -7,6 +7,6 @@ module.exports = {
     locales: ['sk'],
     localeDetection: false,
   },
-  defaultNS: ['account'], // Changed to match the used namespace. TODO change to `translation` namespace used by i18next-parser
+  defaultNS: ['account'], // Changed to match the used namespace. TODO change to `translation` namespace used by i18next-cli
   reloadOnPrerender: process.env.NODE_ENV === 'development',
 }

--- a/next/src/components/common/TableOfContents/TableOfContents.tsx
+++ b/next/src/components/common/TableOfContents/TableOfContents.tsx
@@ -39,7 +39,7 @@ const TableOfContents = ({ scrollOffset = DEFAULT_SCROLL_OFFSET, className }: Pr
   return (
     <div
       className={cn(
-        'sticky top-40 flex max-w-200 flex-col overflow-hidden rounded-lg border border-border-passive-primary bg-background-passive-base px-6',
+        'sticky top-12 flex max-w-200 flex-col overflow-hidden rounded-lg border border-border-passive-primary bg-background-passive-base px-6',
         className,
       )}
     >
@@ -62,6 +62,7 @@ const TableOfContents = ({ scrollOffset = DEFAULT_SCROLL_OFFSET, className }: Pr
                     onPress={() => {
                       handleItemPress(heading.id)
                     }}
+                    className="text-left"
                   >
                     {heading.text}
                   </Button>

--- a/next/src/components/page-contents/FormLandingPageContent/FormLandingPageContent.tsx
+++ b/next/src/components/page-contents/FormLandingPageContent/FormLandingPageContent.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@bratislava/component-library'
+import { Button, Typography } from '@bratislava/component-library'
 import { useTranslation } from 'next-i18next/pages'
 
 import { FormWithLandingPageFragment } from '@/src/clients/graphql-strapi/api'
@@ -8,7 +8,6 @@ import { ClientLandingPageFormDefinition } from '@/src/components/forms/clientFo
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import FormLandingPageCtaCard from '@/src/components/page-contents/FormLandingPageContent/FormCta/FormLandingPageCtaCard'
 import FormLandingPageCard from '@/src/components/segments/FormLandingPageCard/FormLandingPageCard'
-import MLink from '@/src/components/simple-components/MLink'
 import { isDefined } from '@/src/frontend/utils/general'
 import cn from '@/src/utils/cn'
 
@@ -42,14 +41,14 @@ const FormLandingPage = ({ formDefinition, strapiForm }: FormLandingPageProps) =
         <div className="flex flex-col gap-2 lg:gap-4">
           <Typography variant="h1">{formDefinition.title}</Typography>
           {strapiForm.moreInformationUrl ? (
-            <MLink
-              className="w-max text-size-p-large-r lg:text-size-p-large"
-              variant="underlined"
+            <Button
+              variant="link"
+              size="large"
+              className="w-max"
               href={strapiForm.moreInformationUrl}
-              target="_blank"
             >
               {t('form_header.services_link')}
-            </MLink>
+            </Button>
           ) : null}
         </div>
       </SectionContainer>
@@ -91,7 +90,7 @@ const FormLandingPage = ({ formDefinition, strapiForm }: FormLandingPageProps) =
           </SectionContainer>
         </div>
 
-        <aside className="w-full lg:top-40 lg:w-80 lg:shrink-0">
+        <aside className="w-full lg:w-80 lg:shrink-0">
           <TableOfContents />
         </aside>
       </div>

--- a/next/src/components/page-contents/MunicipalServicePageContent/MunicipalServicePageContent.tsx
+++ b/next/src/components/page-contents/MunicipalServicePageContent/MunicipalServicePageContent.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@bratislava/component-library'
+import { Button, Typography } from '@bratislava/component-library'
 import { useTranslation } from 'next-i18next/pages'
 
 import { MunicipalServiceEntityFragment } from '@/src/clients/graphql-strapi/api'
@@ -9,7 +9,6 @@ import SectionContainer from '@/src/components/layouts/SectionContainer'
 import Sections from '@/src/components/layouts/Sections'
 import FormLandingPageCtaCard from '@/src/components/page-contents/FormLandingPageContent/FormCta/FormLandingPageCtaCard'
 import FormLandingPageCard from '@/src/components/segments/FormLandingPageCard/FormLandingPageCard'
-import MLink from '@/src/components/simple-components/MLink'
 import { isDefined } from '@/src/frontend/utils/general'
 import cn from '@/src/utils/cn'
 
@@ -39,9 +38,10 @@ const MunicipalServicePageContent = ({
           <Typography variant="h1">{municipalService.title}</Typography>
           {pageHeaderText ? <Typography>{pageHeaderText}</Typography> : null}
           {moreInformationUrl ? (
-            <MLink className="w-max" variant="underlined" href={moreInformationUrl} target="_blank">
+            // TODO size
+            <Button variant="link" size="small" className="w-max" href={moreInformationUrl}>
               {t('form_header.services_link')}
-            </MLink>
+            </Button>
           ) : null}
         </div>
       </SectionContainer>
@@ -89,7 +89,7 @@ const MunicipalServicePageContent = ({
           ) : null}
         </div>
 
-        <aside className="w-full lg:top-40 lg:w-80 lg:shrink-0">
+        <aside className="w-full lg:w-80 lg:shrink-0">
           <TableOfContents />
         </aside>
       </div>


### PR DESCRIPTION
- fix top position of TOC
- fix TOC text align when title is longer than one line
- use Button instead of MLink, to show also link icon in Form page header and Municipal Service page header
- Replace legacy i18next-parser with i18next-cli in comments