### PR TITLE
Eslint sonarjs pin 4.2.0

### DIFF
--- a/nest-city-account/package-lock.json
+++ b/nest-city-account/package-lock.json
@@ -91,7 +91,7 @@
       "version": "1.0.0",
       "license": "EUPL-1.2",
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "2.39.1",
+        "@openapitools/openapi-generator-cli": "2.40.1",
         "@types/app-root-dir": "0.1.4",
         "@types/fs-extra": "11.0.4",
         "@types/node": "24.13.3",
@@ -11422,9 +11422,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
-      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
@@ -11432,14 +11432,15 @@
         "builtin-modules": "^3.3.0",
         "bytes": "^3.1.2",
         "functional-red-black-tree": "^1.0.1",
-        "globals": "^17.4.0",
+        "globals": "^17.7.0",
         "jsx-ast-utils-x": "^0.1.0",
         "lodash.merge": "^4.6.2",
         "minimatch": "^10.2.5",
         "scslre": "^0.3.0",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "ts-api-utils": "^2.5.0",
-        "typescript": ">=5"
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
       },
       "peerDependencies": {
         "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
@@ -11466,6 +11467,19 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
@@ -19661,6 +19675,22 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/nest-city-account/package-lock.json
+++ b/nest-city-account/package-lock.json
@@ -51,7 +51,7 @@
         "zod": "4.4.3"
       },
       "devDependencies": {
-        "@bratislava/eslint-config-nest": "0.17.0",
+        "@bratislava/eslint-config-nest": "0.19.1",
         "@golevelup/ts-jest": "3.0.0",
         "@nestjs/cli": "11.0.24",
         "@nestjs/testing": "11.1.28",
@@ -4885,50 +4885,51 @@
       }
     },
     "node_modules/@bratislava/eslint-config": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.17.0.tgz",
-      "integrity": "sha512-eHbB4nAXN3IP+bTnv37zaO0e+nnfLQTFx1Mv7JcizhLtPIKaPMB1+4xStE9pWM7l9HoYsHbNdEwZ1t6xl3zpqA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.19.1.tgz",
+      "integrity": "sha512-cSOFkEsyBqzS6JedBZqnD0YbcQkcU3lFxAGWnivgms5NbzUsAUdW9XuT8jsyFkgEgfNTQs3vSJ/yVWZup/6irw==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@eslint/js": "9.34.0",
-        "@eslint/markdown": "8.0.2",
+        "@eslint/js": "9.39.5",
+        "@eslint/markdown": "8.0.3",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-no-unsanitized": "4.1.5",
         "eslint-plugin-security": "4.0.1",
         "eslint-plugin-simple-import-sort": "13.0.0",
-        "eslint-plugin-sonarjs": "4.0.3",
-        "globals": "17.6.0",
-        "typescript-eslint": "8.61.0"
+        "eslint-plugin-sonarjs": "4.2.0",
+        "globals": "17.9.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "eslint": ">= 9",
-        "typescript": ">= 5"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@bratislava/eslint-config-nest": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-nest/-/eslint-config-nest-0.17.0.tgz",
-      "integrity": "sha512-SitadpYBOs803C4BdV+5b8grEPfIRoOBxZhIDSHnKDh5G9+/JObSEZTJ5IRW0ttTe2zw7kyyIM4bY1xcsFW8og==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-nest/-/eslint-config-nest-0.19.1.tgz",
+      "integrity": "sha512-xPv0HCC9yE4Sy4pLPxWzMaNxOJj1sPjJAi3qbyMMOYwtu9t1ZktGQhcqIhLeYWBs6b9PG6KEnRUPUZ5TdAP4CA==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@bratislava/eslint-config": "0.17.0",
-        "@darraghor/eslint-plugin-nestjs-typed": "7.2.4",
-        "@eslint/json": "2.0.0",
-        "eslint-plugin-jest": "29.15.2",
-        "globals": "17.6.0"
+        "@bratislava/eslint-config": "0.19.1",
+        "@darraghor/eslint-plugin-nestjs-typed": "7.3.0",
+        "@eslint/json": "2.0.1",
+        "eslint-plugin-jest": "29.16.0",
+        "globals": "17.9.0"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "eslint": ">= 9",
-        "typescript": ">= 5"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@cacheable/utils": {
@@ -4969,27 +4970,193 @@
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@darraghor/eslint-plugin-nestjs-typed/-/eslint-plugin-nestjs-typed-7.2.4.tgz",
-      "integrity": "sha512-uld8bu0gUU6zrO3EfTlZVN+yGyXl+vKdLi8JH5es0B3+rx+q15E/C1gdDM+LtFlJfzs0o3vL73dus88RhlStlQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@darraghor/eslint-plugin-nestjs-typed/-/eslint-plugin-nestjs-typed-7.3.0.tgz",
+      "integrity": "sha512-5ko032m5DPIGlAqv+KRNNJEGAJW/gXcdTX3YQEyCvvXPWl9PTm3kck+qXdxtfIl5rlt6DV3s3EbvqRSvx2C9QA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "^8.60.0",
-        "@typescript-eslint/type-utils": "^8.60.0",
-        "@typescript-eslint/utils": "^8.60.0",
-        "eslint-module-utils": "2.13.0",
-        "glob": "13.0.0",
+        "@typescript-eslint/scope-manager": "^8.64.0",
+        "@typescript-eslint/type-utils": "^8.64.0",
+        "@typescript-eslint/utils": "^8.64.0",
+        "eslint-module-utils": "2.14.0",
+        "glob": "13.0.6",
         "reflect-metadata": "0.2.2",
         "ts-api-utils": "2.5.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
         "class-validator": "*",
         "eslint": ">=9.18.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/balanced-match": {
@@ -5003,44 +5170,39 @@
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
-    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -5297,9 +5459,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5310,14 +5472,14 @@
       }
     },
     "node_modules/@eslint/json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.0.tgz",
-      "integrity": "sha512-P32ZJMIopNWQd1SFhd0tgjfA/hgzUuVSqHmMi2273QaLWHWimXq6V+qL4DNKnjGzO/aNECtYW+rEJ/pWB6uP+w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.1.tgz",
+      "integrity": "sha512-Thz2j92ceUF3Bq/0TuWb3MWn3Z+Cwc8k5ptF0fakl2D4Mp8mSx07Xr1aQM4R5NoihzarWUdxfOmQ8DesGy4jOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanwhocodes/momoa": "^3.3.10",
         "natural-compare": "^1.4.0"
       },
@@ -5353,9 +5515,9 @@
       }
     },
     "node_modules/@eslint/markdown": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.2.tgz",
-      "integrity": "sha512-W+/0qHp0WbvFEljUvvECNpSWrUHpBWIWwp7F3QqEwQKmaRCmfEWvk6VfUia9pTQ0th6HyBGBsPfg/kG3/aQxLA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.3.tgz",
+      "integrity": "sha512-rBTSSShrq7e4O+PWfeE4azH4/CWPNrC+VGxBXiW00o3vYVJnznsZiDayj3KC9JztIMVRZxZHn2nrDIUau/4j7A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -5363,7 +5525,7 @@
       ],
       "dependencies": {
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "github-slugger": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-frontmatter": "^2.0.1",
@@ -7799,9 +7961,9 @@
       "license": "MIT"
     },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8064,6 +8226,7 @@
       "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.62.1",
@@ -8093,6 +8256,7 @@
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -8103,6 +8267,7 @@
       "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -8185,6 +8350,7 @@
       "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.62.1",
         "@typescript-eslint/typescript-estree": "8.62.1",
