### PR TITLE
Add deploy env files for nest-forms-backend (prototype)

### DIFF
--- a/nest-forms-backend/.env.deploy.development
+++ b/nest-forms-backend/.env.deploy.development
@@ -1,0 +1,50 @@
+# Non-secret env for the development cluster, read at deploy time by
+# infrastructure-deployment-configuration and turned into the app ConfigMap.
+# Secrets live in Passbolt, never here.
+
+NODE_OPTIONS=--max-old-space-size=7000
+MIMETYPE_WHITELIST=application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/jpg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed application/pkcs7-signature application/pkcs7-mime application/xml text/xml application/vnd.etsi.asic-e+zip application/vnd.etsi.asic-s+zip
+MAX_FILE_SIZE=524288000
+MAX_CUMULATIVE_FILE_SIZE=524288000
+NEST_CLAMAV_SCANNER=http://nest-clamav-scanner-app
+MINIO_PATH_STYLE=false
+
+PORT=3000
+NODE_ENV=development
+CLUSTER_ENV=dev
+USER_ACCOUNT_API=https://nest-city-account.dev.bratislava.sk
+SLOVENSKO_SK_CONTAINER_URI=https://fix.slovensko-sk-api.bratislava.sk
+NASES_RECIPIENT_ID=e264cea1-acdc-4db0-8901-275d15b1f48a
+NASES_RECIPIENT_URI=ico://sk/00603481
+
+MINIO_UNSCANNED_BUCKET=forms-dev-uploaded
+MINIO_SAFE_BUCKET=forms-dev-safe
+MINIO_INFECTED_BUCKET=forms-dev-infected
+
+GINIS_SSL_HOST=https://is-ginis-awst.bratislava.sk/gordic/ginis/ws/SSL01_BRA/Ssl.svc
+GINIS_SSL_MTOM_HOST=https://is-ginis-awst.bratislava.sk/gordic/ginis/ws/SSL01_BRA/Ssl.svc/mtom
+GINIS_GIN_HOST=https://is-ginis-awst.bratislava.sk/gordic/ginis/ws/GIN01_BRA/Gin.svc
+
+GINIS_FORM_ID_PROPERTY_ID=MAG000V0A1LL
+GINIS_ANONYMOUS_SENDER_ID=MAG0SE1GGEW9
+GINIS_SHOULD_REGISTER=false
+
+FRONTEND_URL=https://city-account-next.dev.bratislava.sk
+SELF_URL=https://nest-forms-backend.dev.bratislava.sk
+
+MAILGUN_DOMAIN=digital.bratislava.sk
+MAILGUN_HOST=https://api.eu.mailgun.net
+MAILGUN_EMAIL_FROM=Mesto Bratislava <konto@bratislava.sk>
+
+TAX_PDF_JOB_CONCURRENCY=2
+TAX_PDF_JOB_TIMEOUT=30000
+REDIS_PORT=6379
+
+SHAREPOINT_DOMAIN=magistratba.sharepoint.com
+SHAREPOINT_SITE_NAME=UsmernovanieInvesticnejCinnosti_dev
+SHAREPOINT_GRAPH_URL=https://graph.microsoft.com/v1.0
+
+OLO_FRONTEND_URL=https://olo-next.dev.bratislava.sk
+
+FEATURE_TOGGLE_VERSIONING=true
+FEATURE_TOGGLE_FILE_SIZE_LIMITS=true

--- a/nest-forms-backend/.env.deploy.production
+++ b/nest-forms-backend/.env.deploy.production
@@ -1,0 +1,50 @@
+# Non-secret env for the production cluster, read at deploy time by
+# infrastructure-deployment-configuration and turned into the app ConfigMap.
+# Secrets live in Passbolt, never here.
+
+NODE_OPTIONS=--max-old-space-size=7000
+MIMETYPE_WHITELIST=application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/jpg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed application/pkcs7-signature application/pkcs7-mime application/xml text/xml application/vnd.etsi.asic-e+zip application/vnd.etsi.asic-s+zip
+MAX_FILE_SIZE=524288000
+MAX_CUMULATIVE_FILE_SIZE=524288000
+NEST_CLAMAV_SCANNER=http://nest-clamav-scanner-app
+MINIO_PATH_STYLE=false
+
+PORT=3000
+NODE_ENV=production
+CLUSTER_ENV=production
+USER_ACCOUNT_API=https://nest-city-account.bratislava.sk
+SLOVENSKO_SK_CONTAINER_URI=https://slovensko-sk-api.bratislava.sk
+NASES_RECIPIENT_ID=e264cea1-acdc-4db0-8901-275d15b1f48a
+NASES_RECIPIENT_URI=ico://sk/00603481
+
+MINIO_UNSCANNED_BUCKET=forms-prod-uploaded
+MINIO_SAFE_BUCKET=forms-prod-safe
+MINIO_INFECTED_BUCKET=forms-prod-infected
+
+GINIS_SSL_HOST=https://ginis-wso.bratislava.sk/gordic/ginis/ws/SSL01_BRA/Ssl.svc
+GINIS_SSL_MTOM_HOST=https://ginis-wso.bratislava.sk/gordic/ginis/ws/SSL01_BRA/Ssl.svc/mtom
+GINIS_GIN_HOST=https://ginis-wso.bratislava.sk/gordic/ginis/ws/GIN01_BRA/Gin.svc
+
+GINIS_FORM_ID_PROPERTY_ID=MAG000V0A1LL
+GINIS_ANONYMOUS_SENDER_ID=MAG0SE1GGEW9
+GINIS_SHOULD_REGISTER=true
+
+FRONTEND_URL=https://konto.bratislava.sk
+SELF_URL=https://nest-forms-backend.bratislava.sk
+
+MAILGUN_DOMAIN=digital.bratislava.sk
+MAILGUN_HOST=https://api.eu.mailgun.net
+MAILGUN_EMAIL_FROM=Mesto Bratislava <konto@bratislava.sk>
+
+TAX_PDF_JOB_CONCURRENCY=5
+TAX_PDF_JOB_TIMEOUT=30000
+REDIS_PORT=6379
+
+SHAREPOINT_DOMAIN=magistratba.sharepoint.com
+SHAREPOINT_SITE_NAME=UsmernovanieInvesticnejCinnosti_prod
+SHAREPOINT_GRAPH_URL=https://graph.microsoft.com/v1.0
+
+OLO_FRONTEND_URL=https://www.olo.sk
+
+FEATURE_TOGGLE_VERSIONING=true
+FEATURE_TOGGLE_FILE_SIZE_LIMITS=false

