### PR TITLE
docs: add per-app ARCHITECTURE.md + cross-backend workflows doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,23 @@ Monorepo of services, shared libraries and frontend for [konto.bratislava.sk](ht
 
 Each sub-project contains a README which should get you up and running. More documentation can be (eventually) found [here](https://bratislava.github.io)
 
+Each NestJS/Next.js app has a high-level architecture doc in its own `docs/ARCHITECTURE.md` (linked below). Workflows that span multiple backends are documented in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) (cross-backend workflows only).
+
 ⚙️️ `/clamav` Instance of clamav https://www.clamav.net
 
 ⚙️️ `/cvdmirror` Local mirror of cvd database used for clamav scanner
 
 📟 `/forms-shared` Shared components and utils for frontend and backend
 
-🗄️ `/nest-city-account` Service which is handling user related logic for konto
+🗄️ `/nest-city-account` Service which is handling user related logic for konto — [architecture](nest-city-account/docs/ARCHITECTURE.md)
 
-🗄️ `/nest-clamav-scanner` This service is responsible for handling files which were sent to the clamav scanner.
+🗄️ `/nest-clamav-scanner` This service is responsible for handling files which were sent to the clamav scanner. — [architecture](nest-clamav-scanner/docs/ARCHITECTURE.md)
 
-🗄️ `/nest-forms-backend` Service which is handling incoming and outgoing forms created by users
+🗄️ `/nest-forms-backend` Service which is handling incoming and outgoing forms created by users — [architecture](nest-forms-backend/docs/ARCHITECTURE.md)
 
-🗄️ `/nest-tax-backend` This service is responsible for digital tax payment.
+🗄️ `/nest-tax-backend` This service is responsible for digital tax payment. — [architecture](nest-tax-backend/docs/ARCHITECTURE.md)
 
-🏡 `/next` Next.js web app
+🏡 `/next` Next.js web app — [architecture](next/docs/ARCHITECTURE.md)
 
 🗄️ `/strapi` Strapi CMS server
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,7 @@ sequenceDiagram
 
 - **Single-service internal flows** -- e.g. the forms NASES/GINIS delivery pipeline, tax GP-webpay payment, verification against Magproxy/NASES -- documented in each service's own `docs/ARCHITECTURE.md`.
 - **Calls to external (non-konto) systems** -- AWS Cognito, slovensko.sk/NASES, GINIS, Magproxy/RFO/RPO, GP webpay, Bloomreach, Mailgun/SES, Strapi, SharePoint, and the `nest-enforcement-backend` towing proxy called by city-account. These are external dependencies, not konto-to-konto workflows.
-- **Shared-database coupling (not a service call):** both **nest-city-account** and **nest-tax-backend** connect **directly** to the municipal **Noris** MSSQL database. They influence the same external data (e.g. tax delivery methods) but do **not** call each other -- so this is a shared-datastore coupling, not a cross-backend workflow.
+- **Shared-database coupling (not a service call):** both **nest-city-account** and **nest-tax-backend** connect **directly** to the municipal **Noris** financial system (an MSSQL database). They influence the same external data (e.g. tax delivery methods) but do **not** call each other -- so this is a shared-datastore coupling, not a cross-backend workflow.
 - **The frontend (`next`)** calls all three business backends, but as a client, not as one backend orchestrating another; those are covered in the frontend's own doc.
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,160 @@
+# konto.bratislava.sk -- Cross-Backend Workflows
+
+> **Scope.** This document describes **only cross-backend workflows** -- flows where a *single request* or a *single async/scheduled job* calls across **more than one** of the konto NestJS backends. It is **not** a whole-system architecture doc.
+>
+> The high-level architecture of each individual service lives in that service's own `docs/ARCHITECTURE.md`:
+> - [`nest-city-account/docs/ARCHITECTURE.md`](../nest-city-account/docs/ARCHITECTURE.md) -- users, accounts, verification, OAuth2, integration API
+> - [`nest-forms-backend/docs/ARCHITECTURE.md`](../nest-forms-backend/docs/ARCHITECTURE.md) -- e-forms lifecycle, NASES/GINIS delivery
+> - [`nest-tax-backend/docs/ARCHITECTURE.md`](../nest-tax-backend/docs/ARCHITECTURE.md) -- tax fetch/pay, Noris sync
+> - [`nest-clamav-scanner/docs/ARCHITECTURE.md`](../nest-clamav-scanner/docs/ARCHITECTURE.md) -- file virus scanning
+> - [`next/docs/ARCHITECTURE.md`](../next/docs/ARCHITECTURE.md) -- the web frontend (client of the backends; not itself a backend)
+
+## Participating Backends & Edges
+
+Only the four NestJS backends are considered here. Their **cross-backend** call graph is:
+
+```mermaid
+graph LR
+    forms["nest-forms-backend"]
+    tax["nest-tax-backend"]
+    ca["nest-city-account"]
+    clam["nest-clamav-scanner"]
+
+    forms -->|user upsert per request| ca
+    tax -->|user upsert / user data / verified-user ingestion| ca
+    forms -->|enqueue file scan| clam
+    clam -->|scan-result callback| forms
+```
+
+Notably, **nest-city-account is a provider only** (siblings call it; it makes no outbound calls to the trio), and **nest-clamav-scanner talks only to nest-forms-backend**. There is **no** forms↔tax and **no** tax↔clamav interaction.
+
+Transport is HTTP in every case. Two auth styles are used between services:
+- **Cognito Bearer forwarded** -- the caller passes the end user's token through (used for "resolve *this* user").
+- **Service credentials** -- an admin `apiKey` header (city-account integration API) or HTTP **Basic** auth (forms ↔ clamav).
+
+---
+
+## Workflow 1 -- File antivirus scanning (forms ⇄ clamav)
+
+The only fully bidirectional cross-backend workflow, and the one that spans a request *and* a scheduled job.
+
+- **Participants:** nest-forms-backend, nest-clamav-scanner.
+- **Trigger (part A -- request):** a user uploads a file to forms (`POST /files/upload/:formId`).
+- **Trigger (part B -- scheduled job):** the scanner's 20-second `@Cron` worker scans queued files and calls back.
+- **Transport / auth:** HTTP + HTTP Basic, both directions.
+  - forms -> clamav uses raw axios (`nest-forms-backend/src/scanner-client/scanner-client.service.ts`).
+  - clamav -> forms uses the shared `openapi-clients/forms` client (`nest-clamav-scanner/src/forms-client/forms-client.service.ts`).
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Forms as nest-forms-backend
+    participant S3 as MinIO (shared)
+    participant Clam as nest-clamav-scanner
+    participant Clamd as ClamAV daemon
+
+    User->>Forms: POST /files/upload/:formId
+    Forms->>S3: store object (unscanned bucket)
+    Forms->>Forms: create Files row (UPLOADED)
+    Forms->>Clam: POST /api/scan/file (Basic) -> scannerId
+    Note over Clam: enqueued as Files row (ACCEPTED)
+    loop every 20s (cron)
+        Clam->>S3: load file stream
+        Clam->>Clamd: scanStream
+        Clam->>S3: move to safe/infected bucket
+        Clam->>Forms: PATCH /files/scan/:scannerId (Basic) verdict
+        Forms->>Forms: update Files.status, move buckets
+    end
+```
+
+- **Notes:** both services also poll each other's `GET /health` before acting. The scanner re-sends any terminal verdict whose `notified=false` on each cron tick (`fixUnnotifiedFiles`), so a transient forms outage self-heals. Forms rejects a form send until all attachments are `SAFE`/`INFECTED` (`areFormAttachmentsReady`).
+
+---
+
+## Workflow 2 -- Cognito user resolution / upsert (forms → city-account, tax → city-account)
+
+Both forms-backend and tax-backend resolve the calling end user through city-account on **every authenticated request** -- city-account is the single source of truth for the account record behind a Cognito token.
+
+- **Participants:** nest-forms-backend **or** nest-tax-backend -> nest-city-account.
+- **Trigger (request):** any authenticated request to forms or tax.
+- **Transport / auth:** HTTP via `openapi-clients/city-account`, **forwarding the end user's Cognito Bearer** to `userControllerUpsertUser`.
+  - forms: `src/auth-v2/services/city-account-user.service.ts` (in `UserAuthStrategy`).
+  - tax: `@BratislavaUser()` -> `UserInfoPipe` (`src/auth/decorators/user-info.decorator.ts`).
+
+```mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant Svc as forms-backend / tax-backend
+    participant CA as nest-city-account
+    participant Cognito
+
+    FE->>Svc: request + Cognito Bearer
+    Svc->>Cognito: verify JWT
+    Svc->>CA: userControllerUpsertUser (Bearer forwarded)
+    CA->>CA: get-or-create User/LegalPerson
+    CA-->>Svc: user (externalId, birthNumber, tier)
+    Svc-->>FE: proceed with resolved user
+```
+
+- **Notes:** city-account exposes this via its normal user API (Bearer), distinct from the admin-`apiKey` integration API used in Workflows 3-4.
+
+---
+
+## Workflow 3 -- Tax payment user-data enrichment (tax → city-account)
+
+When a card payment succeeds, tax-backend needs the payer's `externalId` (for CRM/Bloomreach tracking), which it fetches from city-account's **integration API** using service credentials.
+
+- **Participants:** nest-tax-backend -> nest-city-account.
+- **Trigger (request):** GP webpay payment-return processing (`GET /payment/cardpay/response/:taxType`).
+- **Transport / auth:** HTTP via `openapi-clients/city-account`, **admin `apiKey`** (`CITY_ACCOUNT_ADMIN_API_KEY`); `integrationControllerGetUserDataByBirthNumber` (retried). `nest-tax-backend/src/utils/subservices/cityaccount.subservice.ts`.
+
+```mermaid
+sequenceDiagram
+    participant GP as GP webpay
+    participant Tax as nest-tax-backend
+    participant CA as nest-city-account
+    participant BR as Bloomreach
+
+    GP->>Tax: payment return (verified digest)
+    Tax->>Tax: mark TaxPayment SUCCESS
+    Tax->>CA: integrationControllerGetUserDataByBirthNumber (apiKey)
+    CA-->>Tax: externalId + delivery method
+    Tax->>BR: track payment event
+```
+
+- **Notes:** the same integration API is called in **batch** (`...GetUserDataByBirthNumbersBatch`) from tax-backend's Noris import and reminder crons -- the same cross-backend edge, exercised from scheduled jobs rather than the payment request.
+
+---
+
+## Workflow 4 -- Newly-verified user ingestion (tax → city-account, scheduled)
+
+tax-backend continuously ingests newly-verified City Account users so it can pre-create taxpayer records.
+
+- **Participants:** nest-tax-backend -> nest-city-account.
+- **Trigger (scheduled job):** tax-backend `@Cron(EVERY_30_SECONDS)` `loadNewUsersFromCityAccount` (`src/tasks/subservices/city-account-ingestion.tasks.service.ts`).
+- **Transport / auth:** HTTP via `openapi-clients/city-account`, **admin `apiKey`**; `integrationControllerGetNewVerifiedUsersBirthNumbers` (paged with `since`/`take`).
+
+```mermaid
+sequenceDiagram
+    participant Cron as tax-backend cron (30s)
+    participant CA as nest-city-account
+    participant DB as tax Postgres
+
+    Cron->>DB: read watermark (Config.LOADING_NEW_USERS_FROM_CITY_ACCOUNT)
+    Cron->>CA: getNewVerifiedUsersBirthNumbers(since, take) (apiKey)
+    CA-->>Cron: page of newly-verified birth numbers
+    Cron->>DB: upsert TaxPayer rows + advance watermark
+```
+
+---
+
+## Out of Scope (deliberately not cross-backend workflows)
+
+- **Single-service internal flows** -- e.g. the forms NASES/GINIS delivery pipeline, tax GP-webpay payment, verification against Magproxy/NASES -- documented in each service's own `docs/ARCHITECTURE.md`.
+- **Calls to external (non-konto) systems** -- AWS Cognito, slovensko.sk/NASES, GINIS, Magproxy/RFO/RPO, GP webpay, Bloomreach, Mailgun/SES, Strapi, SharePoint, and the `nest-enforcement-backend` towing proxy called by city-account. These are external dependencies, not konto-to-konto workflows.
+- **Shared-database coupling (not a service call):** both **nest-city-account** and **nest-tax-backend** connect **directly** to the municipal **Noris** MSSQL database. They influence the same external data (e.g. tax delivery methods) but do **not** call each other -- so this is a shared-datastore coupling, not a cross-backend workflow.
+- **The frontend (`next`)** calls all three business backends, but as a client, not as one backend orchestrating another; those are covered in the frontend's own doc.
+
+---
+
+> **Keep this doc in sync:** if a code change adds, removes, or changes a workflow that crosses konto backends (a new service-to-service call, a changed callback, a new cross-service cron), update this file. Changes that are internal to one service belong in that service's own `docs/ARCHITECTURE.md`.

--- a/nest-city-account/README.md
+++ b/nest-city-account/README.md
@@ -2,6 +2,10 @@
 
 This repository contains backend code of the City Account project.
 
+## Architecture
+
+For a high-level overview of this service (modules, data model, auth, integrations, deployment), see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). For workflows that span multiple konto backends, see the repo-root [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md).
+
 ## Product specification
 
 [Product specification](https://magistratba.sharepoint.com/:w:/s/InnovationTeam/Ee7urGwpSLBGnhyBYT5OJyAB9yPAd8xctA2I_xU6rYWbuA?e=ofobAR)

--- a/nest-city-account/docs/ARCHITECTURE.md
+++ b/nest-city-account/docs/ARCHITECTURE.md
@@ -171,4 +171,20 @@ Representative trace -- **`POST /user-verification/identity-card`**: logger midd
 
 ---
 
-> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, the integration API, crons), update this `ARCHITECTURE.md` in the same change.
+## Async Messaging & Scheduled Jobs
+
+- **Bloomreach outbox** -- a transactional (DB-backed) outbox processed on an interval rather than through a broker queue.
+- **Cron** (`@nestjs/schedule`, `src/tasks/tasks.service.ts`) -- Bloomreach outbox processing, delivery-method + eDesk sync to Noris, OAuth2 code cleanup, yearly delivery-method lock, daily summary emails.
+- **Redis** backs the nonce/replay store; RabbitMQ is provisioned.
+
+## API Documentation
+
+Swagger UI is served at `/api`.
+
+## Deployment
+
+The app is containerised and deployed to **Kubernetes** across three environments -- **development**, **staging**, and **production** -- automated through **GitHub Actions**. Infrastructure code lives in [bratislava/infrastructure-deployment-configuration](https://github.com/bratislava/infrastructure-deployment-configuration).
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, the integration API, crons, deployment), update this `ARCHITECTURE.md` in the same change.

--- a/nest-city-account/docs/ARCHITECTURE.md
+++ b/nest-city-account/docs/ARCHITECTURE.md
@@ -1,0 +1,189 @@
+# nest-city-account -- Architecture
+
+> This is the high-level architecture for the **nest-city-account** service, one app in the `konto.bratislava.sk` monorepo. For workflows that span multiple konto backends, see the repo-root [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
+
+## System Overview
+
+`nest-city-account` is the backend that owns the **user / account domain** for Bratislava City Account (Konto). It manages user and legal-person records, account verification (identity card, eID/UPVS, IČO/RPO), GDPR consents, tax-document delivery-method preferences, and acts as an **OAuth2 identity provider** for client apps (DPB, PAAS-MPA). It also exposes a stable B2B **integration API** consumed by sibling konto backends.
+
+The backend is a **NestJS 11** application backed by **PostgreSQL** (Prisma), with **Redis** (nonce/cache), a transactional **Bloomreach outbox**, and a direct **MSSQL** connection to the municipal **Noris** tax system. Users authenticate with **AWS Cognito**; service callers use an admin **apiKey**; some clients use **RSA request signing**.
+
+### Environments
+
+| Environment | URL |
+|---|---|
+| Production | `https://nest-city-account.bratislava.sk/` |
+| Staging | `https://nest-city-account.staging.bratislava.sk/` |
+| Development | `https://nest-city-account.dev.bratislava.sk/` |
+| Local | `http://localhost:3000/` |
+
+Config is validated/typed via decorator classes (`src/config/environment-variables.ts`, `BaConfigService`). `CLUSTER_ENV` is `dev`/`staging`/`production`.
+
+---
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph clients [Clients]
+        Citizen["Citizen (frontend)<br/>Cognito JWT"]
+        Siblings["Sibling backends<br/>(tax / forms) apiKey"]
+        OAuthApps["OAuth2 clients<br/>(DPB, PAAS-MPA)"]
+    end
+
+    subgraph nest [nest-city-account]
+        Auth["Auth (Cognito / apiKey / RSA)"]
+        User["User + Verification"]
+        Integration["Integration API (B2B)"]
+        OAuth2["OAuth2 server"]
+        Tasks["Tasks (@Cron / outbox)"]
+        Prisma["Prisma"]
+    end
+
+    subgraph storage [Storage]
+        PG["PostgreSQL"]
+        Redis["Redis (nonce/cache)"]
+    end
+
+    subgraph external [External Systems]
+        Cognito["AWS Cognito"]
+        Magproxy["Magproxy (RFO/RPO)"]
+        Nases["NASES / slovensko.sk (UPVS, eDesk)"]
+        Noris["Noris (MSSQL)"]
+        Bloomreach["Bloomreach / Exponea"]
+        Mailgun["Mailgun"]
+        Enforcement["nest-enforcement-backend<br/>(towing proxy)"]
+    end
+
+    Citizen -->|Bearer| Auth
+    Siblings -->|apiKey| Integration
+    OAuthApps --> OAuth2
+    Auth --> User
+    User & Integration & OAuth2 & Tasks --> Prisma --> PG
+    Auth -->|nonce| Redis
+    Auth -->|verify + attrs| Cognito
+    User -->|RFO/RPO lookup| Magproxy
+    User -->|eID / eDesk| Nases
+    Tasks -->|delivery method + eDesk| Noris
+    Tasks -->|CRM outbox| Bloomreach
+    Tasks -->|email + PDF| Mailgun
+    User -->|public towing lookup| Enforcement
+```
+
+---
+
+## Module Map
+
+Root `src/app.module.ts` wires config, Prisma, the feature modules, and `ScheduleModule.forRoot()`; `AppLoggerMiddleware` runs on all routes except `oauth2/*`; `AppController` exposes `GET /healthcheck`.
+
+| Module | Prefix | Auth | Purpose |
+|---|---|---|---|
+| **AuthModule** | `/auth` | -- | Passport strategies/guards (Cognito, admin apiKey, RSA signature) + nonce service |
+| **UserModule** | `/user`, `/user-integration` | Cognito / apiKey | User CRUD, consents, delivery-method preference, Bloomreach sync; B2B contact/ID lookup |
+| **VerificationModule** | `/user-verification` | Cognito | Identity-card, IČO-RPO, eID verification |
+| **IntegrationModule** | `/integration` | apiKey | **Stable B2B API for sibling backends** (see Cross-Backend) |
+| **OAuth2Module** | `/oauth2` | OAuth2 guards | Authorization-code server for client apps |
+| **DpbModule / PaasMpaModule** | `/dpb`, `/paas-mpa` | OAuth2 / RSA | Client integrations (DPB user logins/data; PAAS-MPA registration) |
+| **TowingModule** | `/towing` | public (Turnstile) | Public towing lookup proxy to the enforcement backend |
+| **AdminModule** | `/admin` | apiKey | Maintenance ops + cron |
+| **NorisModule** | -- | -- | Noris (MSSQL) delivery-method + eDesk sync |
+| **TasksModule** | -- | -- | Cron orchestration + Bloomreach outbox processor |
+| Supporting | -- | -- | Magproxy, NASES, Bloomreach, Mailgun, PDF-generator, Cache (Redis), PhysicalEntity, UPVS queue |
+
+---
+
+## Data Model Overview
+
+```mermaid
+erDiagram
+    User ||--o| PhysicalEntity : "1:1"
+    User ||--o{ UserConsents : ""
+    User ||--o{ UserGdprData : ""
+    User ||--o{ UserIdCardVerify : ""
+    User ||--o{ UserLoginClient : ""
+    User ||--o{ DeliveryMethodPreferenceHistory : ""
+    LegalPerson ||--o{ LegalPersonGdprData : ""
+    LegalPerson ||--o{ LegalPersonLoginClient : ""
+    PhysicalEntity ||--o{ ExternalEdeskCheck : "via norisId"
+```
+
+### Models (`prisma/schema.prisma`)
+
+- **User** -- core account. `externalId` (Cognito sub), `email`, `ifo`, `birthNumber` (unique), `cognitoTier`, tax delivery fields, deceased flags, verification counters.
+- **LegalPerson** -- legal/self-employed account (`ico`, unique `[ico, birthNumber]`) with parallel consent/GDPR/login-client relations.
+- **PhysicalEntity** -- consolidated magproxy/NASES data; `uri` (UPVS/eDesk URI), eDesk activity + update metadata. Optional 1:1 to `User`.
+- **UserConsents / *History**, **UserGdprData** -- consents + append-only audit.
+- **UserIdCardVerify** -- short-lived encrypted verification data.
+- **ExternalEdeskCheck** -- UPVS eDesk-check queue keyed on `norisId`.
+- **OAuth2Data** -- authorization codes + encrypted tokens (PKCE).
+- **BloomreachOutbox** -- transactional outbox for CRM commands.
+- **UserLoginClient / LegalPersonLoginClient**, **Config**, **DeliveryMethodPreferenceHistory**.
+
+Enums include `CognitoUserAttributesTierEnum` (NEW, QUEUE/NOT_VERIFIED/IDENTITY_CARD, EID), `DeliveryMethodEnum`, `ConsentEnum`, `GDPRCategoryEnum`, `LoginClientEnum` (DPB, PAAS_MPA, CITY_ACCOUNT).
+
+---
+
+## Authentication & Authorization
+
+Three Passport strategies:
+
+1. **Cognito JWT** -- validates RS256 access tokens via JWKS; loads the user via `CognitoSubservice`. Protects `/user/*` and `/user-verification/*`.
+2. **Admin apiKey** -- `HeaderAPIKeyStrategy` (header `apiKey`, timing-safe compare to `ADMIN_APP_SECRET`). Protects `/admin/*`, `/integration/*`, `/user-integration/*` -- the B2B surface.
+3. **RSA signature** -- `@SignatureAuth()` verifies `X-Signature` (RSA-SHA256 over `METHOD|PATH|TIMESTAMP|BODY`) with a 5-min window and optional Redis-backed nonce replay protection. Used by DPB.
+
+**OAuth2 server** endpoints use their own request guards (`HttpsGuard`, `AuthorizationRequestGuard`, `TokenRequestGuard`, `OAuth2AccessGuard`). **Public**: `GET /healthcheck` and `POST /towing/public/:ecv` (Cloudflare Turnstile captcha).
+
+Swagger schemes: `apiKey` (header) + Bearer (Cognito).
+
+---
+
+## External Integrations
+
+| Integration | Purpose | Files / env |
+|---|---|---|
+| **AWS Cognito** | Identity provider; user attribute/tier management. | `src/auth/strategies/cognito.strategy.ts`; `AWS_COGNITO_*`. |
+| **Magproxy** | RFO/RPO registry lookups (natural + legal persons) via Azure-AD-authenticated OpenAPI client. | `src/magproxy/*`, `openapi-clients/magproxy`; `MAGPROXY_*`. |
+| **NASES / slovensko.sk (UPVS, eDesk)** | eID identity checks, eDesk status. | `src/nases/*`, `openapi-clients/slovensko-sk`; `SLOVENSKO_SK_*`. |
+| **Noris (MSSQL)** | Push delivery methods + eDesk status to the tax system (direct DB). | `src/noris/*`; `MSSQL_*`. |
+| **Bloomreach / Exponea** | CRM via transactional outbox; separate contacts Postgres. | `src/bloomreach/*`; `BLOOMREACH_*`. |
+| **Mailgun** | Delivery-method change emails with PDF attachments. | `src/mailgun/*`; `MAILGUN_*`. |
+| **PDF generator (Playwright)** | Render tax-delivery PDFs. | `src/pdf-generator/*`. |
+| **nest-enforcement-backend** | Public towing lookup proxy. | `src/towing/towing.service.ts`; `ENFORCEMENT_BACKEND_*`. |
+| **Redis** | Nonce replay store / cache. | `src/cache/*`; `REDIS_*`. |
+
+---
+
+## Cross-Backend Calls
+
+Within konto, city-account is the **provider of record** -- siblings call *it*, not the other way around.
+
+- **Inbound (siblings -> city-account):** the Admin-apiKey **Integration API** (`/integration`): `GET /integration/userdata`, `POST /integration/userdata-batch`, `POST /integration/get-verified-users-birth-numbers-batch`; plus `GET /user-integration/contact-and-id-info/:externalId`. **nest-tax-backend** consumes these to resolve taxpayers, batch user data, and ingest newly verified users.
+- **Outbound to konto siblings:** none to forms/tax/clamav (a historical tax-backend upload was removed). The only outbound service proxy is to **nest-enforcement-backend** (towing) -- a Bratislava backend, but not one of the konto trio.
+- **Noris caveat:** city-account reads/writes Noris (MSSQL) directly -- a shared-database integration with the tax domain, not a service-to-service call.
+
+---
+
+## Request Lifecycle
+
+Global setup (`src/main.ts`): custom logger, global `ValidationPipe`, global filters `ErrorFilter` -> `TypeErrorFilter` -> `HttpExceptionFilter`. `AppLoggerMiddleware` logs method/URL/status/timing (except OAuth2 routes, which add `NoCacheMiddleware` + a scoped OAuth2 filter). `ThrowerErrorGuard` is the standard typed-exception factory.
+
+Representative trace -- **`POST /user-verification/identity-card`**: logger middleware -> `ValidationPipe` -> `CognitoGuard` (verify JWT, load user) -> `VerificationService` -> Magproxy (RFO lookup, Azure-AD auth) and/or NASES -> persist encrypted `UserIdCardVerify` and update the user's `cognitoTier`.
+
+---
+
+## Deployment
+
+- **Docker** -- multi-stage on `node:24-alpine` (with Chromium/qpdf for PDF, tini); pulls the shared `openapi-clients` image from Harbor. Prod `CMD` runs `db:migrate:deploy && start:prod` (Prisma migrations at start).
+- **docker-compose (local)** -- main Postgres + Bloomreach-contacts Postgres + RabbitMQ; a bootstrap SQL for the contacts DB.
+- **Scheduling / queues** -- `@nestjs/schedule` crons in `src/tasks/tasks.service.ts` (Bloomreach outbox every 30s, delivery-method + eDesk sync to Noris, OAuth2 cleanup, yearly delivery-method lock, daily summary emails). RabbitMQ + Redis are provisioned; Bloomreach uses a DB outbox rather than a broker.
+- **CI/CD** -- centralized monorepo `.github/workflows/` (`build-nest.yml`, `deploy.yml`); no in-repo k8s manifests (infra in an external repo).
+
+---
+
+## Swagger / OpenAPI
+
+Docs UI at **`/api`** (`src/main.ts`). Security schemes: `apiKey` (header, B2B) + Bearer (Cognito). B2B endpoints tagged `Backend Integration API`, `User integration`, `Towing`.
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, the integration API, crons, deployment), update this `ARCHITECTURE.md` in the same change.

--- a/nest-city-account/docs/ARCHITECTURE.md
+++ b/nest-city-account/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 `nest-city-account` is the backend that owns the **user / account domain** for Bratislava City Account (Konto). It manages user and legal-person records, account verification (identity card, eID/UPVS, IČO/RPO), GDPR consents, tax-document delivery-method preferences, and acts as an **OAuth2 identity provider** for client apps (DPB, PAAS-MPA). It also exposes a stable B2B **integration API** consumed by sibling konto backends.
 
-The backend is a **NestJS 11** application backed by **PostgreSQL** (Prisma), with **Redis** (nonce/cache), a transactional **Bloomreach outbox**, and a direct **MSSQL** connection to the municipal **Noris** tax system. Users authenticate with **AWS Cognito**; service callers use an admin **apiKey**; some clients use **RSA request signing**.
+The backend is a **NestJS** application backed by **PostgreSQL** (Prisma), with **Redis** (nonce/cache), a transactional **Bloomreach outbox**, and a direct **MSSQL** connection to the municipal **Noris** financial system. Users authenticate with **AWS Cognito**; service callers use an admin **apiKey**; some clients use **RSA request signing**.
 
 ### Environments
 
@@ -133,7 +133,7 @@ Three Passport strategies:
 
 **OAuth2 server** endpoints use their own request guards (`HttpsGuard`, `AuthorizationRequestGuard`, `TokenRequestGuard`, `OAuth2AccessGuard`). **Public**: `GET /healthcheck` and `POST /towing/public/:ecv` (Cloudflare Turnstile captcha).
 
-Swagger schemes: `apiKey` (header) + Bearer (Cognito).
+Auth schemes: `apiKey` (header) + Bearer (Cognito).
 
 ---
 
@@ -144,7 +144,7 @@ Swagger schemes: `apiKey` (header) + Bearer (Cognito).
 | **AWS Cognito** | Identity provider; user attribute/tier management. | `src/auth/strategies/cognito.strategy.ts`; `AWS_COGNITO_*`. |
 | **Magproxy** | RFO/RPO registry lookups (natural + legal persons) via Azure-AD-authenticated OpenAPI client. | `src/magproxy/*`, `openapi-clients/magproxy`; `MAGPROXY_*`. |
 | **NASES / slovensko.sk (UPVS, eDesk)** | eID identity checks, eDesk status. | `src/nases/*`, `openapi-clients/slovensko-sk`; `SLOVENSKO_SK_*`. |
-| **Noris (MSSQL)** | Push delivery methods + eDesk status to the tax system (direct DB). | `src/noris/*`; `MSSQL_*`. |
+| **Noris (MSSQL)** | Push delivery methods + eDesk status to the municipal financial system (direct DB). | `src/noris/*`; `MSSQL_*`. |
 | **Bloomreach / Exponea** | CRM via transactional outbox; separate contacts Postgres. | `src/bloomreach/*`; `BLOOMREACH_*`. |
 | **Mailgun** | Delivery-method change emails with PDF attachments. | `src/mailgun/*`; `MAILGUN_*`. |
 | **PDF generator (Playwright)** | Render tax-delivery PDFs. | `src/pdf-generator/*`. |
@@ -171,19 +171,4 @@ Representative trace -- **`POST /user-verification/identity-card`**: logger midd
 
 ---
 
-## Deployment
-
-- **Docker** -- multi-stage on `node:24-alpine` (with Chromium/qpdf for PDF, tini); pulls the shared `openapi-clients` image from Harbor. Prod `CMD` runs `db:migrate:deploy && start:prod` (Prisma migrations at start).
-- **docker-compose (local)** -- main Postgres + Bloomreach-contacts Postgres + RabbitMQ; a bootstrap SQL for the contacts DB.
-- **Scheduling / queues** -- `@nestjs/schedule` crons in `src/tasks/tasks.service.ts` (Bloomreach outbox every 30s, delivery-method + eDesk sync to Noris, OAuth2 cleanup, yearly delivery-method lock, daily summary emails). RabbitMQ + Redis are provisioned; Bloomreach uses a DB outbox rather than a broker.
-- **CI/CD** -- centralized monorepo `.github/workflows/` (`build-nest.yml`, `deploy.yml`); no in-repo k8s manifests (infra in an external repo).
-
----
-
-## Swagger / OpenAPI
-
-Docs UI at **`/api`** (`src/main.ts`). Security schemes: `apiKey` (header, B2B) + Bearer (Cognito). B2B endpoints tagged `Backend Integration API`, `User integration`, `Towing`.
-
----
-
-> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, the integration API, crons, deployment), update this `ARCHITECTURE.md` in the same change.
+> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, the integration API, crons), update this `ARCHITECTURE.md` in the same change.

--- a/nest-clamav-scanner/README.md
+++ b/nest-clamav-scanner/README.md
@@ -2,6 +2,10 @@
 
 Backend utility responsible for handling requests for files needed to be scanned. It uses ClamAV interface to scan files. As a file storage we use our minio bucket storage.
 
+## Architecture
+
+For a high-level overview of this service (endpoints, statuses, the scan/callback flow, deployment), see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). For workflows that span multiple konto backends, see the repo-root [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md).
+
 ## How it works
 
 It has two main parts: Endpoints where new files are added to the queue for the scanning. And a DB queue run by regular cron jobs.

--- a/nest-clamav-scanner/docs/ARCHITECTURE.md
+++ b/nest-clamav-scanner/docs/ARCHITECTURE.md
@@ -1,0 +1,159 @@
+# nest-clamav-scanner -- Architecture
+
+> This is the high-level architecture for the **nest-clamav-scanner** service, one app in the `konto.bratislava.sk` monorepo. For workflows that span multiple konto backends, see the repo-root [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
+
+## System Overview
+
+`nest-clamav-scanner` scans files uploaded to MinIO/S3 for viruses via **ClamAV**. Callers (in practice **nest-forms-backend**) register already-uploaded files for scanning; a 20-second cron worker drains a DB-backed queue, streams each file to ClamAV, moves it to a safe/infected bucket, and calls back to the forms backend with the final verdict.
+
+The backend is a **NestJS 11** application backed by **PostgreSQL** (Prisma, pg adapter). There is **no message broker** -- the "queue" is a Postgres `Files` table polled by an in-process cron. Callers authenticate with **HTTP Basic auth**.
+
+### Environments
+
+| Environment | URL |
+|---|---|
+| Production | `https://nest-clamav-scanner.bratislava.sk/` |
+| Staging | `https://nest-clamav-scanner.staging.bratislava.sk/` |
+| Development | `https://nest-clamav-scanner.dev.bratislava.sk/` |
+| Local | `http://localhost:3200/` |
+
+Config is fail-fast validated (`src/config/environment-variables.ts`, `BaConfig`, `BaConfigService`). Key groups: `clamav` (host/port), `minio` (buckets `unscanned`/`safe`/`infected`), `formsBackend` (`NEST_FORMS_BACKEND`), `fileLimits`.
+
+---
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph caller [Caller]
+        Forms["nest-forms-backend<br/>(sibling)"]
+    end
+
+    subgraph nest [nest-clamav-scanner]
+        Scanner["ScannerModule<br/>/api/scan (enqueue)"]
+        Status["StatusModule<br/>/api/status"]
+        Cron["ScannerCronModule<br/>(20s worker)"]
+        FormsClient["FormsClient<br/>(result callback)"]
+        Prisma["Prisma (Files table = queue)"]
+    end
+
+    subgraph storage [Storage]
+        PG["PostgreSQL"]
+    end
+
+    subgraph external [External Systems]
+        Clamd["ClamAV daemon (clamd)"]
+        Minio["MinIO / S3<br/>(unscanned/safe/infected)"]
+    end
+
+    Forms -->|"POST /api/scan/file(s) (Basic)"| Scanner
+    Forms -->|"GET /health"| Status
+    Scanner --> Prisma --> PG
+    Cron --> Prisma
+    Cron -->|"scan stream"| Clamd
+    Cron -->|"read + move file"| Minio
+    Cron --> FormsClient -->|"PATCH scan/:id verdict"| Forms
+```
+
+---
+
+## Module Map
+
+Root `src/app.module.ts` wires config, clients, Prisma, MinIO/ClamAV clients, auth, and `ScheduleModule.forRoot()`.
+
+| Module | Route prefix | Auth | Purpose |
+|---|---|---|---|
+| **AppController** | `/` | public | `GET /health`, `GET /` hello |
+| **StatusModule** | `/api/status` | public | Health of prisma / minio / forms / clamav + clamav version |
+| **ScannerModule** | `/api/scan` | Basic | Enqueue / query / delete file scan records |
+| **ScannerCronModule** | -- | -- | The 20s cron worker doing actual scanning |
+| **ClamavClientModule** | -- | -- | `clamdjs` scan client |
+| **MinioClient/Storage** | -- | -- | MinIO client + stream/move/list ops |
+| **ClientsModule / FormsClientModule** | -- | -- | Builds the `openapi-clients/forms` client; notifies forms of results |
+
+**Scanner endpoints** (`src/scanner/scanner.controller.ts`, all `BasicGuard`): `POST /api/scan/files` (batch, 202), `POST /api/scan/file` (single, 202), `GET /api/scan/file/:fileUid64/:bucketUid64`, `GET /api/scan/file/:resourceId`, `DELETE /api/scan/file/:resourceId`.
+
+---
+
+## Data Model Overview
+
+Single model **`Files`** (`prisma/schema.prisma`): `id` (UUID), `fileUid`, `bucketUid`, `fileSize`, `fileMimeType`, `status` (`FileStatus`, default `ACCEPTED`), `notified` (was forms told), `runs` (scan attempts), `meta` (JSON), timestamps.
+
+`FileStatus` enum: `ACCEPTED`, `QUEUED`, `SCANNING`, `SAFE`, `INFECTED`, `NOT_FOUND`, `MOVE_ERROR_SAFE`, `MOVE_ERROR_INFECTED`, `SCAN_ERROR`, `SCAN_TIMEOUT`, `SCAN_NOT_SUCCESSFUL`, `FORM_ID_NOT_FOUND`. The table doubles as the durable work queue.
+
+---
+
+## Authentication & Authorization
+
+- **HTTP Basic** only -- `BasicStrategy` (`passport-http`, strategy `'auth-basic'`), `BasicGuard` on every `/api/scan/*` endpoint. Credentials `NEST_CLAMAV_SCANNER_USERNAME`/`_PASSWORD` compared with a timing-safe check. No Cognito here.
+- **Public** -- `GET /`, `GET /health`, and all `GET /api/status/*` (the forms backend polls `/health`).
+
+---
+
+## External Integrations
+
+- **ClamAV daemon (clamd)** -- `ClamavClientService` via `clamdjs` (`scanStream`, `ping`, `version`); result mapped `OK`->`SAFE`, `FOUND`->`INFECTED`, `SCAN TIMEOUT`->`SCAN_TIMEOUT`. Env `CLAMAV_HOST`/`CLAMAV_PORT`. The clamd daemon + a CVD virus-definition mirror live in the sibling repo dirs `/clamav` and `/cvdmirror`.
+- **MinIO / S3** -- `MinioStorageService` (stat/get/copy+remove/list) across three buckets (`unscanned` source, `safe`, `infected`). This is the same S3 where forms-backend uploads files.
+- **nest-forms-backend** (sibling) -- bidirectional; see Cross-Backend Calls.
+
+---
+
+## Cross-Backend Calls
+
+Coupled **exclusively** to **nest-forms-backend** (bidirectional, two transports). No city-account or tax-backend interaction.
+
+- **forms -> scanner (inbound):** forms enqueues files (`POST /api/scan/file(s)`), polls status (`GET /api/scan/file/:id`), deletes records (`DELETE`), and polls `GET /health`. Transport: raw axios + Basic auth (forms side: `src/scanner-client/scanner-client.service.ts`).
+- **scanner -> forms (outbound callback):** the cron worker pushes the final verdict via `FormsClientService.updateFileStatus` -> `filesControllerUpdateFileStatusScannerId` (`PATCH scan/:scannerId` on forms), using the shared `openapi-clients/forms` client + Basic auth. It callbacks only for terminal statuses (`SAFE`, `INFECTED`, `NOT_FOUND`, `MOVE_ERROR_*`, `SCAN_NOT_SUCCESSFUL`). A `GET /` health poll gates the callback. `fixUnnotifiedFiles()` re-sends any terminal record with `notified=false` each cron tick.
+
+---
+
+## Request / Scan Lifecycle
+
+No global pipes/filters/interceptors; guards are the only per-route gate; validation is manual in `ScannerService`.
+
+**Enqueue** (`ScannerService.scanFile`): validate `fileUid` -> default bucket to `unscanned` -> dedupe (existing -> `410`) -> `fileExists` in MinIO (`404`) -> size check (`413`) -> mime-type vs whitelist (`400`) -> insert `Files` row (`ACCEPTED`) -> `202`. Batch caps at `MAX_FILES_PER_REQUEST`.
+
+**Scan** (`ScannerCronService`, every 20s, single-flight via `globalThis.cronRunning`):
+
+```mermaid
+sequenceDiagram
+    participant Cron
+    participant DB as Files (Postgres)
+    participant Clam as ClamAV
+    participant S3 as MinIO
+    participant Forms as nest-forms-backend
+
+    Cron->>Clam: require clamd up (else abort)
+    Cron->>Forms: GET / (forms up?)
+    Cron->>DB: fix unnotified / stuck / failed records
+    Cron->>DB: take up to 80 ACCEPTED -> QUEUED
+    loop batches of 4
+        Cron->>DB: mark SCANNING (runs++)
+        Cron->>S3: load file stream (NOT_FOUND if missing)
+        Cron->>Clam: scanStream (race vs timeout)
+        alt SAFE / INFECTED
+            Cron->>S3: move to safe/infected bucket
+        end
+        Cron->>DB: persist final status
+        Cron->>Forms: PATCH scan/:id verdict (if terminal)
+    end
+```
+
+---
+
+## Deployment
+
+- **Docker** -- multi-stage on `node:24-alpine`; pulls the shared `openapi-clients` image from Harbor. Prod `CMD` runs `db:migrate:deploy && start:prod` (Prisma migrations at start). `tini` init.
+- **docker-compose (local)** -- `nest` (port 3200, debug 9229) + `postgres` (54302); overrides `CLAMAV_HOST=clamav-app` and points at a local forms backend. Depends on the `/clamav` (clamd) and `/cvdmirror` (definitions) sibling repo dirs.
+- **Scheduling** -- one in-process `@Cron('*/20 * * * * *')` job; Postgres is the durable queue (no broker). Horizontal scaling of the worker would double-process without external coordination.
+- **CI/CD** -- centralized monorepo `.github/workflows/` (`build-nest.yml`, `build.yml`, `deploy.yml`); no service-local k8s manifests (infra lives in an external repo).
+
+---
+
+## Swagger / OpenAPI
+
+Docs UI at **`/api`**; raw spec at **`/spec-json`** (`src/main.ts`). Single security scheme: **HTTP Basic**. Tags: `Health`, `Statuses`, `Scanner`.
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (endpoints, statuses, the scan/callback flow, ClamAV/MinIO wiring, deployment), update this `ARCHITECTURE.md` in the same change.

--- a/nest-clamav-scanner/docs/ARCHITECTURE.md
+++ b/nest-clamav-scanner/docs/ARCHITECTURE.md
@@ -141,4 +141,18 @@ sequenceDiagram
 
 ---
 
-> **Keep this doc in sync:** if a code change updates something described here (endpoints, statuses, the scan/callback flow, ClamAV/MinIO wiring), update this `ARCHITECTURE.md` in the same change.
+## Scheduled Jobs
+
+The scan worker is a single in-process `@Cron('*/20 * * * * *')` job; the durable queue is the Postgres `Files` table (no message broker). Horizontally scaling the worker would double-process without external coordination.
+
+## API Documentation
+
+Swagger UI is served at `/api` (raw OpenAPI spec at `/spec-json`).
+
+## Deployment
+
+The app is containerised and deployed to **Kubernetes** across three environments -- **development**, **staging**, and **production** -- automated through **GitHub Actions**. Infrastructure code lives in [bratislava/infrastructure-deployment-configuration](https://github.com/bratislava/infrastructure-deployment-configuration).
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (endpoints, statuses, the scan/callback flow, ClamAV/MinIO wiring, deployment), update this `ARCHITECTURE.md` in the same change.

--- a/nest-clamav-scanner/docs/ARCHITECTURE.md
+++ b/nest-clamav-scanner/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 `nest-clamav-scanner` scans files uploaded to MinIO/S3 for viruses via **ClamAV**. Callers (in practice **nest-forms-backend**) register already-uploaded files for scanning; a 20-second cron worker drains a DB-backed queue, streams each file to ClamAV, moves it to a safe/infected bucket, and calls back to the forms backend with the final verdict.
 
-The backend is a **NestJS 11** application backed by **PostgreSQL** (Prisma, pg adapter). There is **no message broker** -- the "queue" is a Postgres `Files` table polled by an in-process cron. Callers authenticate with **HTTP Basic auth**.
+The backend is a **NestJS** application backed by **PostgreSQL** (Prisma). There is **no message broker** -- the "queue" is a Postgres `Files` table polled by an in-process cron. Callers authenticate with **HTTP Basic auth**.
 
 ### Environments
 
@@ -141,19 +141,4 @@ sequenceDiagram
 
 ---
 
-## Deployment
-
-- **Docker** -- multi-stage on `node:24-alpine`; pulls the shared `openapi-clients` image from Harbor. Prod `CMD` runs `db:migrate:deploy && start:prod` (Prisma migrations at start). `tini` init.
-- **docker-compose (local)** -- `nest` (port 3200, debug 9229) + `postgres` (54302); overrides `CLAMAV_HOST=clamav-app` and points at a local forms backend. Depends on the `/clamav` (clamd) and `/cvdmirror` (definitions) sibling repo dirs.
-- **Scheduling** -- one in-process `@Cron('*/20 * * * * *')` job; Postgres is the durable queue (no broker). Horizontal scaling of the worker would double-process without external coordination.
-- **CI/CD** -- centralized monorepo `.github/workflows/` (`build-nest.yml`, `build.yml`, `deploy.yml`); no service-local k8s manifests (infra lives in an external repo).
-
----
-
-## Swagger / OpenAPI
-
-Docs UI at **`/api`**; raw spec at **`/spec-json`** (`src/main.ts`). Single security scheme: **HTTP Basic**. Tags: `Health`, `Statuses`, `Scanner`.
-
----
-
-> **Keep this doc in sync:** if a code change updates something described here (endpoints, statuses, the scan/callback flow, ClamAV/MinIO wiring, deployment), update this `ARCHITECTURE.md` in the same change.
+> **Keep this doc in sync:** if a code change updates something described here (endpoints, statuses, the scan/callback flow, ClamAV/MinIO wiring), update this `ARCHITECTURE.md` in the same change.

--- a/nest-forms-backend/README.md
+++ b/nest-forms-backend/README.md
@@ -1,5 +1,9 @@
 # nest-forms-backend
 
+## Architecture
+
+For a high-level overview of this service (modules, data model, auth, integrations, delivery pipeline, deployment), see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). For workflows that span multiple konto backends, see the repo-root [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md).
+
 ## Run locally
 
 1. Run from `docker compose`:

--- a/nest-forms-backend/docs/ARCHITECTURE.md
+++ b/nest-forms-backend/docs/ARCHITECTURE.md
@@ -4,9 +4,9 @@
 
 ## System Overview
 
-`nest-forms-backend` processes Bratislava City Account **e-forms**. It owns the full form lifecycle: creation, draft editing, file upload + antivirus scanning, validation, submission to the Slovak government (**NASES / slovensko.sk**), registration into **GINIS** (document management), delivery to SharePoint/PowerApps and email/webhook channels, and PDF generation.
+`nest-forms-backend` processes Bratislava City Account **e-forms**. It owns the full form lifecycle: creation, draft editing, file upload + antivirus scanning, validation, submission to the Slovak government (**NASES / slovensko.sk**), registration into **GINIS** (the municipality's registry system), delivery to SharePoint/PowerApps and email/webhook channels, and PDF generation.
 
-The backend is a **NestJS 11** application backed by **PostgreSQL** (Prisma), with **RabbitMQ** (delayed-message exchange) for async delivery, **Redis/Bull** for SharePoint jobs, **MinIO/S3** for files, and **Playwright/Piscina** for PDF rendering. End users authenticate with **AWS Cognito** (including guest identities); service callers use HTTP Basic / admin apiKey.
+The backend is a **NestJS** application backed by **PostgreSQL** (Prisma), with **RabbitMQ** (delayed-message exchange) for async delivery, **Redis/Bull** for SharePoint jobs, **MinIO/S3** for files, and **Playwright/Piscina** for PDF rendering. End users authenticate with **AWS Cognito** (including guest identities); service callers use HTTP Basic / admin apiKey.
 
 Form lifecycle (`FormState`): `DRAFT -> QUEUED -> DELIVERED_NASES -> DELIVERED_GINIS -> SENDING_TO_SHAREPOINT -> PROCESSING -> FINISHED` (plus `REJECTED`, `ERROR`), with a parallel `GinisState` sub-lifecycle.
 
@@ -125,7 +125,7 @@ Two generations coexist:
 - **v2 (end users)** -- `UserAuthStrategy` (`passport-custom`) accepts **either** a Cognito Bearer token **or** a guest-identity header (never both). Bearer path verifies the JWT (`aws-jwt-verify`), fetches Cognito attributes, and fetches the City Account user (cross-backend, see below). Guest path assumes the unauth IAM role via STS and validates the ARN. `UserAuthGuard` + `@AllowedUserTypes(...)` gate user types; `FormAccessGuard` enforces per-form ownership.
 - **v1 (service/admin)** -- `BasicStrategy` (HTTP Basic, `NEST_FORMS_BACKEND_USERNAME/PASSWORD`, timing-safe) -- **used by the ClamAV scanner callback**; `AdminStrategy` (`apiKey` -> `ADMIN_APP_SECRET`) on `admin` endpoints.
 
-**Public**: root, status, `POST /webhook`, and `GET /files/download/file/:jwtToken` (auth inside a signed JWT). Swagger schemes: Bearer, Basic, apiKey, and a custom `cognitoGuestIdentityId` header.
+**Public**: root, status, `POST /webhook`, and `GET /files/download/file/:jwtToken` (auth inside a signed JWT). Auth schemes: Bearer, Basic, apiKey, and a custom `cognitoGuestIdentityId` header.
 
 ---
 
@@ -136,7 +136,7 @@ Two generations coexist:
 | **nest-city-account** (sibling) | Resolve/create the City Account user on every authenticated request. | `src/clients/clients.service.ts`, `src/auth-v2/services/city-account-user.service.ts`; `USER_ACCOUNT_API`. See Cross-Backend. |
 | **nest-clamav-scanner** (sibling) | Antivirus scanning of uploaded files (bidirectional). | `src/scanner-client/scanner-client.service.ts`, `src/files/*`; `NEST_CLAMAV_SCANNER`. See Cross-Backend. |
 | **slovensko.sk / NASES** | Government form submission (SKTalk XML) + identity. | `src/nases/*`, `openapi-clients/slovensko-sk`, `src/api-jwt-tokens/*`; `SLOVENSKO_SK_*`. |
-| **GINIS** | Document register/upload/assign (`@bratislava/ginis-sdk`). | `src/ginis/*`; `GINIS_*`. |
+| **GINIS** | The municipality's registry system: register/upload/assign documents (`@bratislava/ginis-sdk`). | `src/ginis/*`; `GINIS_*`. |
 | **SharePoint / Graph** | Deliver "nájomné bývanie" forms after NASES (Bull job). | `src/ginis/subservices/sharepoint.service.ts`; `SHAREPOINT_*`. |
 | **MinIO / S3** | File storage (unscanned/safe/infected buckets). | `src/minio-*`; `MINIO_*`. |
 | **Mailgun / OLO SMTP** | Confirmation + delivery emails. | `src/mailer/*`; `MAILGUN_*`, `OLO_SMTP_*`. |
@@ -194,19 +194,4 @@ The **eID** path (`/form-sender/eid/...`) verifies the signature, submits to NAS
 
 ---
 
-## Deployment
-
-- **Docker** -- multi-stage; pulls prebuilt `forms-shared` + `openapi-clients` images from Harbor (by digest); installs Playwright Chromium. Prod `CMD` runs `db:migrate:deploy && start:prod`.
-- **docker-compose (local)** -- Postgres (54321), RabbitMQ delayed-message image (5611/15611), Redis (6311).
-- **Async infra** -- RabbitMQ (`@golevelup/nestjs-rabbitmq`, `x-delayed-message` exchange; queues `RABBIT_FORM_DELIVERY`, `RABBIT_GINIS`), Bull/Redis (`sharepoint` queue), Piscina (tax PDFs). `@nestjs/schedule` crons: delete old drafts, GINIS submission-state check, NASES registration validation, expired-migration purge.
-- **CI/CD** -- monorepo `.github/workflows/` (`build-nest.yml`, `deploy.yml`); no service-local k8s manifests (infra external).
-
----
-
-## Swagger / OpenAPI
-
-Docs UI at **`/api`**; raw spec at **`/spec-json`** (`src/bootstrap.ts`). Security schemes: Bearer, Basic (scanner), apiKey, and custom `cognitoGuestIdentityId`.
-
----
-
-> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, delivery pipeline, deployment), update this `ARCHITECTURE.md` in the same change.
+> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, delivery pipeline), update this `ARCHITECTURE.md` in the same change.