@@ -11214,9 +11380,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11276,9 +11442,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11356,9 +11522,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "29.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
-      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
+      "version": "29.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.16.0.tgz",
+      "integrity": "sha512-0WFBxDHlT2ratGQfnFQEVIsgQJ5cfd+0IV8Kc6U3X2onB8ATLG23voD2Ch5G9fCkEpCPmCMuzW0tbS0kYb8biw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11371,7 +11537,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "jest": "*",
-        "typescript": ">=4.8.4 <7.0.0"
+        "typescript": ">=4.8.4 <8.0.0"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {
@@ -11467,19 +11633,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
-      "version": "17.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
@@ -12466,9 +12619,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18991,6 +19144,7 @@
       "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.62.1",
         "@typescript-eslint/parser": "8.62.1",

--- a/nest-city-account/package.json
+++ b/nest-city-account/package.json
@@ -71,7 +71,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@bratislava/eslint-config-nest": "0.17.0",
+    "@bratislava/eslint-config-nest": "0.19.1",
     "@golevelup/ts-jest": "3.0.0",
     "@nestjs/cli": "11.0.24",
     "@nestjs/testing": "11.1.28",
@@ -101,11 +101,6 @@
     "ts-unused-exports": "11.0.1",
     "type-fest": "5.8.0",
     "typescript": "6.0.3"
-  },
-  "overrides": {
-    "typescript-eslint": "8.62.1",
-    "@typescript-eslint/parser": "8.62.1",
-    "eslint-plugin-sonarjs": "4.2.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/nest-city-account/package.json
+++ b/nest-city-account/package.json
@@ -104,7 +104,8 @@
   },
   "overrides": {
     "typescript-eslint": "8.62.1",
-    "@typescript-eslint/parser": "8.62.1"
+    "@typescript-eslint/parser": "8.62.1",
+    "eslint-plugin-sonarjs": "4.2.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/nest-city-account/src/nases/nases.service.ts
+++ b/nest-city-account/src/nases/nases.service.ts
@@ -1,6 +1,7 @@
 import { HttpStatus, Injectable } from '@nestjs/common'
 import { AxiosError, isAxiosError } from 'axios'
-import _ from 'lodash'
+import keyBy from 'lodash/keyBy'
+import uniqBy from 'lodash/uniqBy'
 import {
   ApiIamIdentitiesIdGet200Response,
   UpvsCorporateBody,
@@ -297,8 +298,8 @@ export class NasesService {
   async getIdentitiesByUris(
     inputs: GetUpvsIdentitiesByUrisParam
   ): Promise<GetIdentitiesByUrisResult> {
-    const uniqueInputs = _.uniqBy(inputs, 'uri')
-    const inputsByUri = _.keyBy(uniqueInputs, 'uri') as Partial<
+    const uniqueInputs = uniqBy(inputs, 'uri')
+    const inputsByUri = keyBy(uniqueInputs, 'uri') as Partial<
       Record<string, GetUpvsIdentitiesByUrisParam[number]>
     >
 

--- a/nest-city-account/src/user-verification/utils/subservice/__tests__/verification.subservice.spec.ts
+++ b/nest-city-account/src/user-verification/utils/subservice/__tests__/verification.subservice.spec.ts
@@ -192,24 +192,20 @@ describe('VerificationSubservice', () => {
       expect(service['validatePersonName'](rfoData, '  Ján  ', '  Novák  ')).toBe(true)
     })
 
-    it('should not match when diacritics differ', () => {
+    it.each([
+      { scenario: 'diacritics differ in the first name', firstName: 'Jan', lastName: 'Novák' },
+      { scenario: 'diacritics differ in the last name', firstName: 'Ján', lastName: 'Novak' },
+      { scenario: 'letter case differs in the first name', firstName: 'ján', lastName: 'Novák' },
+      { scenario: 'letter case differs in the last name', firstName: 'Ján', lastName: 'NOVÁK' },
+      { scenario: 'the first name does not match', firstName: 'Peter', lastName: 'Novák' },
+      { scenario: 'the last name does not match', firstName: 'Ján', lastName: 'Horváth' },
+    ])('should not match when $scenario', ({ firstName, lastName }) => {
       const rfoData: RfoIdentityListElement = {
         menaOsoby: [{ meno: 'Ján' }],
         priezviskaOsoby: [{ meno: 'Novák' }],
       }
 
-      expect(service['validatePersonName'](rfoData, 'Jan', 'Novák')).toBe(false)
-      expect(service['validatePersonName'](rfoData, 'Ján', 'Novak')).toBe(false)
-    })
-
-    it('should not match when letter case differs', () => {
-      const rfoData: RfoIdentityListElement = {
-        menaOsoby: [{ meno: 'Ján' }],
-        priezviskaOsoby: [{ meno: 'Novák' }],
-      }
-
-      expect(service['validatePersonName'](rfoData, 'ján', 'Novák')).toBe(false)
-      expect(service['validatePersonName'](rfoData, 'Ján', 'NOVÁK')).toBe(false)
+      expect(service['validatePersonName'](rfoData, firstName, lastName)).toBe(false)
     })
 
     it('should support multiple first names and multiple last names (all parts must match)', () => {
@@ -241,16 +237,6 @@ describe('VerificationSubservice', () => {
       }
 
       expect(service['validatePersonName'](rfoData, 'Ján', 'Novák')).toBe(false)
-    })
-
-    it('should return false when the provided names do not match RFO', () => {
-      const rfoData: RfoIdentityListElement = {
-        menaOsoby: [{ meno: 'Ján' }],
-        priezviskaOsoby: [{ meno: 'Novák' }],
-      }
-
-      expect(service['validatePersonName'](rfoData, 'Peter', 'Novák')).toBe(false)
-      expect(service['validatePersonName'](rfoData, 'Ján', 'Horváth')).toBe(false)
     })
 
     it('should not depend on the order of names in RFO lists (order-insensitive)', () => {
@@ -321,16 +307,6 @@ describe('VerificationSubservice', () => {
       }
 
       expect(service['validatePersonName'](rfoData, 'Ján', 'Novák')).toBe(false)
-    })
-
-    it('should return false if any provided name part is missing in RFO (multi-name input)', () => {
-      const rfoData: RfoIdentityListElement = {
-        menaOsoby: [{ meno: 'Ján' }], // Peter missing
-        priezviskaOsoby: [{ meno: 'Novák' }, { meno: 'Horváth' }],
-      }
-
-      expect(service['validatePersonName'](rfoData, 'Ján Peter', 'Novák')).toBe(false)
-      expect(service['validatePersonName'](rfoData, 'Ján', 'Novák Horváth Svoboda')).toBe(false)
     })
   })
 })

--- a/nest-city-account/src/utils/__test__/norisCodec.spec.ts
+++ b/nest-city-account/src/utils/__test__/norisCodec.spec.ts
@@ -92,7 +92,7 @@ describe('DeliveryMethodCodec', () => {
 
       allNorisValues.forEach((norisValue) => {
         const encoded = DeliveryMethodCodec.encode(norisValue)
-        expect(encoded).not.toBe(null)
+        expect(encoded).not.toBeNull()
         expect(Object.values(DeliveryMethodEnum)).toContain(encoded)
       })
     })
@@ -117,19 +117,19 @@ describe('DeliveryMethodCodec', () => {
       }).toThrow()
     })
 
-    it('should throw when decoding empty string', () => {
+    it('should throw when encoding empty string', () => {
       expect(() => {
         DeliveryMethodCodec.encode('' as DeliveryMethod)
       }).toThrow()
     })
 
-    it('should throw when decoding numeric input', () => {
+    it('should throw when encoding numeric input', () => {
       expect(() => {
         DeliveryMethodCodec.encode(123 as unknown as DeliveryMethod)
       }).toThrow()
     })
 
-    it('should throw when decoding object input', () => {
+    it('should throw when encoding object input', () => {
       expect(() => {
         DeliveryMethodCodec.encode({} as DeliveryMethod)
       }).toThrow()

--- a/nest-city-account/src/utils/decorators/__test__/validation.decorators.spec.ts
+++ b/nest-city-account/src/utils/decorators/__test__/validation.decorators.spec.ts
@@ -90,26 +90,13 @@ describe('IsIdentityCard', () => {
     expect(errors).toHaveLength(0)
   })
 
-  it('rejects wrong length', async () => {
-    const dto = plainToInstance(IdentityCardDto, { idCard: 'AB12345' })
-    const errors = await validate(dto)
-    expect(errors.length).toBeGreaterThan(0)
-  })
-
-  it('rejects missing letter prefix', async () => {
-    const dto = plainToInstance(IdentityCardDto, { idCard: 'A1123456' })
-    const errors = await validate(dto)
-    expect(errors.length).toBeGreaterThan(0)
-  })
-
-  it('rejects non-digit middle segment', async () => {
-    const dto = plainToInstance(IdentityCardDto, { idCard: 'AB12X456' })
-    const errors = await validate(dto)
-    expect(errors.length).toBeGreaterThan(0)
-  })
-
-  it('rejects non-string', async () => {
-    const dto = plainToInstance(IdentityCardDto, { idCard: null })
+  it.each([
+    { reason: 'wrong length', idCard: 'AB12345' },
+    { reason: 'missing letter prefix', idCard: 'A1123456' },
+    { reason: 'non-digit middle segment', idCard: 'AB12X456' },
+    { reason: 'non-string', idCard: null },
+  ])('rejects $reason', async ({ idCard }) => {
+    const dto = plainToInstance(IdentityCardDto, { idCard })
     const errors = await validate(dto)
     expect(errors.length).toBeGreaterThan(0)
   })
@@ -127,26 +114,13 @@ describe('IsIco', () => {
     expect(errors).toHaveLength(0)
   })
 
-  it('rejects too short', async () => {
-    const dto = plainToInstance(IcoDto, { ico: '12345' })
-    const errors = await validate(dto)
-    expect(errors.length).toBeGreaterThan(0)
-  })
-
-  it('rejects too long', async () => {
-    const dto = plainToInstance(IcoDto, { ico: '123456789' })
-    const errors = await validate(dto)
-    expect(errors.length).toBeGreaterThan(0)
-  })
-
-  it('rejects non-digits', async () => {
-    const dto = plainToInstance(IcoDto, { ico: '12345a' })
-    const errors = await validate(dto)
-    expect(errors.length).toBeGreaterThan(0)
-  })
-
-  it('rejects non-string', async () => {
-    const dto = plainToInstance(IcoDto, { ico: 123456 })
+  it.each([
+    { reason: 'too short', ico: '12345' },
+    { reason: 'too long', ico: '123456789' },
+    { reason: 'non-digits', ico: '12345a' },
+    { reason: 'non-string', ico: 123456 },
+  ])('rejects $reason', async ({ ico }) => {
+    const dto = plainToInstance(IcoDto, { ico })
     const errors = await validate(dto)
     expect(errors.length).toBeGreaterThan(0)
   })

--- a/nest-clamav-scanner/package-lock.json
+++ b/nest-clamav-scanner/package-lock.json
@@ -34,7 +34,7 @@
         "rimraf": "6.0.1"
       },
       "devDependencies": {
-        "@bratislava/eslint-config-nest": "0.17.0",
+        "@bratislava/eslint-config-nest": "0.19.1",
         "@nestjs/cli": "11.0.24",
         "@nestjs/schematics": "11.1.0",
         "@nestjs/testing": "11.1.28",
@@ -4328,50 +4328,51 @@
       }
     },
     "node_modules/@bratislava/eslint-config": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.17.0.tgz",
-      "integrity": "sha512-eHbB4nAXN3IP+bTnv37zaO0e+nnfLQTFx1Mv7JcizhLtPIKaPMB1+4xStE9pWM7l9HoYsHbNdEwZ1t6xl3zpqA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.19.1.tgz",
+      "integrity": "sha512-cSOFkEsyBqzS6JedBZqnD0YbcQkcU3lFxAGWnivgms5NbzUsAUdW9XuT8jsyFkgEgfNTQs3vSJ/yVWZup/6irw==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@eslint/js": "9.34.0",
-        "@eslint/markdown": "8.0.2",
+        "@eslint/js": "9.39.5",
+        "@eslint/markdown": "8.0.3",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-no-unsanitized": "4.1.5",
         "eslint-plugin-security": "4.0.1",
         "eslint-plugin-simple-import-sort": "13.0.0",
-        "eslint-plugin-sonarjs": "4.0.3",
-        "globals": "17.6.0",
-        "typescript-eslint": "8.61.0"
+        "eslint-plugin-sonarjs": "4.2.0",
+        "globals": "17.9.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "eslint": ">= 9",
-        "typescript": ">= 5"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@bratislava/eslint-config-nest": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-nest/-/eslint-config-nest-0.17.0.tgz",
-      "integrity": "sha512-SitadpYBOs803C4BdV+5b8grEPfIRoOBxZhIDSHnKDh5G9+/JObSEZTJ5IRW0ttTe2zw7kyyIM4bY1xcsFW8og==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-nest/-/eslint-config-nest-0.19.1.tgz",
+      "integrity": "sha512-xPv0HCC9yE4Sy4pLPxWzMaNxOJj1sPjJAi3qbyMMOYwtu9t1ZktGQhcqIhLeYWBs6b9PG6KEnRUPUZ5TdAP4CA==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@bratislava/eslint-config": "0.17.0",
-        "@darraghor/eslint-plugin-nestjs-typed": "7.2.4",
-        "@eslint/json": "2.0.0",
-        "eslint-plugin-jest": "29.15.2",
-        "globals": "17.6.0"
+        "@bratislava/eslint-config": "0.19.1",
+        "@darraghor/eslint-plugin-nestjs-typed": "7.3.0",
+        "@eslint/json": "2.0.1",
+        "eslint-plugin-jest": "29.16.0",
+        "globals": "17.9.0"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "eslint": ">= 9",
-        "typescript": ">= 5"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -4404,27 +4405,193 @@
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@darraghor/eslint-plugin-nestjs-typed/-/eslint-plugin-nestjs-typed-7.2.4.tgz",
-      "integrity": "sha512-uld8bu0gUU6zrO3EfTlZVN+yGyXl+vKdLi8JH5es0B3+rx+q15E/C1gdDM+LtFlJfzs0o3vL73dus88RhlStlQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@darraghor/eslint-plugin-nestjs-typed/-/eslint-plugin-nestjs-typed-7.3.0.tgz",
+      "integrity": "sha512-5ko032m5DPIGlAqv+KRNNJEGAJW/gXcdTX3YQEyCvvXPWl9PTm3kck+qXdxtfIl5rlt6DV3s3EbvqRSvx2C9QA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "^8.60.0",
-        "@typescript-eslint/type-utils": "^8.60.0",
-        "@typescript-eslint/utils": "^8.60.0",
-        "eslint-module-utils": "2.13.0",
-        "glob": "13.0.0",
+        "@typescript-eslint/scope-manager": "^8.64.0",
+        "@typescript-eslint/type-utils": "^8.64.0",
+        "@typescript-eslint/utils": "^8.64.0",
+        "eslint-module-utils": "2.14.0",
+        "glob": "13.0.6",
         "reflect-metadata": "0.2.2",
         "ts-api-utils": "2.5.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
         "class-validator": "*",
         "eslint": ">=9.18.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/balanced-match": {
@@ -4438,44 +4605,57 @@
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4753,9 +4933,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4766,14 +4946,14 @@
       }
     },
     "node_modules/@eslint/json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.0.tgz",
-      "integrity": "sha512-P32ZJMIopNWQd1SFhd0tgjfA/hgzUuVSqHmMi2273QaLWHWimXq6V+qL4DNKnjGzO/aNECtYW+rEJ/pWB6uP+w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.1.tgz",
+      "integrity": "sha512-Thz2j92ceUF3Bq/0TuWb3MWn3Z+Cwc8k5ptF0fakl2D4Mp8mSx07Xr1aQM4R5NoihzarWUdxfOmQ8DesGy4jOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanwhocodes/momoa": "^3.3.10",
         "natural-compare": "^1.4.0"
       },
@@ -4782,9 +4962,9 @@
       }
     },
     "node_modules/@eslint/markdown": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.2.tgz",
-      "integrity": "sha512-W+/0qHp0WbvFEljUvvECNpSWrUHpBWIWwp7F3QqEwQKmaRCmfEWvk6VfUia9pTQ0th6HyBGBsPfg/kG3/aQxLA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.3.tgz",
+      "integrity": "sha512-rBTSSShrq7e4O+PWfeE4azH4/CWPNrC+VGxBXiW00o3vYVJnznsZiDayj3KC9JztIMVRZxZHn2nrDIUau/4j7A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -4792,7 +4972,7 @@
       ],
       "dependencies": {
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "github-slugger": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-frontmatter": "^2.0.1",
@@ -5991,16 +6171,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@nestjs/cli/node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@nestjs/cli/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -6009,23 +6179,6 @@
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6981,9 +7134,9 @@
       "license": "MIT"
     },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7188,6 +7341,7 @@
       "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.62.1",
@@ -7217,6 +7371,7 @@
       "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -7299,6 +7454,7 @@
       "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.62.1",
         "@typescript-eslint/typescript-estree": "8.62.1",
@@ -8375,6 +8531,8 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9568,6 +9726,8 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9986,13 +10146,14 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
-      "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
         "is-date-object": "^1.1.0",
@@ -10127,9 +10288,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10189,9 +10350,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10269,9 +10430,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "29.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
-      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
+      "version": "29.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.16.0.tgz",
+      "integrity": "sha512-0WFBxDHlT2ratGQfnFQEVIsgQJ5cfd+0IV8Kc6U3X2onB8ATLG23voD2Ch5G9fCkEpCPmCMuzW0tbS0kYb8biw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10284,7 +10445,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "jest": "*",
-        "typescript": ">=4.8.4 <7.0.0"
+        "typescript": ">=4.8.4 <8.0.0"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {
@@ -10380,19 +10541,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
-      "version": "17.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
@@ -11013,6 +11161,8 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11236,6 +11386,16 @@
         "is-property": "^1.0.2"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "dev": true,
@@ -11399,9 +11559,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11505,6 +11665,8 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11664,6 +11826,7 @@
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -11836,6 +11999,8 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11954,12 +12119,15 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.1.0",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"
       },
@@ -12044,6 +12212,8 @@
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12138,6 +12308,8 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14845,13 +15017,14 @@
       }
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -15024,14 +15197,16 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -15288,6 +15463,8 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15938,6 +16115,8 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16110,6 +16289,8 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17225,6 +17406,7 @@
       "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.62.1",
         "@typescript-eslint/parser": "8.62.1",
@@ -17760,12 +17942,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.19",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/nest-clamav-scanner/package-lock.json
+++ b/nest-clamav-scanner/package-lock.json
@@ -64,7 +64,7 @@
       "version": "1.0.0",
       "license": "EUPL-1.2",
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "2.39.1",
+        "@openapitools/openapi-generator-cli": "2.40.1",
         "@types/app-root-dir": "0.1.4",
         "@types/fs-extra": "11.0.4",
         "@types/node": "24.13.3",
@@ -74,9 +74,9 @@
         "chalk": "5.6.2",
         "commander": "15.0.0",
         "diff": "9.0.0",
-        "fs-extra": "11.3.6",
+        "fs-extra": "11.4.0",
         "npm-run-all": "4.1.5",
-        "prettier": "3.9.5",
+        "prettier": "3.9.6",
         "rimraf": "6.1.3",
         "tsx": "4.23.1",
         "typescript": "6.0.3"
@@ -10335,9 +10335,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
-      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
@@ -10345,14 +10345,15 @@
         "builtin-modules": "^3.3.0",
         "bytes": "^3.1.2",
         "functional-red-black-tree": "^1.0.1",
-        "globals": "^17.4.0",
+        "globals": "^17.7.0",
         "jsx-ast-utils-x": "^0.1.0",
         "lodash.merge": "^4.6.2",
         "minimatch": "^10.2.5",
         "scslre": "^0.3.0",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "ts-api-utils": "^2.5.0",
-        "typescript": ">=5"
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
       },
       "peerDependencies": {
         "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
@@ -10379,6 +10380,19 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
@@ -17900,6 +17914,22 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/nest-clamav-scanner/package.json
+++ b/nest-clamav-scanner/package.json
@@ -76,7 +76,8 @@
   },
   "overrides": {
     "typescript-eslint": "8.62.1",
-    "@typescript-eslint/parser": "8.62.1"
+    "@typescript-eslint/parser": "8.62.1",
+    "eslint-plugin-sonarjs": "4.2.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/nest-clamav-scanner/package.json
+++ b/nest-clamav-scanner/package.json
@@ -53,7 +53,7 @@
     "rimraf": "6.0.1"
   },
   "devDependencies": {
-    "@bratislava/eslint-config-nest": "0.17.0",
+    "@bratislava/eslint-config-nest": "0.19.1",
     "@nestjs/cli": "11.0.24",
     "@nestjs/schematics": "11.1.0",
     "@nestjs/testing": "11.1.28",
@@ -73,11 +73,6 @@
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",
     "typescript": "6.0.3"
-  },
-  "overrides": {
-    "typescript-eslint": "8.62.1",
-    "@typescript-eslint/parser": "8.62.1",
-    "eslint-plugin-sonarjs": "4.2.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/nest-forms-backend/package-lock.json
+++ b/nest-forms-backend/package-lock.json
@@ -58,7 +58,7 @@
         "xml2js": "0.6.2"
       },
       "devDependencies": {
-        "@bratislava/eslint-config-nest": "0.17.0",
+        "@bratislava/eslint-config-nest": "0.19.1",
         "@golevelup/ts-jest": "3.0.0",
         "@nestjs/cli": "11.0.24",
         "@nestjs/schematics": "11.1.0",
@@ -1206,56 +1206,57 @@
       }
     },
     "node_modules/@bratislava/eslint-config": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.17.0.tgz",
-      "integrity": "sha512-eHbB4nAXN3IP+bTnv37zaO0e+nnfLQTFx1Mv7JcizhLtPIKaPMB1+4xStE9pWM7l9HoYsHbNdEwZ1t6xl3zpqA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.19.1.tgz",
+      "integrity": "sha512-cSOFkEsyBqzS6JedBZqnD0YbcQkcU3lFxAGWnivgms5NbzUsAUdW9XuT8jsyFkgEgfNTQs3vSJ/yVWZup/6irw==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@eslint/js": "9.34.0",
-        "@eslint/markdown": "8.0.2",
+        "@eslint/js": "9.39.5",
+        "@eslint/markdown": "8.0.3",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-no-unsanitized": "4.1.5",
         "eslint-plugin-security": "4.0.1",
         "eslint-plugin-simple-import-sort": "13.0.0",
-        "eslint-plugin-sonarjs": "4.0.3",
-        "globals": "17.6.0",
-        "typescript-eslint": "8.61.0"
+        "eslint-plugin-sonarjs": "4.2.0",
+        "globals": "17.9.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "eslint": ">= 9",
-        "typescript": ">= 5"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@bratislava/eslint-config-nest": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-nest/-/eslint-config-nest-0.17.0.tgz",
-      "integrity": "sha512-SitadpYBOs803C4BdV+5b8grEPfIRoOBxZhIDSHnKDh5G9+/JObSEZTJ5IRW0ttTe2zw7kyyIM4bY1xcsFW8og==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-nest/-/eslint-config-nest-0.19.1.tgz",
+      "integrity": "sha512-xPv0HCC9yE4Sy4pLPxWzMaNxOJj1sPjJAi3qbyMMOYwtu9t1ZktGQhcqIhLeYWBs6b9PG6KEnRUPUZ5TdAP4CA==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@bratislava/eslint-config": "0.17.0",
-        "@darraghor/eslint-plugin-nestjs-typed": "7.2.4",
-        "@eslint/json": "2.0.0",
-        "eslint-plugin-jest": "29.15.2",
-        "globals": "17.6.0"
+        "@bratislava/eslint-config": "0.19.1",
+        "@darraghor/eslint-plugin-nestjs-typed": "7.3.0",
+        "@eslint/json": "2.0.1",
+        "eslint-plugin-jest": "29.16.0",
+        "globals": "17.9.0"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "eslint": ">= 9",
-        "typescript": ">= 5"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@bratislava/eslint-config-nest/node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1266,9 +1267,9 @@
       }
     },
     "node_modules/@bratislava/eslint-config/node_modules/@eslint/js": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1279,9 +1280,9 @@
       }
     },
     "node_modules/@bratislava/eslint-config/node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1363,27 +1364,193 @@
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@darraghor/eslint-plugin-nestjs-typed/-/eslint-plugin-nestjs-typed-7.2.4.tgz",
-      "integrity": "sha512-uld8bu0gUU6zrO3EfTlZVN+yGyXl+vKdLi8JH5es0B3+rx+q15E/C1gdDM+LtFlJfzs0o3vL73dus88RhlStlQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@darraghor/eslint-plugin-nestjs-typed/-/eslint-plugin-nestjs-typed-7.3.0.tgz",
+      "integrity": "sha512-5ko032m5DPIGlAqv+KRNNJEGAJW/gXcdTX3YQEyCvvXPWl9PTm3kck+qXdxtfIl5rlt6DV3s3EbvqRSvx2C9QA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "^8.60.0",
-        "@typescript-eslint/type-utils": "^8.60.0",
-        "@typescript-eslint/utils": "^8.60.0",
-        "eslint-module-utils": "2.13.0",
-        "glob": "13.0.0",
+        "@typescript-eslint/scope-manager": "^8.64.0",
+        "@typescript-eslint/type-utils": "^8.64.0",
+        "@typescript-eslint/utils": "^8.64.0",
+        "eslint-module-utils": "2.14.0",
+        "glob": "13.0.6",
         "reflect-metadata": "0.2.2",
         "ts-api-utils": "2.5.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
         "class-validator": "*",
         "eslint": ">=9.18.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/balanced-match": {
@@ -1397,44 +1564,39 @@
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
-    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1690,14 +1852,14 @@
       }
     },
     "node_modules/@eslint/json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.0.tgz",
