### PR TITLE
fix: temporarily ignore published but disabled forms

### DIFF
--- a/nest-forms-backend/src/nases/services/__tests__/nases.cron.service.spec.ts
+++ b/nest-forms-backend/src/nases/services/__tests__/nases.cron.service.spec.ts
@@ -418,9 +418,16 @@ describe('NasesCronService', () => {
 
       const result = await service.validateFormRegistrations()
 
+      /*
+      TODO: temporarily changing, after fix put back.
+      https://github.com/bratislava/private-konto.bratislava.sk/issues/1680
+
       expect(result['published-but-disabled']).toHaveLength(1)
       expect(result['published-but-disabled'][0].slug).toBe('disabled-form')
       expect(result.valid).toHaveLength(2)
+      */
+      expect(result['published-but-disabled']).toHaveLength(0)
+      expect(result.valid).toHaveLength(3)
     })
 
     it('should set registration status to true for a published-but-disabled form', async () => {
@@ -474,8 +481,16 @@ describe('NasesCronService', () => {
 
       await service.validateFormRegistrations()
 
+      /*
+      TODO: temporarily changing, after fix put back.
+      https://github.com/bratislava/private-konto.bratislava.sk/issues/1680
+
       expect(errorSpy).toHaveBeenCalled()
       expect(logSpy).not.toHaveBeenCalled()
+      */
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(logSpy).toHaveBeenCalled()
     })
 
     it('should put a not-published disabled form into not-published, not published-but-disabled', async () => {

--- a/nest-forms-backend/src/nases/services/nases.cron.service.ts
+++ b/nest-forms-backend/src/nases/services/nases.cron.service.ts
@@ -38,6 +38,7 @@ export default class NasesCronService {
 
   private resolvePublishedResultKey(
     isPublished: boolean,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     isDisabled: boolean | undefined,
   ): keyof ValidateFormRegistrationsResultDto {
     if (!isPublished) {
@@ -46,7 +47,7 @@ export default class NasesCronService {
     /**
      * TODO: slovensko.sk /eform/status returns only one property, that is "status". Even when it is disabled in slovensko.sk, it returns
      * "Publikovaný", thus we can't differ between published and active, and not active.
-     * 
+     *
      * https://github.com/bratislava/private-konto.bratislava.sk/issues/1680
      */
     // return isDisabled ? 'published-but-disabled' : 'valid'

--- a/nest-forms-backend/src/nases/services/nases.cron.service.ts
+++ b/nest-forms-backend/src/nases/services/nases.cron.service.ts
@@ -43,7 +43,14 @@ export default class NasesCronService {
     if (!isPublished) {
       return 'not-published'
     }
-    return isDisabled ? 'published-but-disabled' : 'valid'
+    /**
+     * TODO: slovensko.sk /eform/status returns only one property, that is "status". Even when it is disabled in slovensko.sk, it returns
+     * "Publikovaný", thus we can't differ between published and active, and not active.
+     * 
+     * https://github.com/bratislava/private-konto.bratislava.sk/issues/1680
+     */
+    // return isDisabled ? 'published-but-disabled' : 'valid'
+    return 'valid'
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)


### PR DESCRIPTION
Currently, slovensko.sk API does not differ between active and inactive form registrations, for both it just returns they are "published". This results in daily error in slack. We should temporarily turn it off, and fix the underlying issue: https://github.com/bratislava/private-konto.bratislava.sk/issues/1680