--- a/nest-forms-backend/.env.deploy.staging
+++ b/nest-forms-backend/.env.deploy.staging
@@ -1,0 +1,50 @@
+# Non-secret env for the staging cluster, read at deploy time by
+# infrastructure-deployment-configuration and turned into the app ConfigMap.
+# Secrets live in Passbolt, never here.
+
+NODE_OPTIONS=--max-old-space-size=7000
+MIMETYPE_WHITELIST=application/pdf application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation text/csv image/jpeg image/jpg image/png image/gif image/tiff image/bmp image/vnd.dwg image/vnd.dxf application/zip application/x-zip-compressed application/pkcs7-signature application/pkcs7-mime application/xml text/xml application/vnd.etsi.asic-e+zip application/vnd.etsi.asic-s+zip
+MAX_FILE_SIZE=524288000
+MAX_CUMULATIVE_FILE_SIZE=524288000
+NEST_CLAMAV_SCANNER=http://nest-clamav-scanner-app
+MINIO_PATH_STYLE=false
+
+PORT=3000
+NODE_ENV=production
+CLUSTER_ENV=staging
+USER_ACCOUNT_API=https://nest-city-account.staging.bratislava.sk
+SLOVENSKO_SK_CONTAINER_URI=https://fix.slovensko-sk-api.bratislava.sk
+NASES_RECIPIENT_ID=e264cea1-acdc-4db0-8901-275d15b1f48a
+NASES_RECIPIENT_URI=ico://sk/00603481
+
+MINIO_UNSCANNED_BUCKET=forms-staging-uploaded
+MINIO_SAFE_BUCKET=forms-staging-safe
+MINIO_INFECTED_BUCKET=forms-staging-infected
+
+GINIS_SSL_HOST=https://is-ginis-awst.bratislava.sk/gordic/ginis/ws/SSL01_BRA/Ssl.svc
+GINIS_SSL_MTOM_HOST=https://is-ginis-awst.bratislava.sk/gordic/ginis/ws/SSL01_BRA/Ssl.svc/mtom
+GINIS_GIN_HOST=https://is-ginis-awst.bratislava.sk/gordic/ginis/ws/GIN01_BRA/Gin.svc
+
+GINIS_FORM_ID_PROPERTY_ID=MAG000V0A1LL
+GINIS_ANONYMOUS_SENDER_ID=MAG0SE1GGEW9
+GINIS_SHOULD_REGISTER=false
+
+FRONTEND_URL=https://city-account-next.staging.bratislava.sk
+SELF_URL=https://nest-forms-backend.staging.bratislava.sk
+
+MAILGUN_DOMAIN=digital.bratislava.sk
+MAILGUN_HOST=https://api.eu.mailgun.net
+MAILGUN_EMAIL_FROM=Mesto Bratislava <konto@bratislava.sk>
+
+TAX_PDF_JOB_CONCURRENCY=2
+TAX_PDF_JOB_TIMEOUT=30000
+REDIS_PORT=6379
+
+SHAREPOINT_DOMAIN=magistratba.sharepoint.com
+SHAREPOINT_SITE_NAME=UsmernovanieInvesticnejCinnosti_dev
+SHAREPOINT_GRAPH_URL=https://graph.microsoft.com/v1.0
+
+OLO_FRONTEND_URL=https://olo-next.staging.bratislava.sk
+
+FEATURE_TOGGLE_VERSIONING=true
+FEATURE_TOGGLE_FILE_SIZE_LIMITS=false


### PR DESCRIPTION
> [!NOTE]
> **Prototype, still being worked on.** Merging this alone changes nothing — the infrastructure side that reads these files is not in place yet. Docs and the remaining apps will follow once this one is tested end to end.

Moves the non-secret deploy config for `nest-forms-backend` out of the Terraform `kubernetes_config_map.env` blocks in `infrastructure-deployment-configuration` and into this repo, one file per cluster:

- `nest-forms-backend/.env.deploy.development`
- `nest-forms-backend/.env.deploy.staging`
- `nest-forms-backend/.env.deploy.production`

Values are copied verbatim from the current configmaps — verified by parsing each file with the same regex the Terraform unit uses and diffing against the `.tf` data blocks. 36 keys, identical in all three clusters, so the first apply is a no-op.

> [!NOTE]
> `DATABASE_URL`, `REDIS_SERVICE` and `RABBIT_MQ_URI` deliberately stay in Terraform — they are on the deployment module's `env`, not the ConfigMap, and interpolate cluster-internal service names and `$(SECRET_VAR)` references.