-      "integrity": "sha512-P32ZJMIopNWQd1SFhd0tgjfA/hgzUuVSqHmMi2273QaLWHWimXq6V+qL4DNKnjGzO/aNECtYW+rEJ/pWB6uP+w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.1.tgz",
+      "integrity": "sha512-Thz2j92ceUF3Bq/0TuWb3MWn3Z+Cwc8k5ptF0fakl2D4Mp8mSx07Xr1aQM4R5NoihzarWUdxfOmQ8DesGy4jOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanwhocodes/momoa": "^3.3.10",
         "natural-compare": "^1.4.0"
       },
@@ -1733,9 +1895,9 @@
       }
     },
     "node_modules/@eslint/markdown": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.2.tgz",
-      "integrity": "sha512-W+/0qHp0WbvFEljUvvECNpSWrUHpBWIWwp7F3QqEwQKmaRCmfEWvk6VfUia9pTQ0th6HyBGBsPfg/kG3/aQxLA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.3.tgz",
+      "integrity": "sha512-rBTSSShrq7e4O+PWfeE4azH4/CWPNrC+VGxBXiW00o3vYVJnznsZiDayj3KC9JztIMVRZxZHn2nrDIUau/4j7A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -1743,7 +1905,7 @@
       ],
       "dependencies": {
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "github-slugger": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-frontmatter": "^2.0.1",
@@ -4863,9 +5025,9 @@
       "license": "MIT"
     },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5265,6 +5427,7 @@
       "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.62.1",
@@ -5294,6 +5457,7 @@
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5304,6 +5468,7 @@
       "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -5386,6 +5551,7 @@
       "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.62.1",
         "@typescript-eslint/typescript-estree": "8.62.1",
@@ -6680,6 +6846,7 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -8211,6 +8378,7 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -8950,9 +9118,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9012,9 +9180,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9092,9 +9260,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "29.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
-      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
+      "version": "29.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.16.0.tgz",
+      "integrity": "sha512-0WFBxDHlT2ratGQfnFQEVIsgQJ5cfd+0IV8Kc6U3X2onB8ATLG23voD2Ch5G9fCkEpCPmCMuzW0tbS0kYb8biw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9107,7 +9275,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "jest": "*",
-        "typescript": ">=4.8.4 <7.0.0"
+        "typescript": ">=4.8.4 <8.0.0"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {
@@ -9881,6 +10049,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
       },
@@ -10150,6 +10319,16 @@
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -10464,6 +10643,7 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -10815,6 +10995,7 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -10934,13 +11115,15 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"
       },
@@ -11039,6 +11222,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -11133,6 +11317,7 @@
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -14107,13 +14292,14 @@
       "license": "MIT"
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -14668,6 +14854,7 @@
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -15557,6 +15744,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -15745,6 +15933,7 @@
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -17147,6 +17336,7 @@
       "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.62.1",
         "@typescript-eslint/parser": "8.62.1",
@@ -17755,13 +17945,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/nest-forms-backend/package-lock.json
+++ b/nest-forms-backend/package-lock.json
@@ -108,7 +108,7 @@
         "adm-zip": "0.5.17",
         "ajv": "8.20.0",
         "ajv-formats": "3.0.1",
-        "dayjs": "1.11.20",
+        "dayjs": "1.11.21",
         "eta": "3.5.0",
         "expr-eval": "2.0.2",
         "ibantools": "4.5.1",
@@ -165,7 +165,7 @@
         "pdf-to-img": "6.2.0",
         "playwright": "1.59.1",
         "postcss": "8.5.14",
-        "prettier": "3.8.3",
+        "prettier": "3.9.6",
         "prompts": "2.4.2",
         "react": "19.2.6",
         "react-dom": "19.2.6",
@@ -195,7 +195,7 @@
       "version": "1.0.0",
       "license": "EUPL-1.2",
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "2.39.1",
+        "@openapitools/openapi-generator-cli": "2.40.1",
         "@types/app-root-dir": "0.1.4",
         "@types/fs-extra": "11.0.4",
         "@types/node": "24.13.3",
@@ -205,9 +205,9 @@
         "chalk": "5.6.2",
         "commander": "15.0.0",
         "diff": "9.0.0",
-        "fs-extra": "11.3.6",
+        "fs-extra": "11.4.0",
         "npm-run-all": "4.1.5",
-        "prettier": "3.9.5",
+        "prettier": "3.9.6",
         "rimraf": "6.1.3",
         "tsx": "4.23.1",
         "typescript": "6.0.3"
