### PR TITLE
643 form values trimming

### DIFF
--- a/next/src/components/fields/PasswordField.tsx
+++ b/next/src/components/fields/PasswordField.tsx
@@ -17,6 +17,8 @@ const PasswordField = (props: PasswordFieldProps, ref: Ref<HTMLInputElement>) =>
       {...props}
       ref={ref}
       type={isHidden ? 'password' : 'text'}
+      // Do not trim password fields on blur
+      isTrimmedOnBlur={false}
       endIcon={
         <RACToggleButton
           aria-label={t('auth.fields.password_eyeButton.aria')}

--- a/next/src/components/fields/TextAreaField.tsx
+++ b/next/src/components/fields/TextAreaField.tsx
@@ -26,44 +26,46 @@ const TextAreaField = (
     ...rest
   }: TextAreaFieldProps,
   ref: Ref<HTMLTextAreaElement>,
-) => (
-  <RACTextField
-    {...rest}
-    isInvalid={!!errorMessage}
-    validationBehavior="aria"
-    className={cn('flex w-full flex-col gap-2', rest.className)}
-  >
-    <FieldWrapper
-      label={label}
-      isRequired={rest.isRequired}
-      displayOptionalLabel={displayOptionalLabel}
-      labelSize={labelSize}
-      helptext={helptext}
-      helptextFooter={helptextFooter}
-      errorMessage={errorMessage}
+) => {
+  return (
+    <RACTextField
+      {...rest}
+      isInvalid={!!errorMessage}
+      validationBehavior="aria"
+      className={cn('flex w-full flex-col gap-2', rest.className)}
     >
-      <RACTextArea
-        ref={ref}
-        placeholder={placeholder}
-        className={({ isFocused, isDisabled, isInvalid }) =>
-          cn(
-            'w-full rounded-lg border bg-background-passive-base text-size-p-small-r text-content-passive-secondary base-focus-ring outline-hidden lg:text-size-p-small',
-            'min-h-30',
-            isDisabled ? 'resize-none' : 'resize-y',
-            'px-3 py-2 lg:px-4 lg:py-3',
-            'placeholder:text-content-passive-tertiary',
-            {
-              'border-border-active-default': !isInvalid && !isFocused,
-              'border-border-active-focused': !isInvalid && isFocused,
-              'border-border-error': isInvalid,
-              'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
-              'hover:border-border-active-hover': !isDisabled && !isInvalid && !isFocused,
-            },
-          )
-        }
-      />
-    </FieldWrapper>
-  </RACTextField>
-)
+      <FieldWrapper
+        label={label}
+        isRequired={rest.isRequired}
+        displayOptionalLabel={displayOptionalLabel}
+        labelSize={labelSize}
+        helptext={helptext}
+        helptextFooter={helptextFooter}
+        errorMessage={errorMessage}
+      >
+        <RACTextArea
+          ref={ref}
+          placeholder={placeholder}
+          className={({ isFocused, isDisabled, isInvalid }) =>
+            cn(
+              'w-full rounded-lg border bg-background-passive-base text-size-p-small-r text-content-passive-secondary base-focus-ring outline-hidden lg:text-size-p-small',
+              'min-h-30',
+              isDisabled ? 'resize-none' : 'resize-y',
+              'px-3 py-2 lg:px-4 lg:py-3',
+              'placeholder:text-content-passive-tertiary',
+              {
+                'border-border-active-default': !isInvalid && !isFocused,
+                'border-border-active-focused': !isInvalid && isFocused,
+                'border-border-error': isInvalid,
+                'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
+                'hover:border-border-active-hover': !isDisabled && !isInvalid && !isFocused,
+              },
+            )
+          }
+        />
+      </FieldWrapper>
+    </RACTextField>
+  )
+}
 
 export default forwardRef(TextAreaField)

--- a/next/src/components/fields/TextAreaField.tsx
+++ b/next/src/components/fields/TextAreaField.tsx
@@ -9,9 +9,14 @@ import cn from '@/src/utils/cn'
 
 import FieldWrapper from './_shared/FieldWrapper'
 import { FieldBaseProps } from './_shared/types'