--- a/nest-forms-backend/docs/ARCHITECTURE.md
+++ b/nest-forms-backend/docs/ARCHITECTURE.md
@@ -194,4 +194,21 @@ The **eID** path (`/form-sender/eid/...`) verifies the signature, submits to NAS
 
 ---
 
-> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, delivery pipeline), update this `ARCHITECTURE.md` in the same change.
+## Async Messaging & Scheduled Jobs
+
+- **RabbitMQ** (`@golevelup/nestjs-rabbitmq`) -- an `x-delayed-message` exchange with queues `RABBIT_FORM_DELIVERY` and `RABBIT_GINIS`; `@RabbitRPC` consumers drive the form-delivery and GINIS pipelines.
+- **Bull / Redis** -- a `sharepoint` queue for SharePoint/PowerApps delivery.
+- **Piscina** -- a worker pool for tax-form PDF generation.
+- **Cron** (`@nestjs/schedule`) -- delete old drafts, GINIS submission-state check, NASES registration validation, expired-migration purge.
+
+## API Documentation
+
+Swagger UI is served at `/api` (raw OpenAPI spec at `/spec-json`).
+
+## Deployment
+
+The app is containerised and deployed to **Kubernetes** across three environments -- **development**, **staging**, and **production** -- automated through **GitHub Actions**. Infrastructure code lives in [bratislava/infrastructure-deployment-configuration](https://github.com/bratislava/infrastructure-deployment-configuration).
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, delivery pipeline, async messaging, deployment), update this `ARCHITECTURE.md` in the same change.