@@ -9158,9 +9158,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
-      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
@@ -9168,14 +9168,15 @@
         "builtin-modules": "^3.3.0",
         "bytes": "^3.1.2",
         "functional-red-black-tree": "^1.0.1",
-        "globals": "^17.4.0",
+        "globals": "^17.7.0",
         "jsx-ast-utils-x": "^0.1.0",
         "lodash.merge": "^4.6.2",
         "minimatch": "^10.2.5",
         "scslre": "^0.3.0",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "ts-api-utils": "^2.5.0",
-        "typescript": ">=5"
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
       },
       "peerDependencies": {
         "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
@@ -17884,9 +17885,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/nest-forms-backend/package.json
+++ b/nest-forms-backend/package.json
@@ -117,7 +117,8 @@
   },
   "overrides": {
     "typescript-eslint": "8.62.1",
-    "@typescript-eslint/parser": "8.62.1"
+    "@typescript-eslint/parser": "8.62.1",
+    "eslint-plugin-sonarjs": "4.2.0"
   },
   "engines": {
     "node": ">=24.15.x",

--- a/nest-forms-backend/package.json
+++ b/nest-forms-backend/package.json
@@ -80,7 +80,7 @@
     "xml2js": "0.6.2"
   },
   "devDependencies": {
-    "@bratislava/eslint-config-nest": "0.17.0",
+    "@bratislava/eslint-config-nest": "0.19.1",
     "@golevelup/ts-jest": "3.0.0",
     "@nestjs/cli": "11.0.24",
     "@nestjs/schematics": "11.1.0",
@@ -114,11 +114,6 @@
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",
     "typescript": "6.0.3"
-  },
-  "overrides": {
-    "typescript-eslint": "8.62.1",
-    "@typescript-eslint/parser": "8.62.1",
-    "eslint-plugin-sonarjs": "4.2.0"
   },
   "engines": {
     "node": ">=24.15.x",

--- a/nest-tax-backend/package-lock.json
+++ b/nest-tax-backend/package-lock.json
@@ -44,7 +44,7 @@
         "zod": "4.4.3"
       },
       "devDependencies": {
-        "@bratislava/eslint-config-nest": "0.17.0",
+        "@bratislava/eslint-config-nest": "0.19.1",
         "@golevelup/ts-jest": "3.0.0",
         "@nestjs/schematics": "11.1.0",
         "@nestjs/testing": "11.1.28",
@@ -1314,56 +1314,57 @@
       }
     },
     "node_modules/@bratislava/eslint-config": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.17.0.tgz",
-      "integrity": "sha512-eHbB4nAXN3IP+bTnv37zaO0e+nnfLQTFx1Mv7JcizhLtPIKaPMB1+4xStE9pWM7l9HoYsHbNdEwZ1t6xl3zpqA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.19.1.tgz",
+      "integrity": "sha512-cSOFkEsyBqzS6JedBZqnD0YbcQkcU3lFxAGWnivgms5NbzUsAUdW9XuT8jsyFkgEgfNTQs3vSJ/yVWZup/6irw==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@eslint/js": "9.34.0",
-        "@eslint/markdown": "8.0.2",
+        "@eslint/js": "9.39.5",
+        "@eslint/markdown": "8.0.3",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-no-unsanitized": "4.1.5",
         "eslint-plugin-security": "4.0.1",
         "eslint-plugin-simple-import-sort": "13.0.0",
-        "eslint-plugin-sonarjs": "4.0.3",
-        "globals": "17.6.0",
-        "typescript-eslint": "8.61.0"
+        "eslint-plugin-sonarjs": "4.2.0",
+        "globals": "17.9.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "eslint": ">= 9",
-        "typescript": ">= 5"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@bratislava/eslint-config-nest": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-nest/-/eslint-config-nest-0.17.0.tgz",
-      "integrity": "sha512-SitadpYBOs803C4BdV+5b8grEPfIRoOBxZhIDSHnKDh5G9+/JObSEZTJ5IRW0ttTe2zw7kyyIM4bY1xcsFW8og==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-nest/-/eslint-config-nest-0.19.1.tgz",
+      "integrity": "sha512-xPv0HCC9yE4Sy4pLPxWzMaNxOJj1sPjJAi3qbyMMOYwtu9t1ZktGQhcqIhLeYWBs6b9PG6KEnRUPUZ5TdAP4CA==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@bratislava/eslint-config": "0.17.0",
-        "@darraghor/eslint-plugin-nestjs-typed": "7.2.4",
-        "@eslint/json": "2.0.0",
-        "eslint-plugin-jest": "29.15.2",
-        "globals": "17.6.0"
+        "@bratislava/eslint-config": "0.19.1",
+        "@darraghor/eslint-plugin-nestjs-typed": "7.3.0",
+        "@eslint/json": "2.0.1",
+        "eslint-plugin-jest": "29.16.0",
+        "globals": "17.9.0"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "eslint": ">= 9",
-        "typescript": ">= 5"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@bratislava/eslint-config-nest/node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1374,9 +1375,9 @@
       }
     },
     "node_modules/@bratislava/eslint-config/node_modules/@eslint/js": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1387,9 +1388,9 @@
       }
     },
     "node_modules/@bratislava/eslint-config/node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1434,27 +1435,245 @@
       }
     },
     "node_modules/@darraghor/eslint-plugin-nestjs-typed": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@darraghor/eslint-plugin-nestjs-typed/-/eslint-plugin-nestjs-typed-7.2.4.tgz",
-      "integrity": "sha512-uld8bu0gUU6zrO3EfTlZVN+yGyXl+vKdLi8JH5es0B3+rx+q15E/C1gdDM+LtFlJfzs0o3vL73dus88RhlStlQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@darraghor/eslint-plugin-nestjs-typed/-/eslint-plugin-nestjs-typed-7.3.0.tgz",
+      "integrity": "sha512-5ko032m5DPIGlAqv+KRNNJEGAJW/gXcdTX3YQEyCvvXPWl9PTm3kck+qXdxtfIl5rlt6DV3s3EbvqRSvx2C9QA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "^8.60.0",
-        "@typescript-eslint/type-utils": "^8.60.0",
-        "@typescript-eslint/utils": "^8.60.0",
-        "eslint-module-utils": "2.13.0",
-        "glob": "13.0.0",
+        "@typescript-eslint/scope-manager": "^8.64.0",
+        "@typescript-eslint/type-utils": "^8.64.0",
+        "@typescript-eslint/utils": "^8.64.0",
+        "eslint-module-utils": "2.14.0",
+        "glob": "13.0.6",
         "reflect-metadata": "0.2.2",
         "ts-api-utils": "2.5.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
         "class-validator": "*",
         "eslint": ">=9.18.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@darraghor/eslint-plugin-nestjs-typed/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@electric-sql/pglite": {
@@ -1705,14 +1924,14 @@
       }
     },
     "node_modules/@eslint/json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.0.tgz",
-      "integrity": "sha512-P32ZJMIopNWQd1SFhd0tgjfA/hgzUuVSqHmMi2273QaLWHWimXq6V+qL4DNKnjGzO/aNECtYW+rEJ/pWB6uP+w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.1.tgz",
+      "integrity": "sha512-Thz2j92ceUF3Bq/0TuWb3MWn3Z+Cwc8k5ptF0fakl2D4Mp8mSx07Xr1aQM4R5NoihzarWUdxfOmQ8DesGy4jOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanwhocodes/momoa": "^3.3.10",
         "natural-compare": "^1.4.0"
       },
@@ -1748,9 +1967,9 @@
       }
     },
     "node_modules/@eslint/markdown": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.2.tgz",
-      "integrity": "sha512-W+/0qHp0WbvFEljUvvECNpSWrUHpBWIWwp7F3QqEwQKmaRCmfEWvk6VfUia9pTQ0th6HyBGBsPfg/kG3/aQxLA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.3.tgz",
+      "integrity": "sha512-rBTSSShrq7e4O+PWfeE4azH4/CWPNrC+VGxBXiW00o3vYVJnznsZiDayj3KC9JztIMVRZxZHn2nrDIUau/4j7A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -1758,7 +1977,7 @@
       ],
       "dependencies": {
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "github-slugger": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-frontmatter": "^2.0.1",
@@ -2225,27 +2444,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3069,59 +3267,6 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@nestjs/cli/node_modules/rxjs": {
@@ -4263,9 +4408,9 @@
       "license": "MIT"
     },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4590,6 +4735,7 @@
       "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.62.1",
@@ -4619,6 +4765,7 @@
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4629,6 +4776,7 @@
       "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -4711,6 +4859,7 @@
       "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.62.1",
         "@typescript-eslint/typescript-estree": "8.62.1",
@@ -7804,13 +7953,14 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
-      "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
         "is-date-object": "^1.1.0",
@@ -7950,9 +8100,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8012,9 +8162,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8092,9 +8242,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "29.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
-      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
+      "version": "29.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.16.0.tgz",
+      "integrity": "sha512-0WFBxDHlT2ratGQfnFQEVIsgQJ5cfd+0IV8Kc6U3X2onB8ATLG23voD2Ch5G9fCkEpCPmCMuzW0tbS0kYb8biw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8107,7 +8257,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "jest": "*",
-        "typescript": ">=4.8.4 <7.0.0"
+        "typescript": ">=4.8.4 <8.0.0"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {
@@ -9230,17 +9380,17 @@
       "license": "ISC"
     },
     "node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -9265,16 +9415,37 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-      "license": "BlueOak-1.0.0",
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -13016,13 +13187,14 @@
       }
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -15779,6 +15951,7 @@
       "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.62.1",
         "@typescript-eslint/parser": "8.62.1",

--- a/nest-tax-backend/package-lock.json
+++ b/nest-tax-backend/package-lock.json
@@ -82,7 +82,7 @@
       "version": "1.0.0",
       "license": "EUPL-1.2",
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "2.39.1",
+        "@openapitools/openapi-generator-cli": "2.40.1",
         "@types/app-root-dir": "0.1.4",
         "@types/fs-extra": "11.0.4",
         "@types/node": "24.13.3",
@@ -92,9 +92,9 @@
         "chalk": "5.6.2",
         "commander": "15.0.0",
         "diff": "9.0.0",
-        "fs-extra": "11.3.6",
+        "fs-extra": "11.4.0",
         "npm-run-all": "4.1.5",
-        "prettier": "3.9.5",
+        "prettier": "3.9.6",
         "rimraf": "6.1.3",
         "tsx": "4.23.1",
         "typescript": "6.0.3"
@@ -8158,9 +8158,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
-      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
@@ -8168,14 +8168,15 @@
         "builtin-modules": "^3.3.0",
         "bytes": "^3.1.2",
         "functional-red-black-tree": "^1.0.1",
-        "globals": "^17.4.0",
+        "globals": "^17.7.0",
         "jsx-ast-utils-x": "^0.1.0",
         "lodash.merge": "^4.6.2",
         "minimatch": "^10.2.5",
         "scslre": "^0.3.0",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "ts-api-utils": "^2.5.0",