+import useTrimOnBlur from './_shared/useTrimOnBlur'
 
 export interface TextAreaFieldProps extends RACTextFieldProps, FieldBaseProps {
   placeholder?: string
+  /**
+   * @default true
+   */
+  isTrimmedOnBlur?: boolean
 }
 
 const TextAreaField = (
@@ -23,13 +28,17 @@ const TextAreaField = (
     helptextFooter,
     errorMessage,
     placeholder,
+    isTrimmedOnBlur = true,
     ...rest
   }: TextAreaFieldProps,
   ref: Ref<HTMLTextAreaElement>,
 ) => {
+  const handleBlur = useTrimOnBlur({ isTrimmedOnBlur, ...rest })
+
   return (
     <RACTextField
       {...rest}
+      onBlur={handleBlur}
       isInvalid={!!errorMessage}
       validationBehavior="aria"
       className={cn('flex w-full flex-col gap-2', rest.className)}

--- a/next/src/components/fields/TextField.tsx
+++ b/next/src/components/fields/TextField.tsx
@@ -36,52 +36,54 @@ const TextField = (
     ...rest
   }: TextFieldProps,
   ref: Ref<HTMLInputElement>,
-) => (
-  <RACTextField
-    {...rest}
-    isInvalid={!!errorMessage}
-    validationBehavior="aria"
-    className={cn('flex w-full flex-col gap-2', rest.className)}
-  >
-    <FieldWrapper
-      label={label}
-      isRequired={rest.isRequired}
-      displayOptionalLabel={displayOptionalLabel}
-      labelSize={labelSize}
-      helptext={helptext}
-      helptextFooter={helptextFooter}
-      errorMessage={errorMessage}
+) => {
+  return (
+    <RACTextField
+      {...rest}
+      isInvalid={!!errorMessage}
+      validationBehavior="aria"
+      className={cn('flex w-full flex-col gap-2', rest.className)}
     >
-      <div className="relative">
-        <RACInput
-          ref={ref}
-          placeholder={placeholder}
-          autoCapitalize={autoCapitalize}
-          autoCorrect={autoCorrect}
-          spellCheck={spellCheck}
-          autoComplete={autoComplete}
-          data-cy={rest.name ? `input-${rest.name}` : undefined}
-          className={({ isFocused, isDisabled, isInvalid }) =>
-            cn(
-              'w-full rounded-lg border bg-background-passive-base text-size-p-small-r text-content-passive-secondary base-focus-ring outline-hidden lg:text-size-p-small',
-              'px-3 py-2 lg:px-4 lg:py-3',
-              'placeholder:text-content-passive-tertiary',
-              {
-                'border-border-active-default': !isInvalid && !isFocused,
-                'border-border-active-focused': !isInvalid && isFocused,
-                'border-border-error': isInvalid,
-                'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
-                'hover:border-border-active-hover': !isDisabled && !isInvalid && !isFocused,
-              },
-            )
-          }
-        />
-        {endIcon ? (
-          <div className="absolute inset-y-0 right-0 flex items-center">{endIcon}</div>
-        ) : null}
-      </div>
-    </FieldWrapper>
-  </RACTextField>
-)
+      <FieldWrapper
+        label={label}
+        isRequired={rest.isRequired}
+        displayOptionalLabel={displayOptionalLabel}
+        labelSize={labelSize}
+        helptext={helptext}
+        helptextFooter={helptextFooter}
+        errorMessage={errorMessage}
+      >
+        <div className="relative">
+          <RACInput
+            ref={ref}
+            placeholder={placeholder}
+            autoCapitalize={autoCapitalize}
+            autoCorrect={autoCorrect}
+            spellCheck={spellCheck}
+            autoComplete={autoComplete}
+            data-cy={rest.name ? `input-${rest.name}` : undefined}
+            className={({ isFocused, isDisabled, isInvalid }) =>
+              cn(
+                'w-full rounded-lg border bg-background-passive-base text-size-p-small-r text-content-passive-secondary base-focus-ring outline-hidden lg:text-size-p-small',
+                'px-3 py-2 lg:px-4 lg:py-3',
+                'placeholder:text-content-passive-tertiary',
+                {
+                  'border-border-active-default': !isInvalid && !isFocused,
+                  'border-border-active-focused': !isInvalid && isFocused,
+                  'border-border-error': isInvalid,
+                  'border-border-active-disabled bg-background-passive-tertiary': isDisabled,
+                  'hover:border-border-active-hover': !isDisabled && !isInvalid && !isFocused,
+                },
+              )
+            }
+          />
+          {endIcon ? (
+            <div className="absolute inset-y-0 right-0 flex items-center">{endIcon}</div>
+          ) : null}
+        </div>
+      </FieldWrapper>
+    </RACTextField>
+  )
+}
 
 export default forwardRef(TextField)

