### PR TITLE
Fix `required` in environment decorators 

### DIFF
--- a/nest-city-account/src/config/environment-decorators.ts
+++ b/nest-city-account/src/config/environment-decorators.ts
@@ -23,7 +23,7 @@ import {
  * as a real value), required fields fail with "should not be empty" instead of
  * a type error, and `config.get('FOO') ?? fallback` behaves.
  */
-function EmptyTransform() {
+function EmptyStringTransform() {
   return Transform(({ value }: { value: unknown }) =>
     typeof value === 'string' && value.trim() === '' ? undefined : value
   )
@@ -82,7 +82,7 @@ function StringListTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     BooleanTransform(),
     Presence(required),
     IsBoolean()
@@ -100,7 +100,7 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     NumberTransform(),
     Presence(required),
     IsInt(),
@@ -114,7 +114,7 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 }
 
 export function EnvString({ required = true }: { required?: boolean } = {}) {
-  return applyDecorators(Expose(), EmptyTransform(), Presence(required), IsString())
+  return applyDecorators(Expose(), EmptyStringTransform(), Presence(required), IsString())
 }
 
 export function EnvUrl({
@@ -126,7 +126,7 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
@@ -148,7 +148,7 @@ export function EnvEnum(
   enumType: object,
   { required = true }: { required?: boolean } = {}
 ) {
-  return applyDecorators(Expose(), EmptyTransform(), Presence(required), IsEnum(enumType))
+  return applyDecorators(Expose(), EmptyStringTransform(), Presence(required), IsEnum(enumType))
 }
 
 /**

--- a/nest-city-account/src/config/environment-decorators.ts
+++ b/nest-city-account/src/config/environment-decorators.ts
@@ -23,7 +23,7 @@ import {
  * as a real value), required fields fail with "should not be empty" instead of
  * a type error, and `config.get('FOO') ?? fallback` behaves.
  */
-function EmptyStringTransform() {
+function EmptyToUndefinedTransform() {
   return Transform(({ value }: { value: unknown }) =>
     typeof value === 'string' && value.trim() === '' ? undefined : value
   )
@@ -35,7 +35,7 @@ function EmptyStringTransform() {
  * Omitting it leaves IsString()/IsInt()/IsUrl() to reject an absent value with
  * a type error.
  */
-function Presence(required: boolean) {
+function IsRequired(required: boolean) {
   // eslint-disable-next-line sonarjs/no-selector-parameter -- callers pass a named variable, never a literal
   return required ? IsNotEmpty() : IsOptional()
 }
@@ -83,9 +83,9 @@ function StringListTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
+    EmptyToUndefinedTransform(),
     BooleanTransform(),
-    Presence(required),
+    IsRequired(required),
     IsBoolean()
   )
 }
@@ -101,9 +101,9 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
+    EmptyToUndefinedTransform(),
     NumberTransform(),
-    Presence(required),
+    IsRequired(required),
     IsInt(),
     ...(min === undefined ? [] : [Min(min)]),
     ...(max === undefined ? [] : [Max(max)])
@@ -115,7 +115,7 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 }
 
 export function EnvString({ required = true }: { required?: boolean } = {}) {
-  return applyDecorators(Expose(), EmptyStringTransform(), Presence(required), IsString())
+  return applyDecorators(Expose(), EmptyToUndefinedTransform(), IsRequired(required), IsString())
 }
 
 export function EnvUrl({
@@ -127,8 +127,8 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
     IsUrl({ require_tld: requireTld })
@@ -149,7 +149,7 @@ export function EnvEnum(
   enumType: object,
   { required = true }: { required?: boolean } = {}
 ) {
-  return applyDecorators(Expose(), EmptyStringTransform(), Presence(required), IsEnum(enumType))
+  return applyDecorators(Expose(), EmptyToUndefinedTransform(), IsRequired(required), IsEnum(enumType))
 }
 
 /**

--- a/nest-city-account/src/config/environment-decorators.ts
+++ b/nest-city-account/src/config/environment-decorators.ts
@@ -36,6 +36,7 @@ function EmptyStringTransform() {
  * a type error.
  */
 function Presence(required: boolean) {
+  // eslint-disable-next-line sonarjs/no-selector-parameter -- callers pass a named variable, never a literal
   return required ? IsNotEmpty() : IsOptional()
 }
 

--- a/nest-city-account/src/config/environment-decorators.ts
+++ b/nest-city-account/src/config/environment-decorators.ts
@@ -7,11 +7,37 @@ import {
   IsEnum,
   IsInt,
   IsNotEmpty,
+  IsOptional,
   IsString,
   IsUrl,
   Max,
   Min,
 } from 'class-validator'
+
+/**
+ * `process.env` cannot distinguish "unset" from "set to nothing": `FOO=` and a
+ * missing `FOO` mean the same thing to whoever wrote the env file, but arrive
+ * as '' and undefined respectively. Normalising '' to undefined means
+ * IsOptional() actually skips the property (it short-circuits on
+ * null/undefined only, so a raw '' falls through to IsString() and is accepted
+ * as a real value), required fields fail with "should not be empty" instead of
+ * a type error, and `config.get('FOO') ?? fallback` behaves.
+ */
+function EmptyTransform() {
+  return Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' && value.trim() === '' ? undefined : value
+  )
+}
+
+/**
+ * IsOptional() is not a validator but a conditional on the whole property: if
+ * the value is null or undefined, every other validator on it is skipped.
+ * Omitting it leaves IsString()/IsInt()/IsUrl() to reject an absent value with
+ * a type error.
+ */
+function Presence(required: boolean) {
+  return required ? IsNotEmpty() : IsOptional()
+}
 
 function BooleanTransform() {
   return Transform(({ value }: { value: unknown }) => {
@@ -56,9 +82,10 @@ function StringListTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
     BooleanTransform(),
-    IsBoolean(),
-    ...(required ? [IsNotEmpty()] : [])
+    Presence(required),
+    IsBoolean()
   )
 }
 
@@ -73,9 +100,10 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
     NumberTransform(),
+    Presence(required),
     IsInt(),
-    ...(required ? [IsNotEmpty()] : []),
     ...(min === undefined ? [] : [Min(min)]),
     ...(max === undefined ? [] : [Max(max)])
   )
@@ -86,7 +114,7 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 }
 
 export function EnvString({ required = true }: { required?: boolean } = {}) {
-  return applyDecorators(Expose(), IsString(), ...(required ? [IsNotEmpty()] : []))
+  return applyDecorators(Expose(), EmptyTransform(), Presence(required), IsString())
 }
 
 export function EnvUrl({
@@ -98,10 +126,11 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
-    IsUrl({ require_tld: requireTld }),
-    ...(required ? [IsNotEmpty()] : [])
+    IsUrl({ require_tld: requireTld })
   )
 }
 
@@ -119,7 +148,7 @@ export function EnvEnum(
   enumType: object,
   { required = true }: { required?: boolean } = {}
 ) {
-  return applyDecorators(Expose(), IsEnum(enumType), ...(required ? [IsNotEmpty()] : []))
+  return applyDecorators(Expose(), EmptyTransform(), Presence(required), IsEnum(enumType))
 }
 
 /**

--- a/nest-clamav-scanner/src/config/environment-decorators.ts
+++ b/nest-clamav-scanner/src/config/environment-decorators.ts
@@ -21,7 +21,7 @@ import {
  * as a real value), required fields fail with "should not be empty" instead of
  * a type error, and `config.get('FOO') ?? fallback` behaves.
  */
-function EmptyStringTransform() {
+function EmptyToUndefinedTransform() {
   return Transform(({ value }: { value: unknown }) =>
     typeof value === 'string' && value.trim() === '' ? undefined : value,
   )
@@ -33,7 +33,7 @@ function EmptyStringTransform() {
  * Omitting it leaves IsString()/IsInt()/IsUrl() to reject an absent value with
  * a type error.
  */
-function Presence(required: boolean) {
+function IsRequired(required: boolean) {
   // eslint-disable-next-line sonarjs/no-selector-parameter -- callers pass a named variable, never a literal
   return required ? IsNotEmpty() : IsOptional()
 }
@@ -66,9 +66,9 @@ function NumberTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
+    EmptyToUndefinedTransform(),
     BooleanTransform(),
-    Presence(required),
+    IsRequired(required),
     IsBoolean(),
   )
 }
@@ -84,9 +84,9 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
+    EmptyToUndefinedTransform(),
     NumberTransform(),
-    Presence(required),
+    IsRequired(required),
     IsInt(),
     ...(min === undefined ? [] : [Min(min)]),
     ...(max === undefined ? [] : [Max(max)]),
@@ -100,8 +100,8 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 export function EnvString({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     IsString(),
   )
 }
@@ -115,8 +115,8 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
     IsUrl({ require_tld: requireTld }),
@@ -129,8 +129,8 @@ export function EnvEnum(
 ) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     IsEnum(enumType),
   )
 }

--- a/nest-clamav-scanner/src/config/environment-decorators.ts
+++ b/nest-clamav-scanner/src/config/environment-decorators.ts
@@ -21,7 +21,7 @@ import {
  * as a real value), required fields fail with "should not be empty" instead of
  * a type error, and `config.get('FOO') ?? fallback` behaves.
  */
-function EmptyTransform() {
+function EmptyStringTransform() {
   return Transform(({ value }: { value: unknown }) =>
     typeof value === 'string' && value.trim() === '' ? undefined : value,
   )
@@ -65,7 +65,7 @@ function NumberTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     BooleanTransform(),
     Presence(required),
     IsBoolean(),
@@ -83,7 +83,7 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     NumberTransform(),
     Presence(required),
     IsInt(),
@@ -99,7 +99,7 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 export function EnvString({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     IsString(),
   )
@@ -114,7 +114,7 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
@@ -128,7 +128,7 @@ export function EnvEnum(
 ) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     IsEnum(enumType),
   )

--- a/nest-clamav-scanner/src/config/environment-decorators.ts
+++ b/nest-clamav-scanner/src/config/environment-decorators.ts
@@ -5,11 +5,37 @@ import {
   IsEnum,
   IsInt,
   IsNotEmpty,
+  IsOptional,
   IsString,
   IsUrl,
   Max,
   Min,
 } from 'class-validator'
+
+/**
+ * `process.env` cannot distinguish "unset" from "set to nothing": `FOO=` and a
+ * missing `FOO` mean the same thing to whoever wrote the env file, but arrive
+ * as '' and undefined respectively. Normalising '' to undefined means
+ * IsOptional() actually skips the property (it short-circuits on
+ * null/undefined only, so a raw '' falls through to IsString() and is accepted
+ * as a real value), required fields fail with "should not be empty" instead of
+ * a type error, and `config.get('FOO') ?? fallback` behaves.
+ */
+function EmptyTransform() {
+  return Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' && value.trim() === '' ? undefined : value,
+  )
+}
+
+/**
+ * IsOptional() is not a validator but a conditional on the whole property: if
+ * the value is null or undefined, every other validator on it is skipped.
+ * Omitting it leaves IsString()/IsInt()/IsUrl() to reject an absent value with
+ * a type error.
+ */
+function Presence(required: boolean) {
+  return required ? IsNotEmpty() : IsOptional()
+}
 
 function BooleanTransform() {
   return Transform(({ value }: { value: unknown }) => {
@@ -39,9 +65,10 @@ function NumberTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
     BooleanTransform(),
+    Presence(required),
     IsBoolean(),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }
 
@@ -56,9 +83,10 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
     NumberTransform(),
+    Presence(required),
     IsInt(),
-    ...(required ? [IsNotEmpty()] : []),
     ...(min === undefined ? [] : [Min(min)]),
     ...(max === undefined ? [] : [Max(max)]),
   )
@@ -71,8 +99,9 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 export function EnvString({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     IsString(),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }
 
@@ -85,10 +114,11 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
     IsUrl({ require_tld: requireTld }),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }
 
@@ -98,7 +128,8 @@ export function EnvEnum(
 ) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     IsEnum(enumType),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }

--- a/nest-clamav-scanner/src/config/environment-decorators.ts
+++ b/nest-clamav-scanner/src/config/environment-decorators.ts
@@ -34,6 +34,7 @@ function EmptyStringTransform() {
  * a type error.
  */
 function Presence(required: boolean) {
+  // eslint-disable-next-line sonarjs/no-selector-parameter -- callers pass a named variable, never a literal
   return required ? IsNotEmpty() : IsOptional()
 }
 

--- a/nest-forms-backend/src/config/environment-decorators.ts
+++ b/nest-forms-backend/src/config/environment-decorators.ts
@@ -21,7 +21,7 @@ import {
  * as a real value), required fields fail with "should not be empty" instead of
  * a type error, and `config.get('FOO') ?? fallback` behaves.
  */
-function EmptyStringTransform() {
+function EmptyToUndefinedTransform() {
   return Transform(({ value }: { value: unknown }) =>
     typeof value === 'string' && value.trim() === '' ? undefined : value,
   )
@@ -33,7 +33,7 @@ function EmptyStringTransform() {
  * Omitting it leaves IsString()/IsInt()/IsUrl() to reject an absent value with
  * a type error.
  */
-function Presence(required: boolean) {
+function IsRequired(required: boolean) {
   // eslint-disable-next-line sonarjs/no-selector-parameter -- callers pass a named variable, never a literal
   return required ? IsNotEmpty() : IsOptional()
 }
@@ -66,9 +66,9 @@ function NumberTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
+    EmptyToUndefinedTransform(),
     BooleanTransform(),
-    Presence(required),
+    IsRequired(required),
     IsBoolean(),
   )
 }
@@ -84,9 +84,9 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
+    EmptyToUndefinedTransform(),
     NumberTransform(),
-    Presence(required),
+    IsRequired(required),
     IsInt(),
     ...(min === undefined ? [] : [Min(min)]),
     ...(max === undefined ? [] : [Max(max)]),
@@ -100,8 +100,8 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 export function EnvString({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     IsString(),
   )
 }
@@ -115,8 +115,8 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
     IsUrl({ require_tld: requireTld }),
@@ -129,8 +129,8 @@ export function EnvEnum(
 ) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     IsEnum(enumType),
   )
 }

--- a/nest-forms-backend/src/config/environment-decorators.ts
+++ b/nest-forms-backend/src/config/environment-decorators.ts
@@ -21,7 +21,7 @@ import {
  * as a real value), required fields fail with "should not be empty" instead of
  * a type error, and `config.get('FOO') ?? fallback` behaves.
  */
-function EmptyTransform() {
+function EmptyStringTransform() {
   return Transform(({ value }: { value: unknown }) =>
     typeof value === 'string' && value.trim() === '' ? undefined : value,
   )
@@ -65,7 +65,7 @@ function NumberTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     BooleanTransform(),
     Presence(required),
     IsBoolean(),
@@ -83,7 +83,7 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     NumberTransform(),
     Presence(required),
     IsInt(),
@@ -99,7 +99,7 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 export function EnvString({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     IsString(),
   )
@@ -114,7 +114,7 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
@@ -128,7 +128,7 @@ export function EnvEnum(
 ) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     IsEnum(enumType),
   )

--- a/nest-forms-backend/src/config/environment-decorators.ts
+++ b/nest-forms-backend/src/config/environment-decorators.ts
@@ -5,11 +5,37 @@ import {
   IsEnum,
   IsInt,
   IsNotEmpty,
+  IsOptional,
   IsString,
   IsUrl,
   Max,
   Min,
 } from 'class-validator'
+
+/**
+ * `process.env` cannot distinguish "unset" from "set to nothing": `FOO=` and a
+ * missing `FOO` mean the same thing to whoever wrote the env file, but arrive
+ * as '' and undefined respectively. Normalising '' to undefined means
+ * IsOptional() actually skips the property (it short-circuits on
+ * null/undefined only, so a raw '' falls through to IsString() and is accepted
+ * as a real value), required fields fail with "should not be empty" instead of
+ * a type error, and `config.get('FOO') ?? fallback` behaves.
+ */
+function EmptyTransform() {
+  return Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' && value.trim() === '' ? undefined : value,
+  )
+}
+
+/**
+ * IsOptional() is not a validator but a conditional on the whole property: if
+ * the value is null or undefined, every other validator on it is skipped.
+ * Omitting it leaves IsString()/IsInt()/IsUrl() to reject an absent value with
+ * a type error.
+ */
+function Presence(required: boolean) {
+  return required ? IsNotEmpty() : IsOptional()
+}
 
 function BooleanTransform() {
   return Transform(({ value }: { value: unknown }) => {
@@ -39,9 +65,10 @@ function NumberTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
     BooleanTransform(),
+    Presence(required),
     IsBoolean(),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }
 
@@ -56,9 +83,10 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
     NumberTransform(),
+    Presence(required),
     IsInt(),
-    ...(required ? [IsNotEmpty()] : []),
     ...(min === undefined ? [] : [Min(min)]),
     ...(max === undefined ? [] : [Max(max)]),
   )
@@ -71,8 +99,9 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 export function EnvString({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     IsString(),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }
 
@@ -85,10 +114,11 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
     IsUrl({ require_tld: requireTld }),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }
 
@@ -98,7 +128,8 @@ export function EnvEnum(
 ) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     IsEnum(enumType),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }

--- a/nest-forms-backend/src/config/environment-decorators.ts
+++ b/nest-forms-backend/src/config/environment-decorators.ts
@@ -34,6 +34,7 @@ function EmptyStringTransform() {
  * a type error.
  */
 function Presence(required: boolean) {
+  // eslint-disable-next-line sonarjs/no-selector-parameter -- callers pass a named variable, never a literal
   return required ? IsNotEmpty() : IsOptional()
 }
 

--- a/nest-tax-backend/src/config/environment-decorators.ts
+++ b/nest-tax-backend/src/config/environment-decorators.ts
@@ -21,7 +21,7 @@ import {
  * as a real value), required fields fail with "should not be empty" instead of
  * a type error, and `config.get('FOO') ?? fallback` behaves.
  */
-function EmptyStringTransform() {
+function EmptyToUndefinedTransform() {
   return Transform(({ value }: { value: unknown }) =>
     typeof value === 'string' && value.trim() === '' ? undefined : value,
   )
@@ -33,7 +33,7 @@ function EmptyStringTransform() {
  * Omitting it leaves IsString()/IsInt()/IsUrl() to reject an absent value with
  * a type error.
  */
-function Presence(required: boolean) {
+function IsRequired(required: boolean) {
   // eslint-disable-next-line sonarjs/no-selector-parameter -- callers pass a named variable, never a literal
   return required ? IsNotEmpty() : IsOptional()
 }
@@ -66,9 +66,9 @@ function NumberTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
+    EmptyToUndefinedTransform(),
     BooleanTransform(),
-    Presence(required),
+    IsRequired(required),
     IsBoolean(),
   )
 }
@@ -84,9 +84,9 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
+    EmptyToUndefinedTransform(),
     NumberTransform(),
-    Presence(required),
+    IsRequired(required),
     IsInt(),
     ...(min === undefined ? [] : [Min(min)]),
     ...(max === undefined ? [] : [Max(max)]),
@@ -100,8 +100,8 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 export function EnvString({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     IsString(),
   )
 }
@@ -115,8 +115,8 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
     IsUrl({ require_tld: requireTld }),
@@ -129,8 +129,8 @@ export function EnvEnum(
 ) {
   return applyDecorators(
     Expose(),
-    EmptyStringTransform(),
-    Presence(required),
+    EmptyToUndefinedTransform(),
+    IsRequired(required),
     IsEnum(enumType),
   )
 }

--- a/nest-tax-backend/src/config/environment-decorators.ts
+++ b/nest-tax-backend/src/config/environment-decorators.ts
@@ -21,7 +21,7 @@ import {
  * as a real value), required fields fail with "should not be empty" instead of
  * a type error, and `config.get('FOO') ?? fallback` behaves.
  */
-function EmptyTransform() {
+function EmptyStringTransform() {
   return Transform(({ value }: { value: unknown }) =>
     typeof value === 'string' && value.trim() === '' ? undefined : value,
   )
@@ -65,7 +65,7 @@ function NumberTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     BooleanTransform(),
     Presence(required),
     IsBoolean(),
@@ -83,7 +83,7 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     NumberTransform(),
     Presence(required),
     IsInt(),
@@ -99,7 +99,7 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 export function EnvString({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     IsString(),
   )
@@ -114,7 +114,7 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
@@ -128,7 +128,7 @@ export function EnvEnum(
 ) {
   return applyDecorators(
     Expose(),
-    EmptyTransform(),
+    EmptyStringTransform(),
     Presence(required),
     IsEnum(enumType),
   )

--- a/nest-tax-backend/src/config/environment-decorators.ts
+++ b/nest-tax-backend/src/config/environment-decorators.ts
@@ -5,11 +5,37 @@ import {
   IsEnum,
   IsInt,
   IsNotEmpty,
+  IsOptional,
   IsString,
   IsUrl,
   Max,
   Min,
 } from 'class-validator'
+
+/**
+ * `process.env` cannot distinguish "unset" from "set to nothing": `FOO=` and a
+ * missing `FOO` mean the same thing to whoever wrote the env file, but arrive
+ * as '' and undefined respectively. Normalising '' to undefined means
+ * IsOptional() actually skips the property (it short-circuits on
+ * null/undefined only, so a raw '' falls through to IsString() and is accepted
+ * as a real value), required fields fail with "should not be empty" instead of
+ * a type error, and `config.get('FOO') ?? fallback` behaves.
+ */
+function EmptyTransform() {
+  return Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' && value.trim() === '' ? undefined : value,
+  )
+}
+
+/**
+ * IsOptional() is not a validator but a conditional on the whole property: if
+ * the value is null or undefined, every other validator on it is skipped.
+ * Omitting it leaves IsString()/IsInt()/IsUrl() to reject an absent value with
+ * a type error.
+ */
+function Presence(required: boolean) {
+  return required ? IsNotEmpty() : IsOptional()
+}
 
 function BooleanTransform() {
   return Transform(({ value }: { value: unknown }) => {
@@ -39,9 +65,10 @@ function NumberTransform() {
 export function EnvBoolean({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
     BooleanTransform(),
+    Presence(required),
     IsBoolean(),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }
 
@@ -56,9 +83,10 @@ export function EnvInt({
 } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
     NumberTransform(),
+    Presence(required),
     IsInt(),
-    ...(required ? [IsNotEmpty()] : []),
     ...(min === undefined ? [] : [Min(min)]),
     ...(max === undefined ? [] : [Max(max)]),
   )
@@ -71,8 +99,9 @@ export function EnvPort({ required = true }: { required?: boolean } = {}) {
 export function EnvString({ required = true }: { required?: boolean } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     IsString(),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }
 
@@ -85,10 +114,11 @@ export function EnvUrl({
 } = {}) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     // requireTld toggles whether the URL must have a top-level domain (TLD)
     // Disable it for Kubernetes service URLs (e.g. http://nest-forms-backend-app).
     IsUrl({ require_tld: requireTld }),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }
 
@@ -98,7 +128,8 @@ export function EnvEnum(
 ) {
   return applyDecorators(
     Expose(),
+    EmptyTransform(),
+    Presence(required),
     IsEnum(enumType),
-    ...(required ? [IsNotEmpty()] : []),
   )
 }

--- a/nest-tax-backend/src/config/environment-decorators.ts
+++ b/nest-tax-backend/src/config/environment-decorators.ts
@@ -34,6 +34,7 @@ function EmptyStringTransform() {
  * a type error.
  */
 function Presence(required: boolean) {
+  // eslint-disable-next-line sonarjs/no-selector-parameter -- callers pass a named variable, never a literal
   return required ? IsNotEmpty() : IsOptional()
 }
 


### PR DESCRIPTION
## Problem
 
`required: false` never worked. Every `Env*` helper applied its type validator unconditionally:
 
```ts
export function EnvString({ required = true } = {}) {
  return applyDecorators(
    Expose(),
    IsString(),
    ...(required ? [IsNotEmpty()] : []),
  )
}
```
 
Dropping `IsNotEmpty()` is not enough to make a property optional. class-validator runs every validator registered on a property unless something explicitly tells it to skip, and `IsString()` — like `IsInt()`, `IsBoolean()`, `IsUrl()`, `IsEnum()` —
rejects `undefined`. So an unset optional env var failed startup with a type error about a value that was never supposed to be there.
 
Second, smaller problem: `process.env` cannot distinguish "unset" from "set to nothing". `FOO=` in a `.env` file and a missing `FOO` mean the same thing to whoever wrote the file, but arrive as `''` and `undefined`. Left alone, `''` is a valid string, so optional fields silently resolved to empty string, and`config.get('FOO') ?? fallback` never reached the fallback.
 
## Behaviour change
 
| Env var state | Before | After |
| --- | --- | --- |
| set, optional field | value | value |
| **unset, optional field** | **fails: "must be a string"** | **skipped, `undefined`** |
| `FOO=`, optional field | `''` | `undefined` |
| unset, required field | fails, type error | fails: "should not be empty" |
| `FOO=`, required field | fails, message varies by type | fails: "should not be empty" |
| set but wrong type | fails, type error | unchanged |
 
The bolded row is the bug. The rest is either unchanged or a better error message.
Nothing that validated before stops validating now.
 
## The fix
 
Two private helpers, applied uniformly across all six decorators.
 
**`Presence(required)`** returns `IsNotEmpty()` or `IsOptional()`. `IsOptional()`is not a validator but a conditional on the whole property: if the value is `null`or `undefined`, every other validator on that property is skipped. That is thepiece that was missing.
 
**`EmptyStringTransform()`** maps `''` and whitespace-only strings to `undefined`, so absence has exactly one representation by the time validation runs. This is what lets `IsOptional()` do its job — it short-circuits on `null`/`undefined` only, and a bare `''` would otherwise fall straight through to the type validator and be accepted. On required fields it also normalises the failure message.
 
`BooleanTransform` and `NumberTransform` are unchanged. `EmptyTransform` is listed ahead of them so they receive `undefined` rather than `''`.
 
## Ordering
 
`EmptyTransform` must come first in the `applyDecorators` array. Nest's `applyDecorators` invokes decorators front to back, class-transformer records `@Transform` metadata in registration order, and applies them in that same order —
so array position maps to execution order here. Worth knowing that this does *not* hold for `@Transform` decorators stacked directly on a property, where TypeScript applies bottom-up.