-        "typescript": ">=5"
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
       },
       "peerDependencies": {
         "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
@@ -16490,6 +16491,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/nest-tax-backend/package.json
+++ b/nest-tax-backend/package.json
@@ -93,7 +93,8 @@
   },
   "overrides": {
     "typescript-eslint": "8.62.1",
-    "@typescript-eslint/parser": "8.62.1"
+    "@typescript-eslint/parser": "8.62.1",
+    "eslint-plugin-sonarjs": "4.2.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/nest-tax-backend/package.json
+++ b/nest-tax-backend/package.json
@@ -62,7 +62,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@bratislava/eslint-config-nest": "0.17.0",
+    "@bratislava/eslint-config-nest": "0.19.1",
     "@golevelup/ts-jest": "3.0.0",
     "@nestjs/schematics": "11.1.0",
     "@nestjs/testing": "11.1.28",
@@ -90,11 +90,6 @@
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",
     "typescript": "6.0.3"
-  },
-  "overrides": {
-    "typescript-eslint": "8.62.1",
-    "@typescript-eslint/parser": "8.62.1",
-    "eslint-plugin-sonarjs": "4.2.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
+++ b/nest-tax-backend/src/admin/__tests__/admin.service.spec.ts
@@ -1,6 +1,5 @@
 import { createMock } from '@golevelup/ts-jest'
 import { Test, TestingModule } from '@nestjs/testing'
-import isArray from 'lodash/isArray'
 
 import prismaMock from '../../../test/singleton'
 import { createTestTax } from '../../__tests__/factories/tax.factory'
@@ -224,7 +223,7 @@ describe('AdminService', () => {
           parseFloat(norisDataCalled[0].SPL4_2.replace(',', '.')) +
           parseFloat(norisDataCalled[0].SPL4_3.replace(',', '.')),
       ).toEqual(parseFloat(mockNorisData.taxTotal.replace(',', '.')))
-      expect(isArray(norisDataCalled)).toBe(true)
+      expect(Array.isArray(norisDataCalled)).toBe(true)
       expect(yearCalled).toBe(1970)
       expect(optionsCalled).toStrictEqual({
         prepareOnly: false,
@@ -262,7 +261,7 @@ describe('AdminService', () => {
       expect(parseFloat(norisDataCalled[0].SPL4_4.replace(',', '.'))).not.toBe(
         0,
       )
-      expect(isArray(norisDataCalled)).toBe(true)
+      expect(Array.isArray(norisDataCalled)).toBe(true)
       expect(yearCalled).toBe(1970)
       expect(optionsCalled).toStrictEqual({
         prepareOnly: false,

--- a/nest-tax-backend/src/noris/subservices/__tests__/noris-connection.subservice.mock.ts
+++ b/nest-tax-backend/src/noris/subservices/__tests__/noris-connection.subservice.mock.ts
@@ -30,6 +30,7 @@ export const mockConfigService = {
       MSSQL_DB: 'test_db',
       MSSQL_USERNAME: 'test_user',
 
+      // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- mock env value for tests, not a real credential
       MSSQL_PASSWORD: 'test_password',
     }
     return mockEnvs[key] || 'default_value'

--- a/nest-tax-backend/src/noris/subservices/__tests__/noris-validator.subservice.spec.ts
+++ b/nest-tax-backend/src/noris/subservices/__tests__/noris-validator.subservice.spec.ts
@@ -103,8 +103,9 @@ describe('NorisValidatorSubservice', () => {
       describe('valid', () => {
         it('should validate valid real estate taxes', () => {
           validNorisRealEstateTaxes.forEach((tax) => {
-            service.validateSingleNorisData(NorisRealEstateTaxSchema, tax)
-            expect(true).toBe(true)
+            expect(() =>
+              service.validateSingleNorisData(NorisRealEstateTaxSchema, tax),
+            ).not.toThrow()
           })
         })
 
@@ -170,8 +171,9 @@ describe('NorisValidatorSubservice', () => {
       describe('valid', () => {
         it('should validate valid communal waste taxes', () => {
           validNorisCommunalWasteTaxes.forEach((tax) => {
-            service.validateSingleNorisData(NorisCommunalWasteTaxSchema, tax)
-            expect(true).toBe(true)
+            expect(() =>
+              service.validateSingleNorisData(NorisCommunalWasteTaxSchema, tax),
+            ).not.toThrow()
           })
         })
 

--- a/nest-tax-backend/src/noris/utils/__tests__/mapping.helper.spec.ts
+++ b/nest-tax-backend/src/noris/utils/__tests__/mapping.helper.spec.ts
@@ -1021,7 +1021,11 @@ describe('mapNorisToCommunalWasteDatabaseDetail', () => {
     expect(result.addresses[1].containers[0].poplatok).toBe(15_050)
   })
 
-  it('should handle poplatok with zero value', () => {
+  it.each([
+    { description: 'zero value', poplatok: 0, expected: 0 },
+    { description: 'very small decimal values', poplatok: 0.01, expected: 1 },
+    { description: 'large values', poplatok: 9999.99, expected: 999_999 },
+  ])('should handle poplatok with $description', ({ poplatok, expected }) => {
     const mockData: NorisCommunalWasteTaxGrouped = {
       addresses: [
         {
@@ -1035,7 +1039,7 @@ describe('mapNorisToCommunalWasteDatabaseDetail', () => {
               pocet_nadob: 1,
               pocet_odvozov: 52,
               sadzba: 4.314,
-              poplatok: 0,
+              poplatok,
               druh_nadoby: 'N12',
             },
           ],
@@ -1045,60 +1049,6 @@ describe('mapNorisToCommunalWasteDatabaseDetail', () => {
 
     const result = mapNorisToCommunalWasteDatabaseDetail(mockData)
 
-    expect(result.addresses[0].containers[0].poplatok).toBe(0)
-  })
-
-  it('should handle poplatok with very small decimal values', () => {
-    const mockData: NorisCommunalWasteTaxGrouped = {
-      addresses: [
-        {
-          addressDetail: {
-            street: 'Test Street',
-            orientationNumber: '1',
-          },
-          containers: [
-            {
-              objem_nadoby: 120,
-              pocet_nadob: 1,
-              pocet_odvozov: 52,
-              sadzba: 4.314,
-              poplatok: 0.01,
-              druh_nadoby: 'N12',
-            },
-          ],
-        },
-      ],
-    } as NorisCommunalWasteTaxGrouped
-
-    const result = mapNorisToCommunalWasteDatabaseDetail(mockData)
-
-    expect(result.addresses[0].containers[0].poplatok).toBe(1)
-  })
-
-  it('should handle poplatok with large values', () => {
-    const mockData: NorisCommunalWasteTaxGrouped = {
-      addresses: [
-        {
-          addressDetail: {
-            street: 'Test Street',
-            orientationNumber: '1',
-          },
-          containers: [
-            {
-              objem_nadoby: 120,
-              pocet_nadob: 1,
-              pocet_odvozov: 52,
-              sadzba: 4.314,
-              poplatok: 9999.99,
-              druh_nadoby: 'N12',
-            },
-          ],
-        },
-      ],
-    } as NorisCommunalWasteTaxGrouped
-
-    const result = mapNorisToCommunalWasteDatabaseDetail(mockData)
-
-    expect(result.addresses[0].containers[0].poplatok).toBe(999_999)
+    expect(result.addresses[0].containers[0].poplatok).toBe(expected)
   })
 })

--- a/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
+++ b/nest-tax-backend/src/payment/__tests__/payment.service.spec.ts
@@ -33,12 +33,14 @@ const createMockBaConfigService = () => ({
       key: 'mock-value',
       signCert: 'mock-value',
       merchantNumber: '12345',
+      // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- mock config value for tests, not a real credential
       passphrase: 'mock-value',
     },
     [TaxType.KO]: {
       key: 'mock-value',
       signCert: 'mock-value',
       merchantNumber: '12345',
+      // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- mock config value for tests, not a real credential
       passphrase: 'mock-value',
     },
   },
@@ -790,42 +792,40 @@ describe('PaymentService', () => {
       expect(resultKO).toBe('https://example.com/payment/response/KO')
     })
 
-    it('should handle base URL with query parameters', () => {
-      baConfigService.paygate.redirectUrl =
-        'https://example.com/payment/response?param=value'
+    it.each([
+      {
+        scenario: 'with query parameters',
+        redirectUrl: 'https://example.com/payment/response?param=value',
+        taxType: TaxType.DZN,
+        expected: 'https://example.com/payment/response/DZN',
+      },
+      {
+        scenario: 'with hash',
+        redirectUrl: 'https://example.com/payment/response#section',
+        taxType: TaxType.DZN,
+        expected: 'https://example.com/payment/response/DZN',
+      },
+      {
+        scenario: 'with port number',
+        redirectUrl: 'http://payments.example.com:8080/payment/response',
+        taxType: TaxType.KO,
+        expected: 'http://payments.example.com:8080/payment/response/KO',
+      },
+      {
+        scenario: 'ending with multiple slashes',
+        redirectUrl: 'https://example.com/payment/response//',
+        taxType: TaxType.DZN,
+        expected: 'https://example.com/payment/response//DZN',
+      },
+    ])(
+      'should handle base URL $scenario',
+      ({ redirectUrl, taxType, expected }) => {
+        baConfigService.paygate.redirectUrl = redirectUrl
 
-      const result = service['getRedirectUrl'](TaxType.DZN)
+        const result = service['getRedirectUrl'](taxType)
 
-      expect(result).toBe('https://example.com/payment/response/DZN')
-    })
-
-    it('should handle base URL with hash', () => {
-      baConfigService.paygate.redirectUrl =
-        'https://example.com/payment/response#section'
-
-      const result = service['getRedirectUrl'](TaxType.DZN)
-
-      expect(result).toBe('https://example.com/payment/response/DZN')
-    })
-
-    it('should handle base URL with port number', () => {
-      baConfigService.paygate.redirectUrl =
-        'http://payments.example.com:8080/payment/response'
-
-      const result = service['getRedirectUrl'](TaxType.KO)
-
-      expect(result).toBe(
-        'http://payments.example.com:8080/payment/response/KO',
-      )
-    })
-
-    it('should handle base URL ending with multiple slashes', () => {
-      baConfigService.paygate.redirectUrl =
-        'https://example.com/payment/response//'
-
-      const result = service['getRedirectUrl'](TaxType.DZN)
-
-      expect(result).toBe('https://example.com/payment/response//DZN')
-    })
+        expect(result).toBe(expected)
+      },
+    )
   })
 })

--- a/nest-tax-backend/src/payment/subservices/__tests__/gpwebpay.subservice.spec.ts
+++ b/nest-tax-backend/src/payment/subservices/__tests__/gpwebpay.subservice.spec.ts
@@ -20,12 +20,14 @@ describe('GpWebpaySubservice', () => {
         key: 'mock-key',
         signCert: 'mock-cert',
         merchantNumber: 'mock-merchant-number',
+        // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- mock config value for tests, not a real credential
         passphrase: 'mock-passphrase',
       },
       [TaxType.KO]: {
         key: 'mock-key-ko',
         signCert: 'mock-cert-ko',
         merchantNumber: 'mock-merchant-number-ko',
+        // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- mock config value for tests, not a real credential
         passphrase: 'mock-passphrase-ko',
       },
     },

--- a/nest-tax-backend/src/tasks/subservices/__tests__/tax-import-helper.service.spec.ts
+++ b/nest-tax-backend/src/tasks/subservices/__tests__/tax-import-helper.service.spec.ts
@@ -83,96 +83,61 @@ describe('TaxImportHelperService', () => {
       ])
     })
 
-    it('should return false when current time is before the window', async () => {
-      // Set time to 6:00 in Bratislava (before 7:00 start)
-      // 6:00 CET = 5:00 UTC
-      jest.setSystemTime(new Date('2025-01-15T05:00:00.000Z'))
+    it.each([
+      {
+        scenario: 'before the window',
+        // Set time to 6:00 in Bratislava (before 7:00 start)
+        // 6:00 CET = 5:00 UTC
+        now: '2025-01-15T05:00:00.000Z',
+        expected: false,
+      },
+      {
+        scenario: 'after the window',
+        // Set time to 21:00 in Bratislava (after 20:00 end)
+        // 21:00 CET = 20:00 UTC
+        now: '2025-01-15T20:00:00.000Z',
+        expected: false,
+      },
+      {
+        scenario: 'exactly at start hour',
+        // Set time to 7:00 in Bratislava (exactly at start)
+        // 7:00 CET = 6:00 UTC
+        now: '2025-01-15T06:00:00.000Z',
+        expected: true,
+      },
+      {
+        scenario: 'exactly at end hour',
+        // Set time to 20:00 in Bratislava (exactly at end, should be excluded)
+        // 20:00 CET = 19:00 UTC
+        now: '2025-01-15T19:00:00.000Z',
+        expected: false,
+      },
+      {
+        scenario: 'within the window in summer time (CEST)',
+        // Set time to 12:00 in Bratislava during summer (CEST, UTC+2)
+        // 12:00 CEST = 10:00 UTC
+        // Using a date in July (summer time)
+        now: '2025-07-15T10:00:00.000Z',
+        expected: true,
+      },
+    ])(
+      'should return $expected when current time is $scenario',
+      async ({ now, expected }) => {
+        jest.setSystemTime(new Date(now))
 
-      const mockConfig = {
-        TAX_IMPORT_WINDOW_START_HOUR: '7',
-        TAX_IMPORT_WINDOW_END_HOUR: '20',
-      }
-      jest
-        .spyOn(databaseSubservice, 'getConfigByKeys')
-        .mockResolvedValue(mockConfig)
+        const mockConfig = {
+          TAX_IMPORT_WINDOW_START_HOUR: '7',
+          TAX_IMPORT_WINDOW_END_HOUR: '20',
+        }
+        jest
+          .spyOn(databaseSubservice, 'getConfigByKeys')
+          .mockResolvedValue(mockConfig)
 
-      const result = await service.isWithinImportWindow()
+        const result = await service.isWithinImportWindow()
 
-      expect(result).toBe(false)
-    })
-
-    it('should return false when current time is after the window', async () => {
-      // Set time to 21:00 in Bratislava (after 20:00 end)
-      // 21:00 CET = 20:00 UTC
-      jest.setSystemTime(new Date('2025-01-15T20:00:00.000Z'))
-
-      const mockConfig = {
-        TAX_IMPORT_WINDOW_START_HOUR: '7',
-        TAX_IMPORT_WINDOW_END_HOUR: '20',
-      }
-      jest
-        .spyOn(databaseSubservice, 'getConfigByKeys')
-        .mockResolvedValue(mockConfig)
-
-      const result = await service.isWithinImportWindow()
-
-      expect(result).toBe(false)
-    })
-
-    it('should return true when current time is exactly at start hour', async () => {
-      // Set time to 7:00 in Bratislava (exactly at start)
-      // 7:00 CET = 6:00 UTC
-      jest.setSystemTime(new Date('2025-01-15T06:00:00.000Z'))
-
-      const mockConfig = {
-        TAX_IMPORT_WINDOW_START_HOUR: '7',
-        TAX_IMPORT_WINDOW_END_HOUR: '20',
-      }
-      jest
-        .spyOn(databaseSubservice, 'getConfigByKeys')
-        .mockResolvedValue(mockConfig)
-
-      const result = await service.isWithinImportWindow()
-
-      expect(result).toBe(true)
-    })
-
-    it('should return false when current time is exactly at end hour', async () => {
-      // Set time to 20:00 in Bratislava (exactly at end, should be excluded)
-      // 20:00 CET = 19:00 UTC
-      jest.setSystemTime(new Date('2025-01-15T19:00:00.000Z'))
-
-      const mockConfig = {
-        TAX_IMPORT_WINDOW_START_HOUR: '7',
-        TAX_IMPORT_WINDOW_END_HOUR: '20',
-      }
-      jest
-        .spyOn(databaseSubservice, 'getConfigByKeys')
-        .mockResolvedValue(mockConfig)
-
-      const result = await service.isWithinImportWindow()
-
-      expect(result).toBe(false)
-    })
-
-    it('should handle summer time (CEST) correctly', async () => {
-      // Set time to 12:00 in Bratislava during summer (CEST, UTC+2)
-      // 12:00 CEST = 10:00 UTC
-      // Using a date in July (summer time)
-      jest.setSystemTime(new Date('2025-07-15T10:00:00.000Z'))
-
-      const mockConfig = {
-        TAX_IMPORT_WINDOW_START_HOUR: '7',
-        TAX_IMPORT_WINDOW_END_HOUR: '20',
-      }
-      jest
-        .spyOn(databaseSubservice, 'getConfigByKeys')
-        .mockResolvedValue(mockConfig)
-
-      const result = await service.isWithinImportWindow()
-
-      expect(result).toBe(true)
-    })
+        expect(result).toBe(expected)
+      },
+    )
 
     it('should propagate error when getConfigByKeys fails', async () => {
       jest.setSystemTime(new Date('2025-01-15T11:00:00.000Z'))

--- a/nest-tax-backend/src/tasks/subservices/tax-import.tasks.service.ts
+++ b/nest-tax-backend/src/tasks/subservices/tax-import.tasks.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common'
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
-import _ from 'lodash'
+import groupBy from 'lodash/groupBy'
 
 import { Prisma, TaxType } from '../../generated/prisma/client'
 import { CustomErrorNorisTypesEnum } from '../../noris/noris.errors'
@@ -232,7 +232,7 @@ export default class TaxImportTasksService {
     }
 
     // Group by year and taxType to batch the import calls
-    const grouped = _.groupBy(
+    const grouped = groupBy(
       missingTaxAttempts,
       (item) => `${item.year}-${item.taxType}`,
     )

--- a/nest-tax-backend/src/tax/__tests__/tax.service.spec.ts
+++ b/nest-tax-backend/src/tax/__tests__/tax.service.spec.ts
@@ -158,163 +158,104 @@ describe('TaxService', () => {
       expect(result.taxAdministrator).toBeNull()
     })
 
-    it('should set taxPayerWasUpdated to false when TaxPayer has same createdAt and updatedAt', async () => {
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:00.000Z'), // Same as createdAt
-      })
+    // taxPayerWasUpdated is true only when updatedAt is more than 1 second after
+    // createdAt.
+    it.each([
+      {
+        scenario: 'updatedAt is the same as createdAt',
+        updatedAt: '2025-01-01T10:00:00.000Z',
+        expected: 'LOOKING_FOR_YOUR_TAX',
+      },
+      {
+        scenario: 'updatedAt is exactly 1 second after createdAt',
+        updatedAt: '2025-01-01T10:00:01.000Z',
+        expected: 'LOOKING_FOR_YOUR_TAX',
+      },
+      {
+        scenario: 'updatedAt is more than 1 second after createdAt',
+        updatedAt: '2025-01-01T10:00:02.000Z',
+        expected: 'TAX_NOT_ON_RECORD',
+      },
+      {
+        scenario: 'updatedAt is less than 1 second after createdAt',
+        updatedAt: '2025-01-01T10:00:00.500Z',
+        expected: 'LOOKING_FOR_YOUR_TAX',
+      },
+    ])(
+      'should return $expected when $scenario',
+      async ({ updatedAt, expected }) => {
+        const mockTaxPayer = createMockTaxPayer({
+          createdAt: new Date('2025-01-01T10:00:00.000Z'),
+          updatedAt: new Date(updatedAt),
+        })
 
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
+        prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
+        prismaMock.tax.findMany.mockResolvedValue([])
 
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.DZN,
-      )
+        const result = await service.getListOfTaxesByBirthnumberAndType(
+          '123456/789',
+          TaxType.DZN,
+        )
 
-      expect(result.availabilityStatus).toBe('LOOKING_FOR_YOUR_TAX')
-    })
+        expect(result.availabilityStatus).toBe(expected)
+      },
+    )
 
-    it('should set taxPayerWasUpdated to false when updatedAt is exactly 1 second after createdAt', async () => {
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:01.000Z'), // Exactly 1000ms later
-      })
+    // Empty Taxes Array Scenarios. The inclusion period is between Feb 1 and
+    // Jul 1 (exclusive), so the current date drives shouldAddCurrentYear.
+    it.each([
+      {
+        scenario: 'the current date is within the tax inclusion period',
+        now: '2025-03-01T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:00.000Z', // not updated
+        expected: 'LOOKING_FOR_YOUR_TAX',
+      },
+      {
+        scenario: 'the current date is outside the tax inclusion period',
+        now: '2025-12-01T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:02.000Z', // updated -> true
+        expected: 'TAX_NOT_ON_RECORD',
+      },
+      {
+        scenario: 'shouldAddCurrentYear is true and taxPayerWasUpdated is true',
+        now: '2025-03-10T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:02.000Z',
+        expected: 'LOOKING_FOR_YOUR_TAX',
+      },
+      {
+        scenario:
+          'shouldAddCurrentYear is false and taxPayerWasUpdated is false',
+        now: '2025-12-10T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:00.500Z',
+        expected: 'LOOKING_FOR_YOUR_TAX',
+      },
+      {
+        scenario:
+          'shouldAddCurrentYear is false and taxPayerWasUpdated is true',
+        now: '2025-12-10T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:02.000Z',
+        expected: 'TAX_NOT_ON_RECORD',
+      },
+    ])(
+      'should return $expected when no taxes exist and $scenario',
+      async ({ now, updatedAt, expected }) => {
+        jest.setSystemTime(new Date(now))
 
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
+        const mockTaxPayer = createMockTaxPayer({
+          createdAt: new Date('2025-01-01T10:00:00.000Z'),
+          updatedAt: new Date(updatedAt),
+        })
+        prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
+        prismaMock.tax.findMany.mockResolvedValue([])
 
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.DZN,
-      )
+        const result = await service.getListOfTaxesByBirthnumberAndType(
+          '123456/789',
+          TaxType.DZN,
+        )
 
-      expect(result.availabilityStatus).toBe('LOOKING_FOR_YOUR_TAX')
-    })
-
-    it('should set taxPayerWasUpdated to true when updatedAt is more than 1 second after createdAt', async () => {
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:02.000Z'), // 2000ms later
-      })
-
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.DZN,
-      )
-
-      expect(result.availabilityStatus).toBe('TAX_NOT_ON_RECORD')
-    })
-
-    it('should set taxPayerWasUpdated to false when updatedAt is less than 1 second after createdAt', async () => {
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:00.500Z'), // 500ms later
-      })
-
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.DZN,
-      )
-
-      expect(result.availabilityStatus).toBe('LOOKING_FOR_YOUR_TAX')
-    })
-
-    it('should set shouldAddCurrentYear to true when current date is within tax inclusion period', async () => {
-      // Within period: between Feb 1 and Jul 1 (exclusive). Use March 1st.
-      jest.setSystemTime(new Date('2025-03-01T12:00:00.000Z'))
-
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:00.000Z'), // not updated
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.DZN,
-      )
-
-      // With no taxes and shouldAddCurrentYear=true => LOOKING_FOR_YOUR_TAX
-      expect(result.availabilityStatus).toBe('LOOKING_FOR_YOUR_TAX')
-    })
-
-    it('should set shouldAddCurrentYear to false when current date is outside tax inclusion period', async () => {
-      jest.setSystemTime(new Date('2025-12-01T12:00:00.000Z'))
-
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:02.000Z'), // updated -> true
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.DZN,
-      )
-
-      expect(result.availabilityStatus).toBe('TAX_NOT_ON_RECORD')
-    })
-
-    // Empty Taxes Array Scenarios
-    it('should return LOOKING_FOR_YOUR_TAX when no taxes exist and shouldAddCurrentYear is true and taxPayerWasUpdated is true', async () => {
-      // Set within inclusion period
-      jest.setSystemTime(new Date('2025-03-10T12:00:00.000Z'))
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:02.000Z'), // updated => true
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.DZN,
-      )
-      expect(result.availabilityStatus).toBe('LOOKING_FOR_YOUR_TAX')
-    })
-
-    it('should return LOOKING_FOR_YOUR_TAX when no taxes exist and shouldAddCurrentYear is false and taxPayerWasUpdated is false', async () => {
-      // Outside inclusion period
-      jest.setSystemTime(new Date('2025-12-10T12:00:00.000Z'))
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:00.500Z'), // not updated
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.DZN,
-      )
-      expect(result.availabilityStatus).toBe('LOOKING_FOR_YOUR_TAX')
-    })
-
-    it('should return TAX_NOT_ON_RECORD status when no taxes exist and shouldAddCurrentYear is false and taxPayerWasUpdated is true', async () => {
-      // Outside inclusion period
-      jest.setSystemTime(new Date('2025-12-10T12:00:00.000Z'))
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:02.000Z'), // updated
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.DZN,
-      )
-      expect(result.availabilityStatus).toBe('TAX_NOT_ON_RECORD')
-    })
+        expect(result.availabilityStatus).toBe(expected)
+      },
+    )
 
     it('should throw ForbiddenException when birth number is empty for KO tax type', async () => {
       const forbiddenExceptionSpy = jest.spyOn(
@@ -386,104 +327,59 @@ describe('TaxService', () => {
       )
     })
 
-    it('should set shouldAddCurrentYear to true when current date is within tax inclusion period for KO tax type', async () => {
-      // Within period: between Feb 1 and Jul 1 (exclusive). Use March 1st.
-      jest.setSystemTime(new Date('2025-03-01T12:00:00.000Z'))
+    it.each([
+      {
+        scenario: 'the current date is within the tax inclusion period',
+        now: '2025-03-01T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:00.000Z', // not updated
+        expected: TaxAvailabilityStatus.LOOKING_FOR_YOUR_TAX,
+      },
+      {
+        scenario: 'the current date is outside the tax inclusion period',
+        now: '2025-12-01T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:02.000Z', // updated -> true
+        expected: TaxAvailabilityStatus.TAX_NOT_ON_RECORD,
+      },
+      {
+        scenario: 'shouldAddCurrentYear is true and taxPayerWasUpdated is true',
+        now: '2025-03-10T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:02.000Z',
+        expected: TaxAvailabilityStatus.LOOKING_FOR_YOUR_TAX,
+      },
+      {
+        scenario:
+          'shouldAddCurrentYear is false and taxPayerWasUpdated is false',
+        now: '2025-12-10T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:00.500Z',
+        expected: TaxAvailabilityStatus.LOOKING_FOR_YOUR_TAX,
+      },
+      {
+        scenario:
+          'shouldAddCurrentYear is false and taxPayerWasUpdated is true',
+        now: '2025-12-10T12:00:00.000Z',
+        updatedAt: '2025-01-01T10:00:02.000Z',
+        expected: TaxAvailabilityStatus.TAX_NOT_ON_RECORD,
+      },
+    ])(
+      'should return $expected when no KO taxes exist and $scenario',
+      async ({ now, updatedAt, expected }) => {
+        jest.setSystemTime(new Date(now))
 
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:00.000Z'), // not updated
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
+        const mockTaxPayer = createMockTaxPayer({
+          createdAt: new Date('2025-01-01T10:00:00.000Z'),
+          updatedAt: new Date(updatedAt),
+        })
+        prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
+        prismaMock.tax.findMany.mockResolvedValue([])
 
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.KO,
-      )
+        const result = await service.getListOfTaxesByBirthnumberAndType(
+          '123456/789',
+          TaxType.KO,
+        )
 
-      // With no taxes and shouldAddCurrentYear=true => LOOKING_FOR_YOUR_TAX
-      expect(result.availabilityStatus).toBe(
-        TaxAvailabilityStatus.LOOKING_FOR_YOUR_TAX,
-      )
-    })
-
-    it('should set shouldAddCurrentYear to false when current date is outside tax inclusion period for KO tax type', async () => {
-      jest.setSystemTime(new Date('2025-12-01T12:00:00.000Z'))
-
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:02.000Z'), // updated -> true
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.KO,
-      )
-
-      expect(result.availabilityStatus).toBe(
-        TaxAvailabilityStatus.TAX_NOT_ON_RECORD,
-      )
-    })
-
-    it('should return LOOKING_FOR_YOUR_TAX when no KO taxes exist and shouldAddCurrentYear is true and taxPayerWasUpdated is true', async () => {
-      // Set within inclusion period
-      jest.setSystemTime(new Date('2025-03-10T12:00:00.000Z'))
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:02.000Z'), // updated => true
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.KO,
-      )
-      expect(result.availabilityStatus).toBe(
-        TaxAvailabilityStatus.LOOKING_FOR_YOUR_TAX,
-      )
-    })
-
-    it('should return LOOKING_FOR_YOUR_TAX when no KO taxes exist and shouldAddCurrentYear is false and taxPayerWasUpdated is false', async () => {
-      // Outside inclusion period
-      jest.setSystemTime(new Date('2025-12-10T12:00:00.000Z'))
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:00.500Z'), // not updated
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.KO,
-      )
-      expect(result.availabilityStatus).toBe(
-        TaxAvailabilityStatus.LOOKING_FOR_YOUR_TAX,
-      )
-    })
-
-    it('should return TAX_NOT_ON_RECORD status when no KO taxes exist and shouldAddCurrentYear is false and taxPayerWasUpdated is true', async () => {
-      // Outside inclusion period
-      jest.setSystemTime(new Date('2025-12-10T12:00:00.000Z'))
-      const mockTaxPayer = createMockTaxPayer({
-        createdAt: new Date('2025-01-01T10:00:00.000Z'),
-        updatedAt: new Date('2025-01-01T10:00:02.000Z'), // updated
-      })
-      prismaMock.taxPayer.findUnique.mockResolvedValue(mockTaxPayer)
-      prismaMock.tax.findMany.mockResolvedValue([])
-
-      const result = await service.getListOfTaxesByBirthnumberAndType(
-        '123456/789',
-        TaxType.KO,
-      )
-      expect(result.availabilityStatus).toBe(
-        TaxAvailabilityStatus.TAX_NOT_ON_RECORD,
-      )
-    })
+        expect(result.availabilityStatus).toBe(expected)
+      },
+    )
 
     it('should process existing taxes and return AVAILABLE status when taxes exist', async () => {
       // Set outside inclusion period to prevent current year tax addition

--- a/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
+++ b/nest-tax-backend/src/tax/utils/__tests__/unified-tax.util.spec.ts
@@ -773,7 +773,7 @@ describe('UnifiedTaxUtil', () => {
         })
 
         describe('after first payment due threshold', () => {
-          it('', () => {
+          it('without payment', () => {
             const output = getTaxDetailPure({
               ...defaultInputRealEstate,
               taxPayments: [],

--- a/nest-tax-backend/src/tax/utils/helpers/__tests__/tax.helper.spec.ts
+++ b/nest-tax-backend/src/tax/utils/helpers/__tests__/tax.helper.spec.ts
@@ -9,36 +9,21 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 
 describe('checkTaxDateInclusion', () => {
-  it('should return true for shouldAddCurrentYear when current time is within the date range', () => {
-    const mockCurrentTime = dayjs.tz('2024-08-15', 'Europe/Bratislava')
+  it.each([
+    { position: 'within', currentTime: '2024-08-15', expected: true },
+    { position: 'before', currentTime: '2024-08-09', expected: false },
+    { position: 'after', currentTime: '2024-08-21', expected: false },
+  ])(
+    'should return $expected for shouldAddCurrentYear when current time is $position the date range',
+    ({ currentTime, expected }) => {
+      const mockCurrentTime = dayjs.tz(currentTime, 'Europe/Bratislava')
 
-    const result = checkTaxDateInclusion(mockCurrentTime, {
-      from: { month: 8, day: 10 },
-      to: { month: 8, day: 20 },
-    })
+      const result = checkTaxDateInclusion(mockCurrentTime, {
+        from: { month: 8, day: 10 },
+        to: { month: 8, day: 20 },
+      })
 
-    expect(result).toBe(true)
-  })
-
-  it('should return false for shouldAddCurrentYear when current time is before the date range', () => {
-    const mockCurrentTime = dayjs.tz('2024-08-09', 'Europe/Bratislava')
-
-    const result = checkTaxDateInclusion(mockCurrentTime, {
-      from: { month: 8, day: 10 },
-      to: { month: 8, day: 20 },
-    })
-
-    expect(result).toBe(false)
-  })
-
-  it('should return false for shouldAddCurrentYear when current time is after the date range', () => {
-    const mockCurrentTime = dayjs.tz('2024-08-21', 'Europe/Bratislava')
-
-    const result = checkTaxDateInclusion(mockCurrentTime, {
-      from: { month: 8, day: 10 },
-      to: { month: 8, day: 20 },
-    })
-
-    expect(result).toBe(false)
-  })
+      expect(result).toBe(expected)
+    },
+  )
 })

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -130,7 +130,7 @@
         "adm-zip": "0.5.17",
         "ajv": "8.20.0",
         "ajv-formats": "3.0.1",
-        "dayjs": "1.11.20",
+        "dayjs": "1.11.21",
         "eta": "3.5.0",
         "expr-eval": "2.0.2",
         "ibantools": "4.5.1",
@@ -187,7 +187,7 @@
         "pdf-to-img": "6.2.0",
         "playwright": "1.59.1",
         "postcss": "8.5.14",
-        "prettier": "3.8.3",
+        "prettier": "3.9.6",
         "prompts": "2.4.2",
         "react": "19.2.6",
         "react-dom": "19.2.6",
@@ -7461,7 +7461,7 @@
       "version": "1.0.0",
       "license": "EUPL-1.2",
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "2.39.1",
+        "@openapitools/openapi-generator-cli": "2.40.1",
         "@types/app-root-dir": "0.1.4",
         "@types/fs-extra": "11.0.4",
         "@types/node": "24.13.3",
@@ -7471,9 +7471,9 @@
         "chalk": "5.6.2",
         "commander": "15.0.0",
         "diff": "9.0.0",
-        "fs-extra": "11.3.6",
+        "fs-extra": "11.4.0",
         "npm-run-all": "4.1.5",
-        "prettier": "3.9.5",
+        "prettier": "3.9.6",
         "rimraf": "6.1.3",
         "tsx": "4.23.1",
         "typescript": "6.0.3"
@@ -14859,27 +14859,8 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17162,17 +17143,6 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "node_modules/@next/bundle-analyzer": {
@@ -20313,6 +20283,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
@@ -20406,15 +20440,6 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.162",
@@ -22893,41 +22918,86 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-3.0.5.tgz",
-      "integrity": "sha512-dI62Ff3zMezUToi161hs2i1HX1ie8Ia2hO0jtNBfdgRBicAG4ydy2WPt0rMTrAe3ZrlqhpAO3w1jcQEdneYoFA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
-        "@eslint-community/regexpp": "4.12.1",
-        "builtin-modules": "3.3.0",
-        "bytes": "3.1.2",
-        "functional-red-black-tree": "1.0.1",
-        "jsx-ast-utils-x": "0.1.0",
-        "lodash.merge": "4.6.2",
-        "minimatch": "9.0.5",
-        "scslre": "0.3.0",
-        "semver": "7.7.2",
-        "typescript": ">=5"
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.7.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.8.5",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
       },
       "peerDependencies": {
-        "eslint": "^8.0.0 || ^9.0.0"
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
-    "node_modules/eslint-plugin-sonarjs/node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+    "node_modules/eslint-plugin-sonarjs/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -86,7 +86,7 @@
         "yet-another-react-lightbox": "3.32.0"
       },
       "devDependencies": {
-        "@bratislava/eslint-config-next": "0.14.0",
+        "@bratislava/eslint-config-next": "0.19.1",
         "@graphql-codegen/cli": "6.3.0",
         "@graphql-codegen/client-preset": "5.3.0",
         "@graphql-codegen/typescript-graphql-request": "7.0.0",
@@ -14280,103 +14280,55 @@
       }
     },
     "node_modules/@bratislava/eslint-config": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.14.0.tgz",
-      "integrity": "sha512-R42oyLi2bu3Nf9DqvrbHIQ+hR4HO1ZC84/xJwW8eA0S3cbD1MTNJ2Mf1u5YFF21TopJvwp3QUzd5LLA2VmUU6w==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config/-/eslint-config-0.19.1.tgz",
+      "integrity": "sha512-cSOFkEsyBqzS6JedBZqnD0YbcQkcU3lFxAGWnivgms5NbzUsAUdW9XuT8jsyFkgEgfNTQs3vSJ/yVWZup/6irw==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@eslint/js": "9.34.0",
-        "@eslint/markdown": "6.6.0",
+        "@eslint/js": "9.39.5",
+        "@eslint/markdown": "8.0.3",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-import": "2.32.0",
-        "eslint-plugin-no-unsanitized": "4.1.4",
-        "eslint-plugin-security": "3.0.1",
-        "eslint-plugin-simple-import-sort": "12.1.1",
-        "eslint-plugin-sonarjs": "3.0.5",
-        "globals": "16.5.0",
-        "typescript-eslint": "8.52.0"
+        "eslint-plugin-no-unsanitized": "4.1.5",
+        "eslint-plugin-security": "4.0.1",
+        "eslint-plugin-simple-import-sort": "13.0.0",
+        "eslint-plugin-sonarjs": "4.2.0",
+        "globals": "17.9.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "eslint": ">= 9",
-        "typescript": ">= 5"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@bratislava/eslint-config-next": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-next/-/eslint-config-next-0.14.0.tgz",
-      "integrity": "sha512-qEoB8xWd+k+0pISgz28i8jWjNMo87wAupmE9nUzYw+OvktD+WlHe5MrKIAusl3QIsYm0gaislk1+5dHHLmfrYg==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@bratislava/eslint-config-next/-/eslint-config-next-0.19.1.tgz",
+      "integrity": "sha512-BeFI7L9yxrCfg6hAFY/aURtRIAJo7SZrTFn3DkY2WhN+XPI/yFmlprTlVOsX6QJQPkFOsg9NihjHVoArYE3iLA==",
       "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
-        "@bratislava/eslint-config": "0.14.0",
-        "@next/eslint-plugin-next": "15.5.2",
-        "@tanstack/eslint-plugin-query": "5.91.2",
-        "eslint-plugin-i18next": "6.1.3",
+        "@bratislava/eslint-config": "0.19.1",
+        "@tanstack/eslint-plugin-query": "5.101.4",
+        "eslint-plugin-i18next": "6.1.5",
         "eslint-plugin-jsx-a11y": "6.10.2",
         "eslint-plugin-react": "7.37.5",
-        "eslint-plugin-react-hooks": "7.0.1",
-        "globals": "16.5.0"
+        "eslint-plugin-react-hooks": "7.1.1",
+        "globals": "17.9.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
+        "@next/eslint-plugin-next": ">= 16",
         "eslint": ">= 9",
         "eslint-plugin-better-tailwindcss": ">= 4.0.0",
-        "typescript": ">= 5"
-      }
-    },
-    "node_modules/@bratislava/eslint-config-next/node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-glob": "3.3.1"
-      }
-    },
-    "node_modules/@bratislava/eslint-config-next/node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/@bratislava/eslint-config-next/node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@bratislava/eslint-config-next/node_modules/@tanstack/eslint-plugin-query": {
-      "version": "5.91.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^8.44.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
+        "typescript": ">= 5",
+        "typescript-eslint": "^8.61.0"
       }
     },
     "node_modules/@bratislava/eslint-config-next/node_modules/brace-expansion": {
@@ -14453,28 +14405,10 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
-    "node_modules/@bratislava/eslint-config-next/node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.24.4",
-        "@babel/parser": "^7.24.4",
-        "hermes-parser": "^0.25.1",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-validation-error": "^3.5.0 || ^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
-      }
-    },
     "node_modules/@bratislava/eslint-config-next/node_modules/globals": {
-      "version": "16.5.0",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14521,73 +14455,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/@bratislava/eslint-config/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
-      "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.52.0",
-        "@typescript-eslint/visitor-keys": "8.52.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/@typescript-eslint/types": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
-      "integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
-      "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.52.0",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@bratislava/eslint-config/node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14595,223 +14466,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/typescript-eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.52.0.tgz",
-      "integrity": "sha512-atlQQJ2YkO4pfTVQmQ+wvYQwexPDOIgo+RaVcD7gHgzy/IQA+XTyuxNM9M9TVXvttkF7koBHmcwisKdOAf2EcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.52.0",
-        "@typescript-eslint/parser": "8.52.0",
-        "@typescript-eslint/typescript-estree": "8.52.0",
-        "@typescript-eslint/utils": "8.52.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz",
-      "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.52.0",
-        "@typescript-eslint/type-utils": "8.52.0",
-        "@typescript-eslint/utils": "8.52.0",
-        "@typescript-eslint/visitor-keys": "8.52.0",
-        "ignore": "^7.0.5",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.52.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.52.0.tgz",
-      "integrity": "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.52.0",
-        "@typescript-eslint/typescript-estree": "8.52.0",
-        "@typescript-eslint/utils": "8.52.0",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
-      "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.52.0",
-        "@typescript-eslint/types": "8.52.0",
-        "@typescript-eslint/typescript-estree": "8.52.0",
-        "@typescript-eslint/visitor-keys": "8.52.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
-      "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.52.0",
-        "@typescript-eslint/tsconfig-utils": "8.52.0",
-        "@typescript-eslint/types": "8.52.0",
-        "@typescript-eslint/visitor-keys": "8.52.0",
-        "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
-      "integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.52.0",
-        "@typescript-eslint/types": "^8.52.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
-      "integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@bratislava/eslint-config/node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
-      "integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.52.0",
-        "@typescript-eslint/types": "8.52.0",
-        "@typescript-eslint/typescript-estree": "8.52.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@croct/json": {
@@ -15104,16 +14758,16 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/css-tree": {
@@ -15223,9 +14877,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15236,26 +14890,29 @@
       }
     },
     "node_modules/@eslint/markdown": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-6.6.0.tgz",
-      "integrity": "sha512-IsWPy2jU3gaQDlioDC4sT4I4kG1hX1OMWs/q2sWwJrPoMASHW/Z4SDw+6Aql6EsHejGbagYuJbFq9Zvx+Y1b1Q==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.3.tgz",
+      "integrity": "sha512-rBTSSShrq7e4O+PWfeE4azH4/CWPNrC+VGxBXiW00o3vYVJnznsZiDayj3KC9JztIMVRZxZHn2nrDIUau/4j7A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
         "examples/*"
       ],
       "dependencies": {
-        "@eslint/core": "^0.14.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "github-slugger": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-frontmatter": "^2.0.1",
-        "mdast-util-gfm": "^3.0.0",
+        "mdast-util-gfm": "^3.1.0",
+        "mdast-util-math": "^3.0.0",
         "micromark-extension-frontmatter": "^2.0.0",
-        "micromark-extension-gfm": "^3.0.0"
+        "micromark-extension-gfm": "^3.0.0",
+        "micromark-extension-math": "^3.1.0",
+        "micromark-util-normalize-identifier": "^2.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -15269,30 +14926,17 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.2",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -17160,6 +16804,49 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
       "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.12.tgz",
+      "integrity": "sha512-uF2z/qAK2q7B5/6CpnFcBRX6jOq5iCO+Uqh1UkJhXljX1JwLarLYhhoJadO6dPb6moTprOKewMXheBcbIoSbug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "16.2.6",
@@ -20395,6 +20082,29 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.101.4.tgz",
+      "integrity": "sha512-jqAZJWXGd5PthJYH9wmC2O5Ry5xAN2/7zxi9qcANQ+Xix8V5JkqNRjZ8Fh+rYzqzVYGiHqbrHekt+uh38OZVpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.58.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "^5.4.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.100.9",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
@@ -20498,6 +20208,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
       "dev": true,
@@ -20581,13 +20298,82 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.1",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.1",
-        "@typescript-eslint/types": "^8.58.1",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -20602,12 +20388,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.1",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20618,7 +20406,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.1",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20632,8 +20422,36 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.1",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20645,14 +20463,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.1",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.1",
-        "@typescript-eslint/tsconfig-utils": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -20670,41 +20490,10 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -20715,14 +20504,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.1",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20737,11 +20528,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.1",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -20754,6 +20547,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -21369,13 +21164,26 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -22717,14 +22525,14 @@
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -22741,9 +22549,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22802,11 +22610,12 @@
       }
     },
     "node_modules/eslint-plugin-i18next": {
-      "version": "6.1.3",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.1.5.tgz",
+      "integrity": "sha512-xCTfstbK9ZpQ6UFT5S1s6zbZMhKn2o2jRSQYiU2UkV7wt8y1m3WjkUYGkGlipgRdFInYI9+LAqE+JQU/L73HmA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "lodash": "^4.17.21",
         "requireindex": "~1.1.0"
       },
       "engines": {
@@ -22848,9 +22657,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22882,19 +22691,39 @@
       }
     },
     "node_modules/eslint-plugin-no-unsanitized": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.4.tgz",