--- a/next/src/components/fields/TextField.tsx
+++ b/next/src/components/fields/TextField.tsx
@@ -9,6 +9,7 @@ import cn from '@/src/utils/cn'
 
 import FieldWrapper from './_shared/FieldWrapper'
 import { FieldBaseProps } from './_shared/types'
+import useTrimOnBlur from './_shared/useTrimOnBlur'
 
 export interface TextFieldProps
   extends
@@ -17,6 +18,10 @@ export interface TextFieldProps
     Pick<RACInputProps, 'autoCapitalize' | 'autoCorrect' | 'spellCheck'> {
   placeholder?: string
   endIcon?: ReactNode
+  /**
+   * @default true
+   */
+  isTrimmedOnBlur?: boolean
 }
 
 const TextField = (
@@ -33,13 +38,17 @@ const TextField = (
     autoCorrect,
     spellCheck,
     autoComplete,
+    isTrimmedOnBlur = true,
     ...rest
   }: TextFieldProps,
   ref: Ref<HTMLInputElement>,
 ) => {
+  const handleBlur = useTrimOnBlur({ isTrimmedOnBlur, ...rest })
+
   return (
     <RACTextField
       {...rest}
+      onBlur={handleBlur}
       isInvalid={!!errorMessage}
       validationBehavior="aria"
       className={cn('flex w-full flex-col gap-2', rest.className)}

--- a/next/src/components/fields/_shared/useTrimOnBlur.ts
+++ b/next/src/components/fields/_shared/useTrimOnBlur.ts
@@ -1,0 +1,44 @@
+import { FocusEvent } from 'react'
+
+interface UseTrimOnBlurParams<TElement extends Element> {
+  isTrimmedOnBlur: boolean
+  value?: string
+  onChange?: (value: string) => void
+  onBlur?: (event: FocusEvent<TElement>) => void
+}
+
+/**
+ * Returns an `onBlur` handler that trims whitespace from the field value when it loses focus,
+ * propagating the trimmed value through `onChange` (only when it actually changed, to avoid a
+ * spurious update) and then forwarding the event to the original `onBlur`.
+ *
+ * User or browsers often append unwanted whitespace to inputs; trimming on blur helps keep stored
+ * data clean without interfering with typing.
+ *
+ * Disable per field via `isTrimmedOnBlur`.
+ *
+ * Note:
+ * Blur is not guaranteed to fire on every input (e.g. on mobile), so this is not enough on its own
+ * and must be accompanied by trimming the whole payload before submit (see `trimStringValues`).
+ */
+const useTrimOnBlur = <TElement extends Element>({
+  isTrimmedOnBlur,
+  value,
+  onChange,
+  onBlur,
+}: UseTrimOnBlurParams<TElement>) => {
+  const handleBlur = (event: FocusEvent<TElement>) => {
+    if (isTrimmedOnBlur && typeof value === 'string') {
+      const trimmedValue = value.trim()
+
+      if (trimmedValue !== value) {
+        onChange?.(trimmedValue)
+      }
+    }
+    onBlur?.(event)
+  }
+
+  return handleBlur
+}
+
+export default useTrimOnBlur

--- a/next/src/components/forms/useFormSend.tsx
+++ b/next/src/components/forms/useFormSend.tsx
@@ -32,6 +32,7 @@ import {
   popSendEidMetadata,
   setSendEidMetadata,
 } from '@/src/frontend/utils/metadataStorage'
+import trimStringValues from '@/src/frontend/utils/trimStringValues'
 
 /**
  * This hook controls the sending of the form. The logic is scattered across the app.
@@ -98,7 +99,7 @@ const useGetContext = () => {
       formsClient.formSenderControllerSendAndUpdateForm(
         formId,
         {
-          formDataJson: formData,
+          formDataJson: trimStringValues(formData),
         },
         { authStrategy: 'authOrGuestWithToken' },
       ),
@@ -126,7 +127,7 @@ const useGetContext = () => {
         formsClient.formsControllerUpdateForm(
           formId,
           {
-            formDataJson: formData,
+            formDataJson: trimStringValues(formData),
             // `null` must be set explicitly, otherwise the signature would not be removed if needed
             formSignature: signature ?? null,
           },
@@ -154,7 +155,7 @@ const useGetContext = () => {
       formsClient.formSenderControllerSendAndUpdateFormEid(
         formId,
         {
-          formDataJson: formData,
+          formDataJson: trimStringValues(formData),
           // `null` must be set explicitly, otherwise the signature would not be removed if needed
           formSignature: signature ?? null,
           eidToken: sendEidTokenRef.current as string,

--- a/next/src/frontend/hooks/useHookForm.ts
+++ b/next/src/frontend/hooks/useHookForm.ts
@@ -1,9 +1,14 @@
 import { ajvResolver } from '@hookform/resolvers/ajv'
 import { JSONSchemaType } from 'ajv'
 import { useTranslation } from 'next-i18next/pages'
-import { DefaultValues, FieldValues, useForm } from 'react-hook-form'
+import { DefaultValues, FieldValues, useForm, UseFormHandleSubmit } from 'react-hook-form'
+
+import trimStringValues from '@/src/frontend/utils/trimStringValues'
 
 type Errors = Record<string, string | undefined>
+
+// IMPORTANT: All password fields must be included in this array to prevent whitespace trimming on them.
+const passwordKeys = ['password', 'oldPassword'] as const
 
 interface Props<T> {
   // used any as strictNullChecks must be true in tsconfig to use JSONSchemaType<T>
@@ -13,7 +18,7 @@ interface Props<T> {
 
 export default function useHookForm<T extends FieldValues>({ schema, defaultValues }: Props<T>) {
   const { t } = useTranslation('account')
-  // if we want password to contain special symbol add (?=.*?[ !"#$%&'()*+,./:;<=>?@[\\\]^_`{|}~-])
+
   const form = useForm({
     resolver: ajvResolver(schema as JSONSchemaType<T>, {
       formats: {
@@ -25,6 +30,7 @@ export default function useHookForm<T extends FieldValues>({ schema, defaultValu
         postalCode: '^\\s*(\\d\\s*\\d\\s*\\d\\s*\\d\\s*\\d)?\\s*$',
         // postalCode: '^([0-9]{5}|)$',
         idCard: '^([a-zA-Z]{2})([0-9]{6})([0-9]?)$',
+        // TODO: Child organizations can have ICO with 12 digits (it contains 4-digit SID at the end),
         ico: '^[0-9]{8}$',
         rc: (value: string) => {
           const formattedValue = value.replace('/', '')
@@ -55,5 +61,13 @@ export default function useHookForm<T extends FieldValues>({ schema, defaultValu
     errors[key] = t(errorMessage || 'error')
   })
 
-  return { ...form, errors }
+  // Trim the whole payload once more here before submitting, since per-field blur may not fire
+  // on every input (e.g. mobile autofill). Password fields are skipped.
+  const handleSubmit: UseFormHandleSubmit<T> = (onValid, onInvalid) =>
+    form.handleSubmit(
+      (data, event) => onValid(trimStringValues(data, { skippedKeys: passwordKeys }), event),
+      onInvalid,
+    )
+
+  return { ...form, handleSubmit, errors }
 }

--- a/next/src/frontend/utils/trimStringValues.ts
+++ b/next/src/frontend/utils/trimStringValues.ts
@@ -1,0 +1,37 @@
+interface TrimStringValuesOptions {
+  /**
+   * Object keys for which the value (and its descendants) is left untrimmed, e.g. password fields
+   * where a trailing space may be intentional and trimming would break login.
+   */
+  skippedKeys?: readonly string[]
+}
+
+/**
+ * Recursively trims whitespace from every string value in an object, array or primitive.
+ * Object keys are left untouched. Returns a new value and never mutates the input.
+ *
+ * Used as a safety net before form submit, mirroring the per-field trim done on blur
+ * (see TextField/TextAreaField), since blur may not fire on every input (e.g. mobile autofill).
+ */
+const trimStringValues = <TValue>(value: TValue, options: TrimStringValuesOptions = {}): TValue => {
+  if (typeof value === 'string') {
+    return value.trim() as TValue
+  }
+
+  if (Array.isArray(value)) {
+    return (value as unknown[]).map((item) => trimStringValues(item, options)) as TValue
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entryValue]) => [
+        key,
+        options.skippedKeys?.includes(key) ? entryValue : trimStringValues(entryValue, options),
+      ]),
+    ) as TValue
+  }
+
+  return value
+}
+
+export default trimStringValues


### PR DESCRIPTION
Commit by commit.

Proposal of whitespace trimming from input values. Includes:
- on blur trimming in TextField and TextAreaField
- trimming of all string values before submit (both in react-hook-form forms and RJSF forms)
  - skipping password fields (hardcoded list of password field names)
  
  
`trimStringValues()` and `useTrimOnBlure()` were created with help from Claude.