### PR TITLE
1638 Fix saving draft when logging-in during form filing.

### DIFF
--- a/next/src/components/modals/RegistrationModal.tsx
+++ b/next/src/components/modals/RegistrationModal.tsx
@@ -144,7 +144,6 @@ const RegistrationModal = ({ type, login, register, ...rest }: RegistrationModal
             <div className="rounded-t-lg bg-gray-100 p-4 lg:px-6 lg:py-5">
               <Typography variant="h4">{t('registration_modal.body_title')}</Typography>
               <ul className="mt-6 flex flex-col gap-2 lg:gap-4">
-                {}
                 {bodyList.map((item, index) => (
                   <li key={index} className="flex items-center gap-4">
                     <span className="flex size-5 min-w-[20px] items-center justify-center lg:size-6 lg:min-w-[24px]">
@@ -170,7 +169,8 @@ const RegistrationModal = ({ type, login, register, ...rest }: RegistrationModal
             </div>
           </div>
 
-          <AccountLink variant="login" />
+          {/* Use the `login` function that saves draft and redirects to the login page and back to form after login */}
+          <AccountLink variant="login" onLoginPress={login} />
         </div>
         {(type === RegistrationModalType.Initial ||
           type === RegistrationModalType.NotAuthenticatedSubmitForm) && (

--- a/next/src/components/segments/AccountLink/AccountLink.tsx
+++ b/next/src/components/segments/AccountLink/AccountLink.tsx
@@ -1,5 +1,7 @@
-import { Typography } from '@bratislava/component-library'
-import Link, { LinkProps } from 'next/link'
+import url from 'node:url'
+
+import { Button, Typography } from '@bratislava/component-library'
+import { LinkProps } from 'next/link'
 import { useTranslation } from 'next-i18next/pages'
 
 import { useQueryParamRedirect } from '@/src/frontend/hooks/useQueryParamRedirect'
@@ -7,18 +9,23 @@ import { ROUTES } from '@/src/utils/routes'
 
 type Props = {
   variant: 'login' | 'registration' | 'forgotten-password'
+  // Used in RegistrationModal for saving drafts before logging-in and redirecting back to form
+  // The function passed to onLoginPress MUST contain redirect to login page, since the href is ignored
+  onLoginPress?: () => void
 }
 
-const AccountLink = ({ variant }: Props) => {
+const AccountLink = ({ variant, onLoginPress: onLoginPressFromProps }: Props) => {
   const { t } = useTranslation('account')
   const { getRouteWithRedirect } = useQueryParamRedirect()
 
-  const { label, description, href } = (
+  const { label, description, href, onLoginPress } = (
     {
       login: {
         label: t('auth.links.login_link_text'),
         description: t('auth.links.login_description'),
+        // Standard href to login page, used when onLoginPress is undefined
         href: getRouteWithRedirect(ROUTES.LOGIN),
+        onLoginPress: onLoginPressFromProps,
       },
       registration: {
         label: t('auth.links.register_link_text'),
@@ -32,7 +39,7 @@ const AccountLink = ({ variant }: Props) => {
       },
     } satisfies Record<
       Props['variant'],
-      { label: string; description: string; href: LinkProps['href'] }
+      { label: string; description: string; href: LinkProps['href']; onLoginPress?: () => void }
     >
   )[variant]
 
@@ -41,12 +48,20 @@ const AccountLink = ({ variant }: Props) => {
       <Typography variant="p-small" className="font-semibold text-gray-800">
         {description}
       </Typography>
-      <Link
-        href={href}
-        className="rounded-xs font-semibold text-gray-700 underline base-focus-ring hover:text-gray-600 focus:text-gray-800"
+      <Button
+        variant="link"
+        className="font-semibold"
+        // Ignore the href if onLoginPress is present
+        {...(onLoginPress
+          ? { onPress: onLoginPress }
+          : {
+              // getRouteWithRedirect returns UrlObject, so we must convert it to string (until Button accepts UrlObject as href).
+              href: url.format(href),
+              hasLinkIcon: false,
+            })}
       >
         {label}
-      </Link>
+      </Button>
     </div>
   )
 }


### PR DESCRIPTION
- replace Link with Button, to be able to pass `onPress` function, while keeping the styles
- convert urls from `UrlObject` to `string` using `url from 'node:url'`
- pass `onLoginPress` function from `RegistrationModal`
  - Note: I'm not using `const { login } = useFormRedirects()` directly in `AccountLink` because not all instances of AccountLink are wrapped in `FormRedirectsProvider`, so passing `login` by props looks reasonable