-      "integrity": "sha512-cjAoZoq3J+5KJuycYYOWrc0/OpZ7pl2Z3ypfFq4GtaAgheg+L7YGxUo2YS3avIvo/dYU5/zR2hXu3v81M9NxhQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz",
+      "integrity": "sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==",
       "dev": true,
       "license": "MPL-2.0",
       "peerDependencies": {
-        "eslint": "^8 || ^9"
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-security": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-3.0.1.tgz",
-      "integrity": "sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.1.tgz",
+      "integrity": "sha512-/lZCkOxPOWaf1jXAqgICrS8St3BMBccIPvhOSUYuV6VCr1o5nFVG998FnTLt6w2Nxb8Uo0nM8fzmnhp+GY/aEg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -22908,9 +22737,9 @@
       }
     },
     "node_modules/eslint-plugin-simple-import-sort": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
-      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-13.0.0.tgz",
+      "integrity": "sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -22942,29 +22771,6 @@
         "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
-    "node_modules/eslint-plugin-sonarjs/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
       "version": "17.8.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
@@ -22976,22 +22782,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/semver": {
@@ -23899,41 +23689,6 @@
         }
       }
     },
-    "node_modules/graphql-config/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/graphql-config/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/graphql-config/node_modules/minimatch": {
-      "version": "10.2.4",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/graphql-request": {
       "version": "7.4.0",
       "license": "MIT",
@@ -24064,7 +23819,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -24411,29 +24168,6 @@
         }
       }
     },