--- a/nest-forms-backend/docs/ARCHITECTURE.md
+++ b/nest-forms-backend/docs/ARCHITECTURE.md
@@ -1,0 +1,212 @@
+# nest-forms-backend -- Architecture
+
+> This is the high-level architecture for the **nest-forms-backend** service, one app in the `konto.bratislava.sk` monorepo. For workflows that span multiple konto backends, see the repo-root [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
+
+## System Overview
+
+`nest-forms-backend` processes Bratislava City Account **e-forms**. It owns the full form lifecycle: creation, draft editing, file upload + antivirus scanning, validation, submission to the Slovak government (**NASES / slovensko.sk**), registration into **GINIS** (document management), delivery to SharePoint/PowerApps and email/webhook channels, and PDF generation.
+
+The backend is a **NestJS 11** application backed by **PostgreSQL** (Prisma), with **RabbitMQ** (delayed-message exchange) for async delivery, **Redis/Bull** for SharePoint jobs, **MinIO/S3** for files, and **Playwright/Piscina** for PDF rendering. End users authenticate with **AWS Cognito** (including guest identities); service callers use HTTP Basic / admin apiKey.
+
+Form lifecycle (`FormState`): `DRAFT -> QUEUED -> DELIVERED_NASES -> DELIVERED_GINIS -> SENDING_TO_SHAREPOINT -> PROCESSING -> FINISHED` (plus `REJECTED`, `ERROR`), with a parallel `GinisState` sub-lifecycle.
+
+### Environments
+
+| Environment | URL |
+|---|---|
+| Production | `https://nest-forms-backend.bratislava.sk/` |
+| Staging | `https://nest-forms-backend.staging.bratislava.sk/` |
+| Development | `https://nest-forms-backend.dev.bratislava.sk/` |
+| Local | `http://localhost:3100/` |
+
+Config is validated/typed (`src/config/environment-variables.ts`, `BaConfigService`). `CLUSTER_ENV` is `dev`/`staging`/`production`.
+
+---
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph clients [Clients]
+        FE["city-account-next<br/>(Cognito / guest)"]
+        Admin["Admin ops<br/>apiKey"]
+    end
+
+    subgraph nest [nest-forms-backend]
+        Auth["Auth v2 (Cognito+guest) / v1 (Basic+apiKey)"]
+        Forms["Forms + FormsV2 + FileUpload"]
+        Sender["FormSender"]
+        MQ["RabbitMQ producer"]
+        Consumers["Delivery + GINIS consumers (@RabbitRPC)"]
+        Prisma["Prisma"]
+    end
+
+    subgraph storage [Storage]
+        PG["PostgreSQL"]
+        Rabbit["RabbitMQ (delayed)"]
+        Redis["Redis/Bull"]
+        Minio["MinIO / S3"]
+    end
+
+    subgraph external [External Systems]
+        Cognito["AWS Cognito"]
+        CityAccount["nest-city-account<br/>(sibling)"]
+        Clamav["nest-clamav-scanner<br/>(sibling)"]
+        Nases["slovensko.sk / NASES"]
+        Ginis["GINIS"]
+        Sharepoint["SharePoint / Graph"]
+        Mailgun["Mailgun / OLO SMTP"]
+    end
+
+    FE -->|Bearer / guest id| Auth
+    Admin -->|apiKey| Auth
+    Auth -->|user upsert| CityAccount
+    Auth --> Forms --> Sender
+    Forms -->|files| Minio
+    Forms -->|enqueue scan| Clamav
+    Clamav -->|PATCH scan result| Forms
+    Sender --> MQ --> Rabbit --> Consumers
+    Consumers -->|SKTalk submit| Nases
+    Consumers -->|register/upload/assign| Ginis
+    Consumers -->|sharepoint job| Redis
+    Consumers -->|email| Mailgun
+    Forms & Consumers --> Prisma --> PG
+```
+
+---
+
+## Module Map
+
+Root `src/app.module.ts` imports ~20 feature modules plus `AppSharedModule` (Bull/Redis, Schedule, MinIO, Prisma) and `AppV2Module`.
+
+| Module | Prefix | Auth | Purpose |
+|---|---|---|---|
+| **FormsModule** | `forms` | v2 | Form CRUD (get/list/update/archive/bump-version) |
+| **FormsV2Module** | `forms-v2`, `forms/migrations` | v2 | Form creation + guest->auth migration |
+| **FilesModule** | `files` | v2 / Basic | Upload, JWT-signed download, **scanner status callback** |
+| **FormSenderModule** | `form-sender` | v2 | Submit form (standard + eID) |
+| **NasesModule** | -- | -- | slovensko.sk submission + identity + registration cron |
+| **GinisModule** | `ginis` | -- | GINIS register/upload/assign + SharePoint + state cron; RabbitRPC consumer |
+| **FormDeliveryConsumerModule** | -- | -- | Consumes form-delivery queue; routes to email/webhook/slovensko.sk |
+| **ConvertModule / ConvertPdfModule** | `convert` | -- | JSON<->XML, JSON->PDF (Playwright) |
+| **TaxModule** | -- | -- | Tax-form PDF via Piscina worker (in-process, no tax-backend call) |
+| **SignerModule** | `signer` | -- | Prepare data for eID signer software |
+| **AdminModule** | `admin` | apiKey | Mint JWTs, trigger NASES registration check |
+| **AuthModule / AuthV2Module** | -- | -- | v1 (Basic + apiKey) / v2 (Cognito + guest + city-account user) |
+| **ClientsModule / ScannerClientModule** | -- | -- | `openapi-clients` (city-account, slovensko-sk) + ClamAV axios client |
+| **MailerModule / WebhookModule / StatusModule** | `webhook`, `status` | mixed | Mailgun + OLO SMTP; inbound webhook (logs); health |
+
+---
+
+## Data Model Overview
+
+```mermaid
+erDiagram
+    Forms ||--o{ Files : "attachments"
+    FormMigration }o..|| Forms : "guest->auth claim"
+    FormRegistrationStatus }o..o{ Forms : "NASES registration cache"
+```
+
+### Models (`prisma/schema.prisma`)
+
+- **Forms** -- main aggregate. Ownership (`userExternalId` = Cognito sub, `cognitoGuestIdentityId` for guests, `email`, `ownerType` FO/PO, `ico`), NASES fields (`mainUri`, `senderId`, `formSentAt`), content (`formDefinitionSlug`, `jsonVersion`, `formDataJson`, `formSignature`, `formSummary`), `state` (`FormState`), `error` (`FormError`), GINIS (`ginisDocumentId`, `ginisState`).
+- **Files** -- `formId`, `scannerId` (unique, from ClamAV), `minioFileName`, `status` (`FileStatus`), GINIS upload tracking.
+- **FormMigration** -- guest->authenticated claim (`cognitoAuthSub`, `cognitoGuestIdentityId`, `expiresAt`).
+- **FormRegistrationStatus** -- NASES registration cache keyed `[slug, pospId, pospVersion]`.
+
+`FileStatus` mirrors the scanner's statuses (UPLOADED, SAFE, INFECTED, ...). `FormError` enumerates delivery failures (scan/NASES/GINIS/SharePoint/email/webhook).
+
+---
+
+## Authentication & Authorization
+
+Two generations coexist:
+
+- **v2 (end users)** -- `UserAuthStrategy` (`passport-custom`) accepts **either** a Cognito Bearer token **or** a guest-identity header (never both). Bearer path verifies the JWT (`aws-jwt-verify`), fetches Cognito attributes, and fetches the City Account user (cross-backend, see below). Guest path assumes the unauth IAM role via STS and validates the ARN. `UserAuthGuard` + `@AllowedUserTypes(...)` gate user types; `FormAccessGuard` enforces per-form ownership.
+- **v1 (service/admin)** -- `BasicStrategy` (HTTP Basic, `NEST_FORMS_BACKEND_USERNAME/PASSWORD`, timing-safe) -- **used by the ClamAV scanner callback**; `AdminStrategy` (`apiKey` -> `ADMIN_APP_SECRET`) on `admin` endpoints.
+
+**Public**: root, status, `POST /webhook`, and `GET /files/download/file/:jwtToken` (auth inside a signed JWT). Swagger schemes: Bearer, Basic, apiKey, and a custom `cognitoGuestIdentityId` header.
+
+---
+
+## External Integrations
+
+| Integration | Purpose | Files / env |
+|---|---|---|
+| **nest-city-account** (sibling) | Resolve/create the City Account user on every authenticated request. | `src/clients/clients.service.ts`, `src/auth-v2/services/city-account-user.service.ts`; `USER_ACCOUNT_API`. See Cross-Backend. |
+| **nest-clamav-scanner** (sibling) | Antivirus scanning of uploaded files (bidirectional). | `src/scanner-client/scanner-client.service.ts`, `src/files/*`; `NEST_CLAMAV_SCANNER`. See Cross-Backend. |
+| **slovensko.sk / NASES** | Government form submission (SKTalk XML) + identity. | `src/nases/*`, `openapi-clients/slovensko-sk`, `src/api-jwt-tokens/*`; `SLOVENSKO_SK_*`. |
+| **GINIS** | Document register/upload/assign (`@bratislava/ginis-sdk`). | `src/ginis/*`; `GINIS_*`. |
+| **SharePoint / Graph** | Deliver "nájomné bývanie" forms after NASES (Bull job). | `src/ginis/subservices/sharepoint.service.ts`; `SHAREPOINT_*`. |
+| **MinIO / S3** | File storage (unscanned/safe/infected buckets). | `src/minio-*`; `MINIO_*`. |
+| **Mailgun / OLO SMTP** | Confirmation + delivery emails. | `src/mailer/*`; `MAILGUN_*`, `OLO_SMTP_*`. |
+| **forms-shared** (local dep) | Form definitions, validation, summary, send-policy, signature, tax-PDF, SharePoint mapping. | bundled `forms-shared` package. |
+
+Note: form definitions come from the **bundled `forms-shared` package** (compile-time), not a live Strapi call. Tax PDFs are generated **in-process** (Piscina) -- there is no call to nest-tax-backend.
+
+---
+
+## Cross-Backend Calls
+
+Within konto, forms-backend talks to **nest-city-account** and **nest-clamav-scanner** (not tax-backend).
+
+- **-> nest-city-account** (per authenticated request): `UserAuthStrategy` -> `CityAccountUserService.getUser` -> `userControllerUpsertUser` (forwards the user Bearer) to resolve/create the City Account user. Transport: HTTPS via `openapi-clients/city-account`.
+- **-> nest-clamav-scanner** (on file upload): `FilesHelper.notifyScannerClient` -> `POST /api/scan/file` (+ poll/delete + `GET /health`). Transport: axios + HTTP Basic.
+- **<- nest-clamav-scanner** (scan-result callback): the scanner cron calls `PATCH /files/scan/:scannerId` (`BasicGuard`) -> `FilesService.updateFileStatusScannerId` updates the `Files` row and moves the object between MinIO buckets.
+
+See the repo-root [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) for these as end-to-end workflows.
+
+---
+
+## Request Lifecycle
+
+Global setup (`src/bootstrap.ts`): CORS, 50 MB JSON body, global `ValidationPipe`, global filters `ErrorFilter` -> `HttpExceptionFilter`, `AppLoggerMiddleware` on `*`. Per-route guards (`UserAuthGuard`, `FormAccessGuard`, `FormDefinitionMustBeEnabledGuard`) and interceptors (`FileUploadInterceptor`, multer + mimetype whitelist).
+
+Representative flow -- **submit a form with attachments**:
+
+```mermaid
+sequenceDiagram
+    participant FE as city-account-next
+    participant Forms as nest-forms-backend
+    participant Clamav as nest-clamav-scanner
+    participant MQ as RabbitMQ
+    participant Nases as slovensko.sk
+    participant Ginis as GINIS
+
+    FE->>Forms: POST /forms-v2 (create DRAFT)
+    FE->>Forms: POST /files/upload/:formId
+    Forms->>Clamav: POST /api/scan/file (enqueue)
+    Clamav->>Forms: PATCH /files/scan/:scannerId (SAFE/INFECTED)
+    FE->>Forms: POST /form-sender/send-and-update-form/:formId
+    Forms->>Forms: validate, send-policy, attachments ready?
+    Forms->>MQ: publish (10s delay), state QUEUED
+    MQ->>Forms: FormDeliveryConsumer (@RabbitRPC)
+    alt slovensko.sk form
+        Forms->>Nases: SKTalk submit -> DELIVERED_NASES
+        Forms->>MQ: publishToGinis
+        MQ->>Ginis: register -> upload -> assign
+    else email / webhook
+        Forms->>Forms: EmailFormsService / WebhookService
+    end
+```
+
+The **eID** path (`/form-sender/eid/...`) verifies the signature, submits to NASES synchronously, then queues GINIS.
+
+---
+
+## Deployment
+
+- **Docker** -- multi-stage; pulls prebuilt `forms-shared` + `openapi-clients` images from Harbor (by digest); installs Playwright Chromium. Prod `CMD` runs `db:migrate:deploy && start:prod`.
+- **docker-compose (local)** -- Postgres (54321), RabbitMQ delayed-message image (5611/15611), Redis (6311).
+- **Async infra** -- RabbitMQ (`@golevelup/nestjs-rabbitmq`, `x-delayed-message` exchange; queues `RABBIT_FORM_DELIVERY`, `RABBIT_GINIS`), Bull/Redis (`sharepoint` queue), Piscina (tax PDFs). `@nestjs/schedule` crons: delete old drafts, GINIS submission-state check, NASES registration validation, expired-migration purge.
+- **CI/CD** -- monorepo `.github/workflows/` (`build-nest.yml`, `deploy.yml`); no service-local k8s manifests (infra external).
+
+---
+
+## Swagger / OpenAPI
+
+Docs UI at **`/api`**; raw spec at **`/spec-json`** (`src/bootstrap.ts`). Security schemes: Bearer, Basic (scanner), apiKey, and custom `cognitoGuestIdentityId`.
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, delivery pipeline, deployment), update this `ARCHITECTURE.md` in the same change.

--- a/nest-tax-backend/README.md
+++ b/nest-tax-backend/README.md
@@ -2,6 +2,10 @@
 
 This repository contains backend code for digital real estate tax payment services (platba dane z nehnutelností) of the city of Bratislava.
 
+## Architecture
+
+For a high-level overview of this service (modules, data model, auth, integrations, crons, deployment), see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). For workflows that span multiple konto backends, see the repo-root [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md).
+
 # Quick run
 
 If you want to run an application without installing it locally quickly, you can run it through `docker-compose`:

--- a/nest-tax-backend/docs/ARCHITECTURE.md
+++ b/nest-tax-backend/docs/ARCHITECTURE.md
@@ -1,0 +1,207 @@
+# nest-tax-backend -- Architecture
+
+> This is the high-level architecture for the **nest-tax-backend** service, one app in the `konto.bratislava.sk` monorepo. For workflows that span multiple konto backends, see the repo-root [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
+
+## System Overview
+
+`nest-tax-backend` is the backend for the City of Bratislava's **digital tax payment** in City Account (konto.bratislava.sk). It ingests taxes and payments from the municipal **Noris** tax registry, presents tax detail to citizens, generates card-payment links (GP webpay) and QR pay-by-square codes, reconciles payments, and produces bank reports.
+
+It handles two tax types (`TaxType`): **DZN** (daň z nehnuteľnosti / real-estate tax) and **KO** (komunálny odpad / municipal waste tax). Users authenticate with **AWS Cognito**; user identity (birth number) is resolved through the sibling **nest-city-account** service.
+
+The backend is a **NestJS 11** application backed by **PostgreSQL** (Prisma), plus a read integration to an external **MSSQL** Noris database. All async work is `@nestjs/schedule` `@Cron` jobs (no queue/broker).
+
+### Environments
+
+| Environment | URL |
+|---|---|
+| Production | `https://nest-tax-backend.bratislava.sk/` |
+| Staging | `https://nest-tax-backend.staging.bratislava.sk/` |
+| Development | `https://nest-tax-backend.dev.bratislava.sk/` |
+| Local | `http://localhost:3000/` |
+
+Config is validated/typed via decorator classes (`src/config/environment-variables.ts`, `ba-config.ts`, `BaConfigService`). `CLUSTER_ENV` is `dev`/`staging`/`production`. Some runtime config lives in a DB `Config` table (reporting params, Noris error counters).
+
+---
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph clients [Clients]
+        Citizen["Citizen (City Account)<br/>Cognito JWT"]
+        Admin["Admin / ops<br/>apiKey"]
+        PayGate["GP webpay<br/>(browser redirect)"]
+    end
+
+    subgraph nest [nest-tax-backend]
+        Guards["Guards<br/>(Cognito + Tier + apiKey)"]
+        TaxMod["TaxModule (v2)"]
+        PayMod["PaymentModule"]
+        AdminMod["AdminModule"]
+        Noris["NorisModule"]
+        Tasks["TasksModule (@Cron)"]
+        Reporting["CardPaymentReporting"]
+        Prisma["Prisma"]
+    end
+
+    subgraph storage [Storage]
+        PG["PostgreSQL"]
+    end
+
+    subgraph external [External Systems]
+        Cognito["AWS Cognito"]
+        CityAccount["nest-city-account<br/>(sibling backend)"]
+        NorisDB["Noris (MSSQL registry)"]
+        GP["GP webpay"]
+        Bloomreach["Bloomreach / Exponea"]
+        SES["AWS SES (email)"]
+        SFTP["Bank SFTP"]
+    end
+
+    Citizen -->|Bearer| Guards
+    Admin -->|apiKey| Guards
+    PayGate -->|signed redirect| PayMod
+    Guards --> TaxMod & PayMod & AdminMod
+    TaxMod & PayMod & AdminMod & Tasks & Reporting --> Prisma --> PG
+    Guards -->|verify + AdminGetUser| Cognito
+    TaxMod & PayMod & Tasks -->|user birthNumber / externalId| CityAccount
+    Noris -->|tax + payment sync| NorisDB
+    PayMod -->|CREATE_ORDER / digest| GP
+    Tasks & PayMod -->|events| Bloomreach
+    Reporting -->|reports| SES
+    Reporting -->|files| SFTP
+```
+
+---
+
+## Module Map
+
+Root `src/app.module.ts` wires config, Cognito, Prisma, the feature modules, and `ScheduleModule.forRoot()`; `AppLoggerMiddleware` runs on all routes; `AppController` exposes `GET /healthcheck`.
+
+| Module | Prefix / version | Auth | Purpose |
+|---|---|---|---|
+| **Tax** (`src/tax/`) | `tax` (v2) | Cognito + Tier | Read tax detail & tax lists for the citizen |
+| **Payment** (`src/payment/`) | `payment` | Cognito + Tier (response public) | GP webpay link creation + gateway response processing |
+| **Admin** (`src/admin/`) | `admin` | apiKey | Load/update taxes & payments from Noris; testing taxes (non-prod) |
+| **Noris** (`src/noris/`) | -- | -- | Integration with the Noris MSSQL registry (tax + payment sync) |
+| **Tasks** (`src/tasks/`) | -- | -- | All `@Cron` jobs (Noris sync, city-account ingestion, reminders, reporting) |
+| **CardPaymentReporting** | `card-payment-reporting` | apiKey | Generate + email/SFTP card-payment bank reports |
+| **Bloomreach**, **QrCode**, **Clients**, **Prisma**, **Shared**, **Config** | -- | -- | CRM events, QR codes, sibling HTTP client, DB, cross-cutting helpers, typed env |
+
+Citizen endpoints require Cognito tier `IdentityCard` (`TiersGuard` + `@Tiers`). `@BratislavaUser()` (`UserInfoPipe`) upserts the caller in city-account and yields their `birthNumber`.
+
+---
+
+## Data Model Overview
+
+```mermaid
+erDiagram
+    TaxPayer ||--o{ Tax : "owns"
+    TaxPayer }o--o{ TaxAdministrator : "via TaxPayerTaxAdministrator"
+    Tax ||--o{ TaxPayment : "payments"
+    Tax ||--o{ TaxInstallment : "installments"
+    TaxPayer ||--o{ TaxImportAttempt : "imports"
+```
+
+### Models (`prisma/schema.prisma`)
+
+- **TaxPayer** -- citizen; `birthNumber` (unique), `externalId`, address, per-tax-type sync watermarks (`lastUpdatedAtDZN`, `lastUpdatedAtKO`).
+- **Tax** -- one tax per `[taxPayerId, year, type, order]`; `amount` (cents), `variableSymbol` (unique payment key), `taxDetails` (JSON), delivery method, cancellation and reminder flags. `order` set by a DB trigger.
+- **TaxPayment** -- `orderId` (unique GP webpay order = timestamp), `status` (`NEW`/`FAIL`/`SUCCESS`), `amount`, `source` (`CARD`/`QRCODE`/`BANK_ACCOUNT`/`POST`/`CASH`).
+- **TaxInstallment** -- installment schedule with due dates + reminder tracking.
+- **TaxAdministrator** / **TaxPayerTaxAdministrator** -- tax officials (M:N by tax type).
+- **CsvFile**, **Config**, **TaxImportAttempt** -- reporting file tracking, DB-driven config, Noris import status.
+
+Enums: `TaxType`, `PaymentStatus`, `TaxPaymentSource`, `DeliveryMethodNamed`, `UnpaidReminderSent`, `TaxImportStatus`. Amounts are integer cents throughout.
+
+---
+
+## Authentication & Authorization
+
+- **Cognito (citizen)** -- `CognitoAuthModule` verifies access tokens; `AuthenticationGuard` on citizen routes. `TiersGuard` (`@Tiers`) reads the user's `custom:tier` from Cognito (`AdminGetUserCommand`) and requires `IdentityCard` for tax/payment endpoints.
+- **Admin apiKey** -- `AdminStrategy` (Passport `HeaderAPIKeyStrategy`, header `apiKey`) compared to `ADMIN_APP_SECRET` with a timing-safe check; `AdminGuard` on all `/admin/*` and `/card-payment-reporting/*` endpoints.
+- **NotProductionGuard** -- blocks test-only endpoints in production.
+- **Public** -- `GET /healthcheck` and `GET /payment/cardpay/response/:taxType` (GP webpay redirect; integrity enforced by digest verification, not a guard).
+
+---
+
+## External Integrations
+
+| Integration | Purpose | Files / env |
+|---|---|---|
+| **Noris** (MSSQL) | Source of truth for taxes & payments; read via `mssql`. | `src/noris/subservices/*`; `MSSQL_*` |
+| **nest-city-account** (sibling) | Resolve user birth number / `externalId`; ingest new verified users. | `src/clients/clients.service.ts`, `src/utils/subservices/cityaccount.subservice.ts`; `CITY_ACCOUNT_API_URL`, `CITY_ACCOUNT_ADMIN_API_KEY` -- see Cross-Backend. |
+| **GP webpay** | Card payment link (SHA1-signed CREATE_ORDER) + response digest verification. | `src/payment/subservices/gpwebpay.subservice.ts`; `PAYGATE_*` (per-tax-type keys). |
+| **pay-by-square / QR** | QR pay codes (`bysquare` + `qrcode`). | `src/qrcode/qrcode.service.ts`. |
+| **Bloomreach / Exponea** | CRM events (tax created, payment, unpaid reminders), keyed by `city_account_id`. | `src/bloomreach/bloomreach.service.ts`; `BLOOMREACH_*`. |
+| **AWS SES** | Card-payment report email (SES over Mailgun for GDPR). | `src/utils/subservices/email.subservice.ts`; `AWS_SES_*`. |
+| **Bank SFTP** | Upload/read report files. | `src/utils/subservices/sftp-file.subservice.ts`; `REPORTING_*`. |
+| **AWS Cognito** | JWT verify + `AdminGetUser` for tier. | `src/utils/subservices/cognito.subservice.ts`. |
+
+Mailgun env vars exist in `.env.example` but are unused (mail goes via SES); there is no GINIS integration.
+
+---
+
+## Cross-Backend Calls
+
+The only konto sibling involved is **nest-city-account** (over HTTP via the shared `openapi-clients/city-account`). There are **no** calls to/from nest-forms-backend or nest-clamav-scanner. Outbound to city-account:
+
+1. **Upsert current user** -- on every guarded citizen request (`@BratislavaUser()` -> `userControllerUpsertUser`, forwards the user bearer) to resolve `birthNumber`.
+2. **Get user data by birth number** (admin apiKey) -- during payment-success processing to fetch `externalId` for Bloomreach.
+3. **Batch user data by birth numbers** (admin) -- during Noris import, payment/overpayment processing, and reminder crons.
+4. **New verified users** (admin, cron `EVERY_30_SECONDS`) -- `loadNewUsersFromCityAccount` creates `TaxPayer` rows for newly verified City Account users (watermark in the `Config` table).
+
+No inbound sibling-called endpoints (the only inbound HTTP is the external GP webpay redirect).
+
+---
+
+## Request Lifecycle
+
+Global pipeline (`src/main.ts`): URI versioning -> CORS -> global `ValidationPipe` -> global filters `ErrorFilter` -> `TypeErrorFilter` -> `HttpExceptionFilter`. `AppLoggerMiddleware` logs method/URL/status/timing (and decodes the JWT `sub`). `ThrowerErrorGuard` is the standard exception factory; `@HandleErrors` wraps cron methods.
+
+Representative flow -- **full card payment**:
+
+```mermaid
+sequenceDiagram
+    participant Citizen
+    participant Guard as Cognito + Tier
+    participant Pay as PaymentService
+    participant CA as nest-city-account
+    participant DB as PostgreSQL
+    participant GP as GP webpay
+    participant BR as Bloomreach
+
+    Citizen->>Guard: POST /payment/cardpay/full-payment/:year/:type/:order
+    Guard->>CA: @BratislavaUser upsert -> birthNumber
+    Guard->>Pay: authorized (tier IdentityCard)
+    Pay->>DB: create TaxPayment (orderId, NEW)
+    Pay->>GP: signed CREATE_ORDER redirect URL
+    Pay-->>Citizen: redirect to GP webpay
+    Citizen->>GP: pay
+    GP->>Pay: GET /payment/cardpay/response/:taxType (DIGEST)
+    Pay->>Pay: verify digest, map PRCODE
+    Pay->>DB: update TaxPayment SUCCESS/FAIL (source=CARD)
+    Pay->>CA: get externalId by birthNumber (admin)
+    Pay->>BR: track payment
+    Pay-->>Citizen: 302 -> frontend?status=...
+    Note over Pay,DB: cron updatePaymentsFromNoris reconciles independently
+```
+
+---
+
+## Deployment
+
+- **Docker** -- multi-stage on `node:24-alpine`; pulls the shared `openapi-clients` image from Harbor. Prod `CMD` runs `db:migrate:deploy && start:prod` (**Prisma migrations at container start**). `tini` init.
+- **docker-compose (local)** -- `nest` (port 3001, debug 9229) + `postgres` (54320).
+- **Scheduling** -- `@nestjs/schedule` `@Cron` jobs in `src/tasks/tasks.service.ts` (Noris tax/payment sync, unpaid reminders, card-payment reporting, city-account ingestion every 30s, historical/overpayment loads, Bloomreach resend, Noris-error alerts). **No RabbitMQ/Bull.**
+- **CI/CD** -- monorepo `.github/workflows/build.yml` + `deploy.yml`; builds image `harbor.bratislava.sk/standalone/nest-tax-backend` via reusable `build-nest.yml`, deploys via `bratislava/github-actions trigger-infra-deploy` (k8s manifests live in an external infra repo).
+
+---
+
+## Swagger / OpenAPI
+
+Docs UI at **`/api`**; raw spec at **`/spec-json`** (`src/main.ts`). Security schemes: `apiKey` (header, admin/reporting) and Bearer (Cognito, citizen).
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, crons, deployment), update this `ARCHITECTURE.md` in the same change.

--- a/nest-tax-backend/docs/ARCHITECTURE.md
+++ b/nest-tax-backend/docs/ARCHITECTURE.md
@@ -189,4 +189,18 @@ sequenceDiagram
 
 ---
 
-> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, crons), update this `ARCHITECTURE.md` in the same change.
+## Scheduled Jobs
+
+All async work is `@nestjs/schedule` `@Cron` jobs (`src/tasks/tasks.service.ts`) -- Noris tax/payment sync, unpaid reminders, card-payment reporting, city-account ingestion (every 30s), historical/overpayment loads, Bloomreach resend, and Noris-connection-error alerts. There is no message broker.
+
+## API Documentation
+
+Swagger UI is served at `/api` (raw OpenAPI spec at `/spec-json`).
+
+## Deployment
+
+The app is containerised and deployed to **Kubernetes** across three environments -- **development**, **staging**, and **production** -- automated through **GitHub Actions**. Infrastructure code lives in [bratislava/infrastructure-deployment-configuration](https://github.com/bratislava/infrastructure-deployment-configuration).
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, crons, deployment), update this `ARCHITECTURE.md` in the same change.

--- a/nest-tax-backend/docs/ARCHITECTURE.md
+++ b/nest-tax-backend/docs/ARCHITECTURE.md
@@ -4,11 +4,11 @@
 
 ## System Overview
 
-`nest-tax-backend` is the backend for the City of Bratislava's **digital tax payment** in City Account (konto.bratislava.sk). It ingests taxes and payments from the municipal **Noris** tax registry, presents tax detail to citizens, generates card-payment links (GP webpay) and QR pay-by-square codes, reconciles payments, and produces bank reports.
+`nest-tax-backend` is the backend for the City of Bratislava's **digital tax payment** in City Account (konto.bratislava.sk). It ingests taxes and payments from the municipal **Noris** financial system, presents tax detail to citizens, generates card-payment links (GP webpay) and QR pay-by-square codes, reconciles payments, and produces bank reports.
 
 It handles two tax types (`TaxType`): **DZN** (daň z nehnuteľnosti / real-estate tax) and **KO** (komunálny odpad / municipal waste tax). Users authenticate with **AWS Cognito**; user identity (birth number) is resolved through the sibling **nest-city-account** service.
 
-The backend is a **NestJS 11** application backed by **PostgreSQL** (Prisma), plus a read integration to an external **MSSQL** Noris database. All async work is `@nestjs/schedule` `@Cron` jobs (no queue/broker).
+The backend is a **NestJS** application backed by **PostgreSQL** (Prisma), plus an integration to the external **Noris** financial system (an **MSSQL** database). All async work is `@nestjs/schedule` `@Cron` jobs (no queue/broker).
 
 ### Environments
 
@@ -51,7 +51,7 @@ graph TB
     subgraph external [External Systems]
         Cognito["AWS Cognito"]
         CityAccount["nest-city-account<br/>(sibling backend)"]
-        NorisDB["Noris (MSSQL registry)"]
+        NorisDB["Noris (financial system, MSSQL)"]
         GP["GP webpay"]
         Bloomreach["Bloomreach / Exponea"]
         SES["AWS SES (email)"]
@@ -83,7 +83,7 @@ Root `src/app.module.ts` wires config, Cognito, Prisma, the feature modules, and
 | **Tax** (`src/tax/`) | `tax` (v2) | Cognito + Tier | Read tax detail & tax lists for the citizen |
 | **Payment** (`src/payment/`) | `payment` | Cognito + Tier (response public) | GP webpay link creation + gateway response processing |
 | **Admin** (`src/admin/`) | `admin` | apiKey | Load/update taxes & payments from Noris; testing taxes (non-prod) |
-| **Noris** (`src/noris/`) | -- | -- | Integration with the Noris MSSQL registry (tax + payment sync) |
+| **Noris** (`src/noris/`) | -- | -- | Integration with the Noris financial system, MSSQL (tax + payment sync) |
 | **Tasks** (`src/tasks/`) | -- | -- | All `@Cron` jobs (Noris sync, city-account ingestion, reminders, reporting) |
 | **CardPaymentReporting** | `card-payment-reporting` | apiKey | Generate + email/SFTP card-payment bank reports |
 | **Bloomreach**, **QrCode**, **Clients**, **Prisma**, **Shared**, **Config** | -- | -- | CRM events, QR codes, sibling HTTP client, DB, cross-cutting helpers, typed env |
@@ -129,7 +129,7 @@ Enums: `TaxType`, `PaymentStatus`, `TaxPaymentSource`, `DeliveryMethodNamed`, `U
 
 | Integration | Purpose | Files / env |
 |---|---|---|
-| **Noris** (MSSQL) | Source of truth for taxes & payments; read via `mssql`. | `src/noris/subservices/*`; `MSSQL_*` |
+| **Noris** (financial system, MSSQL) | Source of truth for taxes & payments; read via `mssql`. | `src/noris/subservices/*`; `MSSQL_*` |
 | **nest-city-account** (sibling) | Resolve user birth number / `externalId`; ingest new verified users. | `src/clients/clients.service.ts`, `src/utils/subservices/cityaccount.subservice.ts`; `CITY_ACCOUNT_API_URL`, `CITY_ACCOUNT_ADMIN_API_KEY` -- see Cross-Backend. |
 | **GP webpay** | Card payment link (SHA1-signed CREATE_ORDER) + response digest verification. | `src/payment/subservices/gpwebpay.subservice.ts`; `PAYGATE_*` (per-tax-type keys). |
 | **pay-by-square / QR** | QR pay codes (`bysquare` + `qrcode`). | `src/qrcode/qrcode.service.ts`. |
@@ -189,19 +189,4 @@ sequenceDiagram
 
 ---
 
-## Deployment
-
-- **Docker** -- multi-stage on `node:24-alpine`; pulls the shared `openapi-clients` image from Harbor. Prod `CMD` runs `db:migrate:deploy && start:prod` (**Prisma migrations at container start**). `tini` init.
-- **docker-compose (local)** -- `nest` (port 3001, debug 9229) + `postgres` (54320).
-- **Scheduling** -- `@nestjs/schedule` `@Cron` jobs in `src/tasks/tasks.service.ts` (Noris tax/payment sync, unpaid reminders, card-payment reporting, city-account ingestion every 30s, historical/overpayment loads, Bloomreach resend, Noris-error alerts). **No RabbitMQ/Bull.**
-- **CI/CD** -- monorepo `.github/workflows/build.yml` + `deploy.yml`; builds image `harbor.bratislava.sk/standalone/nest-tax-backend` via reusable `build-nest.yml`, deploys via `bratislava/github-actions trigger-infra-deploy` (k8s manifests live in an external infra repo).
-
----
-
-## Swagger / OpenAPI
-
-Docs UI at **`/api`**; raw spec at **`/spec-json`** (`src/main.ts`). Security schemes: `apiKey` (header, admin/reporting) and Bearer (Cognito, citizen).
-
----
-
-> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, crons, deployment), update this `ARCHITECTURE.md` in the same change.
+> **Keep this doc in sync:** if a code change updates something described here (modules, data model, auth, integrations, cross-backend calls, crons), update this `ARCHITECTURE.md` in the same change.

--- a/next/README.md
+++ b/next/README.md
@@ -2,6 +2,10 @@
 
 This readme should get you up & running. For more detailed documentation, check the /docs file in the root of the repo.
 
+## Architecture
+
+For a high-level overview of this app (routing, data layer, auth, integrations, deployment), see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). For workflows that span multiple konto backends, see the repo-root [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md).
+
 ## First-time setup
 
 You need `node` and `npm` installed locally.

--- a/next/docs/ARCHITECTURE.md
+++ b/next/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 `city-account-next` is the **City Account (Bratislavské konto)** web frontend: account management, the e-forms UI, and the tax UI. It has no business data of its own -- it consumes three sibling konto backends (**nest-city-account**, **nest-forms-backend**, **nest-tax-backend**) through generated typed clients, plus two **Strapi** CMS instances for content, and authenticates users with **AWS Cognito** (via Amplify, including guest identities).
 
-It is a **Next.js 16** (Pages Router, Turbopack) application built to a `standalone` server, with heavy SSR via `getServerSideProps` wrapped in Amplify server context, and **TanStack React Query** for client/SSR data. Slovak is the only shipped locale.
+It is a **Next.js** (Pages Router, Turbopack) application built to a `standalone` server, with heavy SSR via `getServerSideProps` wrapped in Amplify server context, and **TanStack React Query** for client/SSR data. Slovak is the only shipped locale.
 
 ### Environments
 
@@ -179,12 +179,4 @@ The three backend clients come from the local **`openapi-clients`** package (reg
 
 ---
 
-## Deployment
-
-- **Docker** -- multi-stage, `output: 'standalone'`. Pulls prebuilt `forms-shared` and `openapi-clients` images from Harbor by digest; `node:24-alpine` base with `tini`, non-root user; prod runs `node build/server.js` (standalone nested under `build/` due to Turbopack root).
-- **Build-time public envs** -- `.env.bratiska-cli-build.{dev,staging,prod}` baked per environment via `build-next.yml`.
-- **CI/CD** -- monorepo `.github/workflows/` (`build.yml`, `build-next.yml`, `deploy.yml` with per-service change detection, `cypress-test.yaml`). Registry Harbor; k8s config lives in an external infra repo. Liveness: `pages/api/healthcheck.ts`.
-
----
-
-> **Keep this doc in sync:** if a code change updates something described here (routing, auth, data layer, integrations, deployment), update this `ARCHITECTURE.md` in the same change.
+> **Keep this doc in sync:** if a code change updates something described here (routing, auth, data layer, integrations), update this `ARCHITECTURE.md` in the same change.

--- a/next/docs/ARCHITECTURE.md
+++ b/next/docs/ARCHITECTURE.md
@@ -179,4 +179,10 @@ The three backend clients come from the local **`openapi-clients`** package (reg
 
 ---
 
-> **Keep this doc in sync:** if a code change updates something described here (routing, auth, data layer, integrations), update this `ARCHITECTURE.md` in the same change.
+## Deployment
+
+The app is containerised (standalone Next.js build) and deployed to **Kubernetes** across three environments -- **development**, **staging**, and **production** -- automated through **GitHub Actions**. Infrastructure code lives in [bratislava/infrastructure-deployment-configuration](https://github.com/bratislava/infrastructure-deployment-configuration).
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (routing, auth, data layer, integrations, deployment), update this `ARCHITECTURE.md` in the same change.

--- a/next/docs/ARCHITECTURE.md
+++ b/next/docs/ARCHITECTURE.md
@@ -1,0 +1,190 @@
+# city-account-next (Frontend) -- Architecture
+
+> This is the high-level architecture for the **next** web frontend (`city-account-next`), one app in the `konto.bratislava.sk` monorepo. For workflows that span multiple konto backends, see the repo-root [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
+
+## System Overview
+
+`city-account-next` is the **City Account (Bratislavské konto)** web frontend: account management, the e-forms UI, and the tax UI. It has no business data of its own -- it consumes three sibling konto backends (**nest-city-account**, **nest-forms-backend**, **nest-tax-backend**) through generated typed clients, plus two **Strapi** CMS instances for content, and authenticates users with **AWS Cognito** (via Amplify, including guest identities).
+
+It is a **Next.js 16** (Pages Router, Turbopack) application built to a `standalone` server, with heavy SSR via `getServerSideProps` wrapped in Amplify server context, and **TanStack React Query** for client/SSR data. Slovak is the only shipped locale.
+
+### Environments
+
+`.env.example` is empty; the authoritative env contract is `src/environment.ts` (validated, `assertEnv` throws on missing). Public vars are `NEXT_PUBLIC_*` baked at build time (per-environment images via bratiska-cli `.env.bratiska-cli-build.{dev,staging,prod}`).
+
+| Var | Points at |
+|---|---|
+| `NEXT_PUBLIC_CITY_ACCOUNT_URL` | nest-city-account |
+| `NEXT_PUBLIC_FORMS_URL` | nest-forms-backend |
+| `NEXT_PUBLIC_TAXES_URL` | nest-tax-backend |
+| `NEXT_PUBLIC_SLOVENSKO_SK_LOGIN_URL` | slovensko.sk / NASES eID login |
+| `bratislavaStrapiUrl`, `cityAccountStrapiUrl` | two Strapi CMS instances |
+
+Plus Cognito (user/identity pool, cookie domain, region), Cloudflare Turnstile, Grafana Faro, GTM, feature toggles.
+
+---
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph browser [Browser / Next.js SSR]
+        Proxy["src/proxy.ts (CSP only)"]
+        Pages["Pages Router (SSR)<br/>amplifyGetServerSideProps"]
+        Content["page-contents + forms engine (RJSF)"]
+        Query["React Query (+ SSR hydration)"]
+        Axios["shared axios instance<br/>(auth interceptor)"]
+        Clients["openapi-clients:<br/>city-account / forms / tax"]
+        Strapi["GraphQL Strapi client"]
+    end
+
+    subgraph external [External Systems]
+        Cognito["AWS Cognito / Amplify"]
+        CA["nest-city-account"]
+        Forms["nest-forms-backend"]
+        Tax["nest-tax-backend"]
+        StrapiCMS["Strapi CMS (x2)"]
+        Nases["slovensko.sk / NASES (eID)"]
+        Faro["Grafana Faro / Plausible / GTM"]
+    end
+
+    Pages --> Content
+    Pages --> Query
+    Content --> Query
+    Query --> Clients --> Axios
+    Axios -->|Bearer / guest id| CA & Forms & Tax
+    Axios -->|"fetchAuthSession"| Cognito
+    Pages --> Strapi --> StrapiCMS
+    Content -->|eID sign/send| Nases
+    Pages -->|"observability"| Faro
+```
+
+---
+
+## Routing / Page Map
+
+Next.js **Pages Router** (`src/pages/`, Slovak slugs; centralized in `src/utils/routes.tsx`). There is **no `middleware.ts`**: Next 16's `src/proxy.ts` handles **Content-Security-Policy only**; auth gating is per-page via `amplifyGetServerSideProps` options.
+
+| Area | Routes |
+|---|---|
+| Home / help | `index.tsx`, `pomoc.tsx` |
+| Auth | `prihlasenie` (login), `registracia`, `zabudnute-heslo`, `zmena-hesla`, `zmena-emailu`, `odhlasenie`, `overenie-identity` |
+| OAuth / SSO / eID | `oauth`, `oauth-potvrdenie`, `sso`, `get-jwt`, `nases/login` (eID token return) |
+| Account | `moj-profil` |
+| Forms | `mestske-sluzby` (list), `mestske-sluzby/[slug]` (create), `mestske-sluzby/[slug]/[id]`, `moje-ziadosti` + `[ziadost]` |
+| Tax | `dane-a-poplatky`, `dane-a-poplatky/[year]/[type]/[order]`, `.../platba` |
+| Payment | `platba/stav` (result) |
+| API routes | `api/csp-report`, `api/healthcheck`, `api/robots` |
+
+`_app.tsx` sets up the provider stack; `_document.tsx` injects the CSP nonce.
+
+---
+
+## Directory Map
+
+| Directory | Purpose |
+|---|---|
+| `src/pages/` | Routes + API routes. |
+| `src/components/` | `auth-forms/`, `forms/` (RJSF e-form engine), `fields/`, `page-contents/` (per-route content), `layouts/`, `segments/` (NavBar/Footer/…), `simple-components/`, styleguide. |
+| `src/frontend/` | App logic: `hooks/` (`useSsrAuth`, `useUser`, OAuth/redirect/form hooks), `utils/` (Amplify wrappers, logger/Faro, ginis, metadata storage), `dtos/`. |
+| `src/clients/` | `axios-instance.ts` + thin wrappers `city-account.ts`, `forms.ts`, `tax.ts`, and `graphql-strapi/` (generated GraphQL SDK). |
+| `src/backend/` | SSR-only helpers (Strapi tax-administrator, GINIS DTO). |
+| `src/utils/` | UI utils (`routes.tsx`, `cn.ts`, sizing hooks). |
+| `public/locales/sk/` | `account.json`, `forms.json`, `rjsf-errors.json`. |
+
+Path alias `@/*` -> repo root. Shared packages `forms-shared` and `openapi-clients` are local `file:` deps (transpiled at build).
+
+---
+
+## Data Layer & State
+
+- **React Query (`@tanstack/react-query` v5)** -- `QueryClient` created in `_app.tsx`; SSR pages create their own client, prefetch, `dehydrate`, and pass `dehydratedState` into a `HydrationBoundary`.
+- **Generated clients** -- `openapi-clients` (local `file:` dep) is wrapped per backend in `src/clients/{city-account,forms,tax}.ts`, each bound to the correct base URL and the shared axios instance. See **Generated API Client**.
+- **Shared axios + auth interceptor** (`src/clients/axios-instance.ts`) -- augments requests with an `authStrategy` (`authOnly` / `authOrGuestWithToken` / `authOrGuestNoToken` / `noAuth`). The request interceptor attaches auth: browser -> Amplify `fetchAuthSession()`, server -> caller-supplied `getSsrAuthSession()`. Signed-in -> `Authorization: Bearer`; guest -> `X-Cognito-Guest-Identity-Id`.
+- **Strapi** -- a `graphql-request` client (`src/clients/graphql-strapi/`) with a `graphql-codegen`-generated SDK; queries in `queries/*.graphql` drive landing pages, homepage, help, tax config content.
+- **forms-shared** -- shared form definitions, validation, send-policy, and summary logic used by the forms engine.
+
+---
+
+## Authentication & Authorization
+
+**AWS Cognito via Amplify** (`src/frontend/utils/amplifyConfig.ts`) -- User Pool + Client + **Identity Pool** with `allowGuestAccess: true`, SSR mode (`ssr: true`).
+
+- **`amplifyGetServerSideProps`** (`src/frontend/utils/amplifyServer.ts`) is the central SSR auth wrapper: always calls `fetchAuthSession` (so guests get an identityId), computes `isSignedIn`, fetches user attributes, injects `SsrAuthContext` (consumed by `useSsrAuth`), and enforces route protection via `requiresSignIn` / `requiresSignOut` / OAuth-redirect options.
+- **Token storage** -- Amplify manages tokens in cookies scoped to `cognitoCookieStorageDomain`; tokens reach backends only through the axios interceptor.
+- **Login** (`prihlasenie.tsx`) uses `aws-amplify/auth` and, on success, upserts the user via `cityAccountClient.userControllerUpsertUser`.
+- **eID / NASES** -- `nases/login.tsx` receives the slovensko.sk token; identity-verification forms drive Cognito tier upgrades.
+
+---
+
+## External Integrations
+
+| Integration | Purpose |
+|---|---|
+| **nest-city-account** (`city-account.ts`) | Users, GDPR consents, OAuth client recording. |
+| **nest-forms-backend** (`forms.ts`) | Form CRUD/send, file upload + scanning, GINIS document detail. |
+| **nest-tax-backend** (`tax.ts`) | Tax lists/details/payment. |
+| **Strapi CMS (x2)** | GraphQL content: landing pages, homepage, help, tax admin/config. |
+| **AWS Cognito** | Auth + guest identities. |
+| **slovensko.sk / NASES** | eID form signing/sending + identity verification. |
+| **GINIS** | Application ("žiadosť") detail (via the forms client). |
+| **Observability / analytics** | Grafana Faro (prod), Plausible (proxied), GTM + Clarity/GA + Cookiebot consent. |
+| **Cloudflare Turnstile** | Captcha on auth/forms. |
+| **Iframe embedding** | `@iframe-resizer/*` + custom adapter (OLO reuses forms in an iframe). |
+
+---
+
+## Data Lifecycle -- Filling & submitting an e-form
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant SSR as amplifyGetServerSideProps
+    participant Page as mestske-sluzby/[slug]
+    participant Engine as RJSF forms engine
+    participant Query as React Query
+    participant Axios as axios (auth interceptor)
+    participant Forms as nest-forms-backend
+
+    User->>SSR: GET /mestske-sluzby/:slug
+    SSR->>SSR: fetchAuthSession (auth or guest id)
+    par content + definition
+        SSR->>Forms: (Strapi content + forms-shared definition)
+    end
+    SSR-->>Page: props + SsrAuthContext
+    Page->>Engine: render form (RJSF + ajv)
+    User->>Engine: fill fields, upload files
+    Engine->>Query: useMutation send (useFormSend)
+    Query->>Axios: formSenderControllerSendAndUpdateForm
+    Axios->>Axios: attach Bearer or X-Cognito-Guest-Identity-Id
+    Axios->>Forms: POST send-and-update-form/:formId
+    Forms-->>Query: sent
+    Note over Engine: eID variant redirects to slovensko.sk then returns via nases/login
+```
+
+The tax flow is analogous: `dane-a-poplatky` SSR calls `taxClient.taxControllerV2GetTaxesListV2` (`authOnly`) for DZN + KO, dehydrates React Query state, and renders under tax data/config providers; payment continues at `.../platba` with the result at `platba/stav`.
+
+---
+
+## Localization
+
+- `next-i18next.config.js` -- `defaultLocale: 'sk'`, `locales: ['sk']` (Slovak only). `appWithTranslation` in `_app.tsx`; SSR translations via `slovakServerSideTranslations`.
+- Namespaces `account`, `forms`, `rjsf-errors` in `public/locales/sk/`. Extraction via `i18next-cli` (`parse-translations`). React-Aria `I18nProvider locale="sk-SK"`.
+
+---
+
+## Generated API Client
+
+The three backend clients come from the local **`openapi-clients`** package (regenerated from each backend's OpenAPI spec). `src/clients/{city-account,forms,tax}.ts` instantiate them against `environment.*Url` and the shared axios instance. When a backend's endpoints change, regenerate `openapi-clients` rather than editing generated code.
+
+---
+
+## Deployment
+
+- **Docker** -- multi-stage, `output: 'standalone'`. Pulls prebuilt `forms-shared` and `openapi-clients` images from Harbor by digest; `node:24-alpine` base with `tini`, non-root user; prod runs `node build/server.js` (standalone nested under `build/` due to Turbopack root).
+- **Build-time public envs** -- `.env.bratiska-cli-build.{dev,staging,prod}` baked per environment via `build-next.yml`.
+- **CI/CD** -- monorepo `.github/workflows/` (`build.yml`, `build-next.yml`, `deploy.yml` with per-service change detection, `cypress-test.yaml`). Registry Harbor; k8s config lives in an external infra repo. Liveness: `pages/api/healthcheck.ts`.
+
+---
+
+> **Keep this doc in sync:** if a code change updates something described here (routing, auth, data layer, integrations, deployment), update this `ARCHITECTURE.md` in the same change.


### PR DESCRIPTION
## What

Adds high-level architecture documentation for the konto monorepo:

- A per-app `docs/ARCHITECTURE.md` for each **NestJS / Next.js** app: `nest-city-account`, `nest-forms-backend`, `nest-tax-backend`, `nest-clamav-scanner`, and `next`. Each covers system overview, high-level architecture (mermaid), module/directory map, data model, auth, external integrations, a representative request/data lifecycle (mermaid), and deployment.
- A **repo-root `docs/ARCHITECTURE.md`** that documents **only cross-backend workflows** — flows where a single request or a single async/scheduled job crosses more than one konto backend (file antivirus scanning forms⇄clamav; Cognito user upsert forms/tax→city-account; tax payment enrichment; scheduled verified-user ingestion). It links to the per-service docs and lists what is out of scope.
- References wired from each app README and the root README.

Shared libraries and infra (`forms-shared`, `openapi-clients`, `strapi`, `clamav`, `cvdmirror`) are intentionally **not** documented, per scope (NestJS/Next.js apps only).

> If a future change updates something described in an ARCHITECTURE.md, please update that doc in the same PR. Cross-backend changes go in the root doc; single-service changes in the service doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)