-    "node_modules/i18next-cli/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/i18next-cli/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/i18next-cli/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -24489,22 +24223,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/i18next-cli/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/i18next-cli/node_modules/path-scurry": {
@@ -25219,10 +24937,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -25787,6 +25507,33 @@
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keyv": {
@@ -26698,7 +26445,9 @@
       }
     },
     "node_modules/mdast-util-gfm": {
-      "version": "3.0.0",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
@@ -26780,6 +26529,26 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -27299,6 +27068,26 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.0",
       "funding": [
@@ -27534,7 +27323,9 @@
       "license": "MIT"
     },
     "node_modules/micromark-util-normalize-identifier": {
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -27681,14 +27472,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -29572,6 +29365,8 @@
     },
     "node_modules/requireindex": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -30364,6 +30159,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -30634,12 +30439,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -30650,6 +30457,8 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -30665,9 +30474,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -30814,16 +30623,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/tsconfig-paths-webpack-plugin/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -30850,16 +30649,6 @@
       },
       "bin": {
         "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/tslib": {
@@ -30959,6 +30748,31 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/ua-parser-js": {
@@ -31801,9 +31615,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/next/package.json
+++ b/next/package.json
@@ -35,7 +35,8 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3"
+    "@types/react-dom": "19.2.3",
+    "eslint-plugin-sonarjs": "4.2.0"
   },
   "dependencies": {
     "@aws-amplify/adapter-nextjs": "1.7.3",

--- a/next/package.json
+++ b/next/package.json
@@ -35,8 +35,7 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
-    "eslint-plugin-sonarjs": "4.2.0"
+    "@types/react-dom": "19.2.3"
   },
   "dependencies": {
     "@aws-amplify/adapter-nextjs": "1.7.3",
@@ -116,7 +115,7 @@
     "yet-another-react-lightbox": "3.32.0"
   },
   "devDependencies": {
-    "@bratislava/eslint-config-next": "0.14.0",
+    "@bratislava/eslint-config-next": "0.19.1",
     "@graphql-codegen/cli": "6.3.0",
     "@graphql-codegen/client-preset": "5.3.0",
     "@graphql-codegen/typescript-graphql-request": "7.0.0",

--- a/next/src/components/styleguide/showcases/MarkdownShowCase.tsx
+++ b/next/src/components/styleguide/showcases/MarkdownShowCase.tsx
@@ -18,7 +18,7 @@ const markdownShowcaseTabs = [
   { id: 'form-markdown', label: 'FormMarkdown' },
 ] as const
 
-const markdownVariants: { id: string; label: string; variant?: MarkdownProps['variant'] }[] = [
+const markdownVariants: { id: string; label: string; variant: MarkdownProps['variant'] }[] = [
   { id: 'small', label: 'Small', variant: 'small' },
   { id: 'default', label: 'Default', variant: 'default' },
   { id: 'accordion', label: 'Accordion', variant: 'accordion' },

--- a/next/src/frontend/utils/formFileUpload.ts
+++ b/next/src/frontend/utils/formFileUpload.ts
@@ -5,7 +5,6 @@ import {
   FileStatusType,
   UploadClientErrorReasonType,
 } from 'forms-shared/form-files/fileStatus'
-import flatten from 'lodash/flatten'
 import { extensions } from 'mime-types'
 import {
   GetFileResponseReducedDto,
@@ -135,12 +134,12 @@ const customMimeExtensions: Record<string, string[]> = {
  * The list must be filtered first, as some mimetypes (e.g. application/x-zip-compressed) supported
  * by BE are not present in this library, however are duplicates of other mimetypes (e.g. application/zip).
  */
-const supportedFileExtensions = flatten(
-  environment.formsMimetypes
-    .map((format) => extensions[format] ?? customMimeExtensions[format])
-    .filter(isDefined)
-    .map((extensionsList) => extensionsList.map((ext) => `.${ext}`)),
-).filter((extension) => !excludedFileExtensions.has(extension))
+const supportedFileExtensions = environment.formsMimetypes
+  .map((format) => extensions[format] ?? customMimeExtensions[format])
+  .filter(isDefined)
+  .map((extensionsList) => extensionsList.map((ext) => `.${ext}`))
+  .flat()
+  .filter((extension) => !excludedFileExtensions.has(extension))
 
 /**
  * Returns an overlap of globally supported file extensions and the file extensions defined in the field if provided.


### PR DESCRIPTION
If i want to use workspaces and TypeScript 7 in any library, the old version of SonarJS doesn't have the max version of TypeScript to <7, so if fetches 7 and fails (no ESLint API), the new version has it. So updated and fixed the issues.

Why we override the default ESLint packages is not documented yet, I will do it later on - https://github.com/bratislava/private-konto.bratislava.sk/issues/1700 

Fixes:
| Rule | Fix |
|---|---|
| `prefer-native-lodash-alternative` | `isArray()` → `Array.isArray()` (2×, admin spec); `flatten(x)` → `x.flat()` (formFileUpload) — plus the two now-unused imports |
| `no-default-utility-imports` | `import _ from 'lodash'` → `lodash/groupBy` (tax-import.tasks), `lodash/uniqBy` + `lodash/keyBy` (nases.service) |
| `no-hardcoded-passwords` | 5 disable comments on mock config/env values |
| `no-trivial-assertions` | `expect(true).toBe(true)` → `expect(() => …).not.toThrow()` (2×) |
| `no-empty-test-title` | `it('')` → `it('without payment')` |
| `no-duplicate-test-title` | 3 encode tests were titled "decoding" — renamed; 1 exact copy-paste duplicate test deleted |
| `prefer-specific-assertions` | `.not.toBe(null)` → `.not.toBeNull()` |
| `no-redundant-optional` | dropped `?` (the type already includes `undefined`) |
| `parameterized-tests` (10×) | parametrize them |
